### PR TITLE
Refactor GoogleCloudStorageGrpcReadChannel to avoid extra buffering.

### DIFF
--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -199,6 +199,129 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <!-- minimizeJar breaks all the dynamic load hacks; add them explicitly -->
+                <filter>
+                  <artifact>com.google.flogger:flogger-log4j-backend</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.grpc:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.opencensus:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>*.json</exclude>
+                    <exclude>google/**</exclude>
+                    <exclude>grpc/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <artifactSet>
+                <includes>
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.google.api-client</include>
+                  <include>com.google.api.grpc</include>
+                  <include>com.google.apis</include>
+                  <include>com.google.auth</include>
+                  <include>com.google.cloud.bigdataoss:gcsio</include>
+                  <include>com.google.cloud.bigdataoss:util-hadoop</include>
+                  <include>com.google.cloud.bigdataoss:util</include>
+                  <include>com.google.flogger</include>
+                  <include>com.google.guava</include>
+                  <include>com.google.http-client</include>
+                  <include>com.google.oauth-client</include>
+                  <include>com.google.protobuf</include>
+                  <!-- Needed by http client and versions conflict -->
+                  <include>commons-codec:commons-codec</include>
+                  <include>io.grpc</include>
+                  <include>io.opencensus</include>
+                  <include>io.perfmark</include>
+                  <include>org.apache.httpcomponents</include>
+                </includes>
+              </artifactSet>
+              <!-- TODO(b/135136403): Reenable minimizeJar.
+                   Disabled because minimizeJar strips out a bunch of files
+                   needed by gRPC for instance NettyChannelProvider and all
+                   it's dependencies. -->
+              <minimizeJar>false</minimizeJar>
+              <relocations>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.gcsio.com</shadedPattern>
+                  <includes>
+                    <include>com.fasterxml.**</include>
+                    <include>com.google.api.**</include>
+                    <include>com.google.auth.**</include>
+                    <include>com.google.cloud.audit.**</include>
+                    <include>com.google.cloud.hadoop.util.**</include>
+                    <include>com.google.common.**</include>
+                    <include>com.google.geo.**</include>
+                    <include>com.google.google.storage.**</include>
+                    <include>com.google.iam.**</include>
+                    <include>com.google.logging.**</include>
+                    <include>com.google.longrunning.**</include>
+                    <include>com.google.rpc.**</include>
+                    <include>com.google.protobuf.**</include>
+                    <include>com.google.thirdparty.**</include>
+                    <include>com.google.type.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>org</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.gcsio.org</shadedPattern>
+                  <includes>
+                    <include>org.apache.commons.codec.**</include>
+                    <include>org.apache.http.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>io</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.gcsio.io</shadedPattern>
+                  <includes>
+                    <include>io.grpc.**</include>
+                    <include>io.opencensus.**</include>
+                    <include>io.perfmark.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/io_grpc_netty_</pattern>
+                  <shadedPattern>META-INF/native/com_google_cloud_hadoop_repackaged_gcsio_io_grpc_netty_</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/libio_grpc_netty_</pattern>
+                  <shadedPattern>META-INF/native/libcom_google_cloud_hadoop_repackaged_gcsio_io_grpc_netty_</shadedPattern>
+                </relocation>
+              </relocations>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -70,7 +70,9 @@ import javax.annotation.Nullable;
  * underlying layer. That is, all interactions with the underlying layer are strictly in terms of
  * buckets and objects.
  *
- * @see <a href="https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/filesystem/index.html">Hadoop FileSystem specification.</a>
+ * @see <a
+ *     href="https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/filesystem/index.html">Hadoop
+ *     FileSystem specification.</a>
  */
 public class GoogleCloudStorageFileSystem {
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -46,7 +46,6 @@ import com.google.api.services.storage.model.ComposeRequest;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.RewriteResponse;
 import com.google.api.services.storage.model.StorageObject;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.ClientRequestHelper;
 import com.google.cloud.hadoop.util.HttpTransportFactory;
@@ -75,14 +74,12 @@ import com.google.google.storage.v1.StorageOuterClass;
 import com.google.protobuf.util.Durations;
 import io.grpc.alts.ComputeEngineChannelBuilder;
 import io.grpc.alts.GoogleDefaultChannelBuilder;
-import io.grpc.auth.MoreCallCredentials;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
-import java.security.Security;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -282,9 +279,9 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
           .withExecutor(backgroundTasksThreadPool);
       this.gcsGrpcBlockingStub =
           StorageGrpc.newBlockingStub(
-              ComputeEngineChannelBuilder.forAddress("storage.googleapis.com",443)
-              .defaultServiceConfig(serviceConfig)
-              .build());
+              ComputeEngineChannelBuilder.forAddress("storage.googleapis.com", 443)
+                  .defaultServiceConfig(serviceConfig)
+                  .build());
     }
   }
 


### PR DESCRIPTION
Switch GoogleCloudStorageGrpcReadChannel from using a local byte buffer to hold data between read() calls while another thread reads it from the server to a different model where we copy directly from the gRPC-returned ByteString into the user-provided ByteBuffer.

It'd be better if Hadoop offered us some sort of Rope or Cord-like data type so that we could avoid making copies at all, but this is about as close as I could get with the contract provided.

I tweaked a whole lot of stuff, so I might've broken something. Unit tests and sanity tests seem to work, though. Still, I'm not very familiar with Hadoop, so please spot check.

Also, I have not implemented a couple of features that might be performance advantages:
* Random reads -- could be useful for a series of very small reads.
* Tail caching
* "Latest" and "Best_effort" read consistency. This change handles only "strict." Unfortunately, this means an extra hop between the client and the server to fetch the latest generation number.