### PR TITLE
Remove list requests caching in performance cache

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -32,6 +32,9 @@
 
 1.  Use Slf4j backend by default for Google Flogger.
 
+1.  Remove list requests caching in the `PerformanceCachingGoogleCloudStorage`
+    and `fs.gs.performance.cache.list.caching.enable` property.
+
 ### 2.0.1 - 2020-02-13
 
 1.  Cooperative Locking FSCK tool: fix recovery of operations that failed before

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -395,10 +395,6 @@ is `false`.
     Maximum number of milliseconds to store a cached metadata in the performance
     cache before it's invalidated.
 
-*   `fs.gs.performance.cache.list.caching.enable` (default: `false`)
-
-    Enable caching of list request results in the performance cache.
-
 ### Cloud Storage [Requester Pays](https://cloud.google.com/storage/docs/requester-pays) feature configuration:
 
 *   `fs.gs.requester.pays.mode` (default: `DISABLED`)

--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -328,12 +328,6 @@
   </property>
 
   <property>
-    <name>fs.gs.performance.cache.list.caching.enable</name>
-    <value>false</value>
-    <description>Enable caching of list request results in the performance cache.</description>
-  </property>
-
-  <property>
     <name>fs.gs.status.parallel.enable</name>
     <value>false</value>
     <description>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -146,13 +146,6 @@ public class GoogleHadoopFileSystemConfiguration {
           "fs.gs.performance.cache.max.entry.age.ms",
           PerformanceCachingGoogleCloudStorageOptions.MAX_ENTRY_AGE_MILLIS_DEFAULT);
 
-  /** Configuration key for whether or not to enable list caching for the performance cache. */
-  public static final HadoopConfigurationProperty<Boolean>
-      GCS_PERFORMANCE_CACHE_LIST_CACHING_ENABLE =
-          new HadoopConfigurationProperty<>(
-              "fs.gs.performance.cache.list.caching.enable",
-              PerformanceCachingGoogleCloudStorageOptions.LIST_CACHING_ENABLED);
-
   /**
    * If true, executes GCS requests in {@code listStatus} and {@code getFileStatus} methods in
    * parallel to reduce latency.
@@ -429,8 +422,6 @@ public class GoogleHadoopFileSystemConfiguration {
     return PerformanceCachingGoogleCloudStorageOptions.builder()
         .setMaxEntryAgeMillis(
             GCS_PERFORMANCE_CACHE_MAX_ENTRY_AGE_MILLIS.get(config, config::getLong))
-        .setListCachingEnabled(
-            GCS_PERFORMANCE_CACHE_LIST_CACHING_ENABLE.get(config, config::getBoolean))
         .build();
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -91,7 +91,6 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.inputstream.min.range.request.size", 524_288);
           put("fs.gs.performance.cache.enable", false);
           put("fs.gs.performance.cache.max.entry.age.ms", 5_000L);
-          put("fs.gs.performance.cache.list.caching.enable", false);
           put("fs.gs.requester.pays.mode", RequesterPaysMode.DISABLED);
           put("fs.gs.requester.pays.project.id", null);
           put("fs.gs.requester.pays.buckets", ImmutableList.of());

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -13,16 +13,13 @@
  */
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.api.client.util.Strings.isNullOrEmpty;
-import static com.google.common.base.Strings.nullToEmpty;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * This class adds a caching layer around a GoogleCloudStorage instance, caching calls that create,
@@ -37,12 +34,6 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
   /** Cache to hold item info and manage invalidation. */
   private final PrefixMappedItemCache cache;
 
-  /** Options that configure delegate storage. */
-  private final GoogleCloudStorageOptions delegateOptions;
-
-  /** Options that configure this cache. */
-  private final PerformanceCachingGoogleCloudStorageOptions options;
-
   /**
    * Creates a wrapper around a GoogleCloudStorage instance, caching calls that create, update,
    * remove, and query for GoogleCloudStorageItemInfo. Those cached copies are returned when
@@ -56,25 +47,20 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
    */
   public PerformanceCachingGoogleCloudStorage(
       GoogleCloudStorage delegate, PerformanceCachingGoogleCloudStorageOptions options) {
-    this(delegate, options, createCache(options));
+    this(delegate, createCache(options));
   }
 
   @VisibleForTesting
   PerformanceCachingGoogleCloudStorage(
       GoogleCloudStorage delegate,
-      PerformanceCachingGoogleCloudStorageOptions options,
       PrefixMappedItemCache cache) {
     super(delegate);
-    this.delegateOptions = delegate.getOptions();
-    this.options = options;
     this.cache = cache;
   }
 
   private static PrefixMappedItemCache createCache(
       PerformanceCachingGoogleCloudStorageOptions options) {
-    PrefixMappedItemCache.Config config = new PrefixMappedItemCache.Config();
-    config.setMaxEntryAgeMillis(options.getMaxEntryAgeMillis());
-    return new PrefixMappedItemCache(config);
+    return new PrefixMappedItemCache(Duration.ofMillis(options.getMaxEntryAgeMillis()));
   }
 
   @Override
@@ -88,12 +74,12 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
   }
 
   @Override
-  public void deleteObjects(List<StorageResourceId> fullObjectNames) throws IOException {
-    super.deleteObjects(fullObjectNames);
+  public void deleteObjects(List<StorageResourceId> resourceIds) throws IOException {
+    super.deleteObjects(resourceIds);
 
     // Remove the deleted objects from cache.
-    for (StorageResourceId id : fullObjectNames) {
-      cache.removeItem(id);
+    for (StorageResourceId resourceId : resourceIds) {
+      cache.removeItem(resourceId);
     }
   }
 
@@ -124,24 +110,9 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
       throws IOException {
     List<GoogleCloudStorageItemInfo> result;
 
-    if (options.isListCachingEnabled()) {
-      result = cache.getList(bucketName, objectNamePrefix);
-
-      if (result == null) {
-        result = super.listObjectInfo(bucketName, objectNamePrefix, null);
-        cache.putList(bucketName, objectNamePrefix, result);
-      }
-
-      filter(result, bucketName, objectNamePrefix, delimiter);
-
-      if (maxResults > 0 && result.size() > maxResults) {
-        result = result.subList(0, (int) maxResults);
-      }
-    } else {
-      result = super.listObjectInfo(bucketName, objectNamePrefix, delimiter, maxResults);
-      for (GoogleCloudStorageItemInfo item : result) {
-        cache.putItem(item);
-      }
+    result = super.listObjectInfo(bucketName, objectNamePrefix, delimiter, maxResults);
+    for (GoogleCloudStorageItemInfo item : result) {
+      cache.putItem(item);
     }
 
     return result;
@@ -151,102 +122,12 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
   public ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
       String bucketName, String objectNamePrefix, String delimiter, String pageToken)
       throws IOException {
-    if (options.isListCachingEnabled()) {
-      return new ListPage<>(listObjectInfo(bucketName, objectNamePrefix, delimiter), null);
-    }
-
     ListPage<GoogleCloudStorageItemInfo> result =
         super.listObjectInfoPage(bucketName, objectNamePrefix, delimiter, pageToken);
     for (GoogleCloudStorageItemInfo item : result.getItems()) {
       cache.putItem(item);
     }
     return result;
-  }
-
-  /**
-   * Matches Google Cloud Storage's delimiter filtering.
-   *
-   * @param items the mutable list of items to filter. Items matching the filter conditions will be
-   *     removed from this list.
-   * @param bucketName the bucket name to filter for.
-   * @param prefix the object name prefix to filter for.
-   * @param delimiter the delimiter to filter on.
-   */
-  private void filter(
-      List<GoogleCloudStorageItemInfo> items,
-      String bucketName,
-      @Nullable String prefix,
-      @Nullable String delimiter)
-      throws IOException {
-    prefix = nullToEmpty(prefix);
-
-    // if delimiter is not specified we don't need to filter-out subdirectories
-    if (isNullOrEmpty(delimiter)) {
-      // if prefix is not specified it means that we are listing all objects in the bucket
-      // and we need to exclude bucket from the result
-      if (prefix.isEmpty()) {
-        Iterator<GoogleCloudStorageItemInfo> itr = items.iterator();
-        while (itr.hasNext()) {
-          GoogleCloudStorageItemInfo item = itr.next();
-          if (item.isBucket()) {
-            itr.remove();
-            break;
-          }
-        }
-      }
-      return;
-    }
-
-    HashSet<String> dirs = new HashSet<>();
-    Iterator<GoogleCloudStorageItemInfo> itr = items.iterator();
-    while (itr.hasNext()) {
-      GoogleCloudStorageItemInfo item = itr.next();
-      String objectName = item.getObjectName();
-
-      // 1. Remove if bucket (means that listing objects in bucket):
-      //    do not return bucket itself (prefix dir) to avoid infinite recursion
-      // 2. Remove if doesn't start with the prefix.
-      // 3. Remove prefix object if it ends with delimiter:
-      //    do not return prefix dir to avoid infinite recursion.
-      if (item.isBucket()
-          || !objectName.startsWith(prefix)
-          || (prefix.endsWith(delimiter) && objectName.equals(prefix))) {
-        itr.remove();
-      } else {
-        // Retain if missing the delimiter after the prefix.
-        int firstIndex = objectName.indexOf(delimiter, prefix.length());
-        if (firstIndex != -1) {
-          // Remove if the first occurrence of the delimiter after the prefix isn't the last.
-          // Remove if the last occurrence of the delimiter isn't the end of the string.
-          int lastIndex = objectName.lastIndexOf(delimiter);
-          if (firstIndex != lastIndex || lastIndex != objectName.length() - 1) {
-            itr.remove();
-            dirs.add(objectName.substring(0, firstIndex + 1));
-          }
-        }
-      }
-    }
-
-    // Remove non-implicit directories (i.e. have corresponding directory objects)
-    for (GoogleCloudStorageItemInfo item : items) {
-      dirs.remove(item.getObjectName());
-    }
-
-    if (dirs.isEmpty()) {
-      return;
-    }
-
-    List<StorageResourceId> dirIds = new ArrayList<>(dirs.size());
-    for (String dir : dirs) {
-      dirIds.add(new StorageResourceId(bucketName, dir));
-    }
-
-    boolean inferImplicitDirectories = delegateOptions.isInferImplicitDirectoriesEnabled();
-    if (inferImplicitDirectories) {
-      for (StorageResourceId dirId : dirIds) {
-        items.add(GoogleCloudStorageItemInfo.createInferredDirectory(dirId));
-      }
-    }
   }
 
   /** This function may return cached copies of GoogleCloudStorageItemInfo. */
@@ -263,16 +144,9 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
       int lastSlashIndex = objectName.lastIndexOf(PATH_DELIMITER);
       String directoryName =
           lastSlashIndex >= 0 ? objectName.substring(0, lastSlashIndex + 1) : null;
-      List<GoogleCloudStorageItemInfo> cachedInDirectory =
-          cache.listItems(bucketName, directoryName);
-      filter(cachedInDirectory, bucketName, directoryName, PATH_DELIMITER);
-      // If there are items already cached in directory, do not prefetch with list requests,
-      // because metadata for this directory already could be prefetched
-      if (cachedInDirectory.isEmpty()) {
-        // make just 1 request to prefetch only 1 page of directory items
-        listObjectInfoPage(bucketName, directoryName, PATH_DELIMITER, /* pageToken= */ null);
-        item = cache.getItem(resourceId);
-      }
+      // make just 1 request to prefetch only 1 page of directory items
+      listObjectInfoPage(bucketName, directoryName, PATH_DELIMITER, /* pageToken= */ null);
+      item = cache.getItem(resourceId);
     }
 
     // If it wasn't in the cache and wasn't cached in directory list request

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageOptions.java
@@ -22,22 +22,15 @@ public abstract class PerformanceCachingGoogleCloudStorageOptions {
   /** Max age of an item in cache in milliseconds. */
   public static final long MAX_ENTRY_AGE_MILLIS_DEFAULT = 5_000;
 
-  /** Flag to enable list caching. */
-  public static final boolean LIST_CACHING_ENABLED = false;
-
   public static final PerformanceCachingGoogleCloudStorageOptions DEFAULT = builder().build();
 
   public static Builder builder() {
     return new AutoValue_PerformanceCachingGoogleCloudStorageOptions.Builder()
-        .setMaxEntryAgeMillis(MAX_ENTRY_AGE_MILLIS_DEFAULT)
-        .setListCachingEnabled(LIST_CACHING_ENABLED);
+        .setMaxEntryAgeMillis(MAX_ENTRY_AGE_MILLIS_DEFAULT);
   }
 
   /** Gets the max age of an item in cache in milliseconds. */
   public abstract long getMaxEntryAgeMillis();
-
-  /** Gets if list caching is enabled. */
-  public abstract boolean isListCachingEnabled();
 
   public abstract Builder toBuilder();
 
@@ -47,9 +40,6 @@ public abstract class PerformanceCachingGoogleCloudStorageOptions {
 
     /** Sets the max age of an item in cache in milliseconds. */
     public abstract Builder setMaxEntryAgeMillis(long maxEntryAgeMillis);
-
-    /** Setting for enabling list caching. */
-    public abstract Builder setListCachingEnabled(boolean listCachingEnabled);
 
     public abstract PerformanceCachingGoogleCloudStorageOptions build();
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -114,7 +114,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public synchronized WritableByteChannel create(
-      StorageResourceId resourceId, final CreateObjectOptions options) throws IOException {
+      StorageResourceId resourceId, CreateObjectOptions options) throws IOException {
     if (!bucketLookup.containsKey(resourceId.getBucketName())) {
       throw new IOException(
           String.format(
@@ -371,17 +371,14 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public synchronized List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter)
-      throws IOException {
+      String bucketName, String objectNamePrefix, String delimiter) {
     return listObjectNames(bucketName, objectNamePrefix, delimiter,
         GoogleCloudStorage.MAX_RESULTS_UNLIMITED);
   }
 
   @Override
   public synchronized List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter,
-      long maxResults)
-      throws IOException {
+      String bucketName, String objectNamePrefix, String delimiter, long maxResults) {
     InMemoryBucketEntry bucketEntry = bucketLookup.get(bucketName);
     if (bucketEntry == null) {
       return new ArrayList<>();
@@ -410,16 +407,14 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public synchronized List<GoogleCloudStorageItemInfo> listObjectInfo(
-      final String bucketName, String objectNamePrefix, String delimiter)
-      throws IOException {
+      String bucketName, String objectNamePrefix, String delimiter) throws IOException {
     return listObjectInfo(bucketName, objectNamePrefix, delimiter,
         GoogleCloudStorage.MAX_RESULTS_UNLIMITED);
   }
 
   @Override
   public synchronized List<GoogleCloudStorageItemInfo> listObjectInfo(
-      final String bucketName, String objectNamePrefix, String delimiter,
-      long maxResults)
+      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
       throws IOException {
     // Since we're just in memory, we can do the naive implementation of just listing names and
     // then calling getItemInfo for each.
@@ -478,8 +473,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public synchronized List<GoogleCloudStorageItemInfo> getItemInfos(
-      List<StorageResourceId> resourceIds)
-      throws IOException {
+      List<StorageResourceId> resourceIds) throws IOException {
     List<GoogleCloudStorageItemInfo> itemInfos = new ArrayList<>();
     for (StorageResourceId resourceId : resourceIds) {
       try {
@@ -523,7 +517,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public void compose(
-      final String bucketName, List<String> sources, String destination, String contentType)
+      String bucketName, List<String> sources, String destination, String contentType)
       throws IOException {
     List<StorageResourceId> sourceResourcesIds =
         Lists.transform(sources, s -> new StorageResourceId(bucketName, s));
@@ -535,9 +529,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public GoogleCloudStorageItemInfo composeObjects(
-      List<StorageResourceId> sources,
-      final StorageResourceId destination,
-      CreateObjectOptions options)
+      List<StorageResourceId> sources, StorageResourceId destination, CreateObjectOptions options)
       throws IOException {
     checkArgument(
         sources.size() <= MAX_COMPOSE_OBJECTS,

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PrefixMappedItemCacheTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PrefixMappedItemCacheTest.java
@@ -17,8 +17,7 @@ import static com.google.cloud.hadoop.gcsio.PerformanceCachingGoogleCloudStorage
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Ticker;
-import com.google.common.collect.Lists;
-import java.util.List;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,13 +56,7 @@ public class PrefixMappedItemCacheTest {
   @Before
   public void setUp() {
     ticker = new TestTicker();
-
-    // Create the cache configuration.
-    PrefixMappedItemCache.Config cacheConfig = new PrefixMappedItemCache.Config();
-    cacheConfig.setMaxEntryAgeMillis(10);
-    cacheConfig.setTicker(ticker);
-
-    cache = new PrefixMappedItemCache(cacheConfig);
+    cache = new PrefixMappedItemCache(ticker, Duration.ofMillis(10));
   }
 
   /** Test items can be retrieved normally. */
@@ -88,23 +81,6 @@ public class PrefixMappedItemCacheTest {
     assertThat(cache.getAllItemsRaw()).isEmpty();
   }
 
-  /** Test expired items cannot be retrieved. */
-  @Test
-  public void testGetItemExpired() {
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A));
-    cache.putList(BUCKET_B, PREFIX_A, Lists.newArrayList(ITEM_B_A));
-    cache.putItem(ITEM_A_ABA);
-    ticker.setTimeMillis(11);
-
-    GoogleCloudStorageItemInfo actualItem = cache.getItem(ITEM_A_A.getResourceId());
-
-    assertThat(actualItem).isNull();
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_B, PREFIX_A)).isTrue();
-  }
-
   /** Test items can be inserted normally. */
   @Test
   public void testPutItemNormal() {
@@ -127,150 +103,6 @@ public class PrefixMappedItemCacheTest {
     assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_A);
   }
 
-  /** Test old expired items are not returned. */
-  @Test
-  public void testPutItemOverwriteExpired() {
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_B, PREFIX_A, Lists.newArrayList(ITEM_B_A));
-    ticker.setTimeMillis(11);
-
-    GoogleCloudStorageItemInfo previousItem = cache.putItem(ITEM_A_ABA);
-
-    assertThat(previousItem).isNull();
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_ABA, ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_B, PREFIX_A)).isTrue();
-  }
-
-  /** Test lists can be retrieved. */
-  @Test
-  public void testGetListNormal() {
-    List<GoogleCloudStorageItemInfo> expectedItems =
-        Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_A_B);
-    cache.putItem(ITEM_B_A);
-    cache.putList(BUCKET_A, "", expectedItems);
-
-    List<GoogleCloudStorageItemInfo> actualItems = cache.getList(BUCKET_A, "");
-
-    assertThat(actualItems).containsExactlyElementsIn(expectedItems);
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw())
-        .containsExactly(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_A_B, ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isTrue();
-  }
-
-  /** Test lists can be retrieved. */
-  @Test
-  public void testGetListNormalAlt() {
-    List<GoogleCloudStorageItemInfo> expectedItems =
-        Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA);
-    cache.putItem(ITEM_A_B);
-    cache.putItem(ITEM_B_A);
-    cache.putList(BUCKET_A, PREFIX_A, expectedItems);
-
-    List<GoogleCloudStorageItemInfo> actualItems = cache.getList(BUCKET_A, PREFIX_A);
-
-    assertThat(actualItems).containsExactlyElementsIn(expectedItems);
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw())
-        .containsExactly(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_A_B, ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isTrue();
-  }
-
-  /** Test derived lists can be retrieved. */
-  @Test
-  public void testGetListDerived() {
-    List<GoogleCloudStorageItemInfo> expectedItems = Lists.newArrayList(ITEM_A_AA, ITEM_A_ABA);
-    cache.putItem(ITEM_B_A);
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_A_B));
-
-    List<GoogleCloudStorageItemInfo> actualItems = cache.getList(BUCKET_A, PREFIX_A + "/");
-
-    assertThat(actualItems).containsExactlyElementsIn(expectedItems);
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw())
-        .containsExactly(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_A_B, ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isTrue();
-  }
-
-  /** Test missing lists cannot be retrieved. */
-  @Test
-  public void testGetListMissing() {
-    List<GoogleCloudStorageItemInfo> actualItems = cache.getList(BUCKET_A, PREFIX_A);
-
-    assertThat(actualItems).isNull();
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).isEmpty();
-  }
-
-  /** Test missing lists cannot be retrieved. */
-  @Test
-  public void testGetListMissingAlt() {
-    cache.putItem(ITEM_A_B);
-    cache.putItem(ITEM_B_A);
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-
-    List<GoogleCloudStorageItemInfo> actualItems = cache.getList(BUCKET_A, "");
-
-    assertThat(actualItems).isNull();
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw())
-        .containsExactly(ITEM_A_B, ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isTrue();
-  }
-
-  /** Test expired lists cannot be retrieved. */
-  @Test
-  public void testGetListExpired() {
-
-    cache.putItem(ITEM_B_A);
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA, ITEM_A_B));
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_AA, ITEM_A_ABA));
-    ticker.setTimeMillis(11);
-
-    List<GoogleCloudStorageItemInfo> actualItems = cache.getList(BUCKET_A, "");
-
-    assertThat(actualItems).isNull();
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isTrue();
-  }
-
-  /** Test lists of items can be inserted. */
-  @Test
-  public void testPutListNormal() {
-    cache.putList(BUCKET_A, PREFIX_AA, Lists.newArrayList(ITEM_A_AA, ITEM_A_ABA));
-
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_AA, ITEM_A_ABA);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_AA)).isTrue();
-  }
-
-  /** Test old but valid lists are overwritten when a new list is inserted. */
-  @Test
-  public void testPutListOverwrite() {
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_AA));
-
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_AA);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isTrue();
-  }
-
-  /** Test old but valid lists are overwritten when a new list is inserted. */
-  @Test
-  public void testPutListOverwriteAlt() {
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_A, PREFIX_AA, Lists.newArrayList(ITEM_A_AA));
-
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA);
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isTrue();
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_AA)).isTrue();
-  }
-
   /** Test items can be removed. */
   @Test
   public void testRemoveItemNormal() {
@@ -283,19 +115,6 @@ public class PrefixMappedItemCacheTest {
     assertThat(cache.getAllItemsRaw()).isEmpty();
   }
 
-  /** Test missing items can be removed. */
-  @Test
-  public void testRemoveItemNormalAlt() {
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-
-    GoogleCloudStorageItemInfo actualItem = cache.removeItem(ITEM_A_AA.getResourceId());
-
-    assertThat(actualItem).isEqualTo(ITEM_A_AA);
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_A, ITEM_A_ABA);
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isTrue();
-  }
-
   /** Test missing items cannot be removed. */
   @Test
   public void testRemoveItemMissing() {
@@ -304,66 +123,6 @@ public class PrefixMappedItemCacheTest {
     assertThat(actualItem).isNull();
     // Verify the state of the cache.
     assertThat(cache.getAllItemsRaw()).isEmpty();
-  }
-
-  /** Test missing items can be removed. */
-  @Test
-  public void testRemoveItemExpired() {
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_A, PREFIX_AA, Lists.newArrayList(ITEM_A_AA));
-    ticker.setTimeMillis(11);
-
-    GoogleCloudStorageItemInfo actualItem = cache.removeItem(ITEM_A_A.getResourceId());
-
-    assertThat(actualItem).isNull();
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).isEmpty();
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_AA)).isTrue();
-  }
-
-  @Test
-  public void testInvalidateBucket() {
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A, ITEM_A_AA));
-    cache.putList(BUCKET_B, "", Lists.newArrayList(ITEM_B_A));
-
-    cache.invalidateBucket(BUCKET_A);
-
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_B_A);
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_B, "")).isTrue();
-  }
-
-  @Test
-  public void testInvalidateBucketAlt() {
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_A, PREFIX_A, Lists.newArrayList(ITEM_A_A, ITEM_A_AA));
-    cache.putList(BUCKET_B, "", Lists.newArrayList(ITEM_B_A));
-
-    cache.invalidateBucket(BUCKET_B);
-
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_A_A, ITEM_A_AA);
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isTrue();
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_A)).isTrue();
-    assertThat(cache.containsListRaw(BUCKET_B, "")).isFalse();
-  }
-
-  /** Test all items are cleared by invalidate all. */
-  @Test
-  public void testInvalidateAll() {
-    cache.putList(BUCKET_A, "", Lists.newArrayList(ITEM_A_A, ITEM_A_AA, ITEM_A_ABA));
-    cache.putList(BUCKET_A, PREFIX_AA, Lists.newArrayList(ITEM_A_AA));
-
-    cache.invalidateAll();
-
-    // Verify the state of the cache.
-    assertThat(cache.getAllItemsRaw()).isEmpty();
-    assertThat(cache.containsListRaw(BUCKET_A, "")).isFalse();
-    assertThat(cache.containsListRaw(BUCKET_A, PREFIX_AA)).isFalse();
   }
 
   /** Ticker with a manual time value used for testing the cache. */

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageIntegrationTest.java
@@ -52,7 +52,7 @@ public class GoogleCloudStorageIntegrationTest extends GoogleCloudStorageTest {
   private static GoogleCloudStorage getPerformanceCachingGoogleCloudStorage() throws IOException {
     return new PerformanceCachingGoogleCloudStorage(
         getGoogleCloudStorage(GoogleCloudStorageTestHelper.getStandardOptionBuilder()),
-        PerformanceCachingGoogleCloudStorageOptions.builder().setListCachingEnabled(true).build());
+        PerformanceCachingGoogleCloudStorageOptions.DEFAULT);
   }
 
   private static GoogleCloudStorage getGoogleCloudStorage() throws IOException {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
@@ -140,10 +140,7 @@ public class GoogleCloudStorageTest {
             ListVisibilityCalculator.IMMEDIATELY_VISIBLE);
     GoogleCloudStorage performanceCachingGcs =
         new PerformanceCachingGoogleCloudStorage(
-            new InMemoryGoogleCloudStorage(),
-            PerformanceCachingGoogleCloudStorageOptions.builder()
-                .setListCachingEnabled(true)
-                .build());
+            new InMemoryGoogleCloudStorage(), PerformanceCachingGoogleCloudStorageOptions.DEFAULT);
     return Arrays.asList(
         new Object[] {gcs}, new Object[] {zeroLaggedGcs}, new Object[] {performanceCachingGcs});
   }
@@ -813,7 +810,8 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorageItemInfo d2Info =
         rawStorage.getItemInfo(
             new StorageResourceId(bucketName, "testListObjectInfoWithDirectoryRepair_d2/"));
-    assertThat(d2Info.exists()).isFalse();
+    assertThat(d2Info.exists())
+        .isEqualTo(rawStorage instanceof PerformanceCachingGoogleCloudStorage);
 
     List<GoogleCloudStorageItemInfo> d2ItemInfo =
         rawStorage.listObjectInfo(


### PR DESCRIPTION
Reason: caching list requests has a little benefit in Hadoop/Spark workloads