### PR TITLE
Add GrpcEnabled to GoogleCloudStorageOptions

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -31,6 +31,9 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class GoogleCloudStorageOptions {
 
+  /** Default setting for enabling GCS gRPC API. */
+  public static final boolean ENABLE_GRPC_API_DEFAULT = false;
+
   /** Default root URL for Cloud Storage API endpoint. */
   public static final String STORAGE_ROOT_URL_DEFAULT = Storage.DEFAULT_ROOT_URL;
 
@@ -76,9 +79,6 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for number of threads to execute GCS batch requests for copy operations. */
   public static final int COPY_BATCH_THREADS_DEFAULT = BATCH_THREADS_DEFAULT;
 
-  /** Default setting for enabling grpc reads/writes. */
-  public static final boolean ENABLE_GRPC_DEFAULT = false;
-
   /** Default setting for GCS HTTP request headers. */
   public static final ImmutableMap<String, String> HTTP_REQUEST_HEADERS_DEFAULT = ImmutableMap.of();
 
@@ -86,6 +86,7 @@ public abstract class GoogleCloudStorageOptions {
 
   public static Builder builder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
+        .setGrpcApiEnabled(ENABLE_GRPC_API_DEFAULT)
         .setStorageRootUrl(STORAGE_ROOT_URL_DEFAULT)
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
         .setInferImplicitDirectoriesEnabled(INFER_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -105,11 +106,12 @@ public abstract class GoogleCloudStorageOptions {
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setRequesterPaysOptions(RequesterPaysOptions.DEFAULT)
         .setCooperativeLockingOptions(CooperativeLockingOptions.DEFAULT)
-        .setGrpcEnabled(ENABLE_GRPC_DEFAULT);
         .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT);
   }
 
   public abstract Builder toBuilder();
+
+  public abstract boolean isGrpcApiEnabled();
 
   public abstract String getStorageRootUrl();
 
@@ -164,8 +166,6 @@ public abstract class GoogleCloudStorageOptions {
 
   public abstract CooperativeLockingOptions getCooperativeLockingOptions();
 
-  public abstract boolean isGrpcEnabled();
-
   public abstract ImmutableMap<String, String> getHttpRequestHeaders();
 
   public void throwIfNotValid() {
@@ -175,6 +175,8 @@ public abstract class GoogleCloudStorageOptions {
   /** Mutable builder for the {@link GoogleCloudStorageOptions} class. */
   @AutoValue.Builder
   public abstract static class Builder {
+
+    public abstract Builder setGrpcApiEnabled(boolean grpcApiEnabled);
 
     public abstract Builder setStorageRootUrl(String rootUrl);
 
@@ -226,8 +228,6 @@ public abstract class GoogleCloudStorageOptions {
 
     public abstract Builder setCooperativeLockingOptions(
         CooperativeLockingOptions cooperativeLockingOptions);
-
-    public abstract Builder setGrpcEnabled(boolean grpcEnabled);
 
     public abstract Builder setHttpRequestHeaders(Map<String, String> httpRequestHeaders);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -76,6 +76,9 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for number of threads to execute GCS batch requests for copy operations. */
   public static final int COPY_BATCH_THREADS_DEFAULT = BATCH_THREADS_DEFAULT;
 
+  /** Default setting for enabling grpc reads/writes. */
+  public static final boolean ENABLE_GRPC_DEFAULT = false;
+
   /** Default setting for GCS HTTP request headers. */
   public static final ImmutableMap<String, String> HTTP_REQUEST_HEADERS_DEFAULT = ImmutableMap.of();
 
@@ -102,6 +105,7 @@ public abstract class GoogleCloudStorageOptions {
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setRequesterPaysOptions(RequesterPaysOptions.DEFAULT)
         .setCooperativeLockingOptions(CooperativeLockingOptions.DEFAULT)
+        .setGrpcEnabled(ENABLE_GRPC_DEFAULT);
         .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT);
   }
 
@@ -159,6 +163,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract RequesterPaysOptions getRequesterPaysOptions();
 
   public abstract CooperativeLockingOptions getCooperativeLockingOptions();
+
+  public abstract boolean isGrpcEnabled();
 
   public abstract ImmutableMap<String, String> getHttpRequestHeaders();
 
@@ -220,6 +226,8 @@ public abstract class GoogleCloudStorageOptions {
 
     public abstract Builder setCooperativeLockingOptions(
         CooperativeLockingOptions cooperativeLockingOptions);
+
+    public abstract Builder setGrpcEnabled(boolean grpcEnabled);
 
     public abstract Builder setHttpRequestHeaders(Map<String, String> httpRequestHeaders);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -31,8 +31,8 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class GoogleCloudStorageOptions {
 
-  /** Default setting for enabling GCS gRPC API. */
-  public static final boolean ENABLE_GRPC_API_DEFAULT = false;
+  /** Default setting for enabling use of GCS gRPC API. */
+  public static final boolean ENABLE_GRPC_DEFAULT = false;
 
   /** Default root URL for Cloud Storage API endpoint. */
   public static final String STORAGE_ROOT_URL_DEFAULT = Storage.DEFAULT_ROOT_URL;
@@ -86,7 +86,7 @@ public abstract class GoogleCloudStorageOptions {
 
   public static Builder builder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
-        .setGrpcApiEnabled(ENABLE_GRPC_API_DEFAULT)
+        .setGrpcEnabled(ENABLE_GRPC_DEFAULT)
         .setStorageRootUrl(STORAGE_ROOT_URL_DEFAULT)
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
         .setInferImplicitDirectoriesEnabled(INFER_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -111,7 +111,7 @@ public abstract class GoogleCloudStorageOptions {
 
   public abstract Builder toBuilder();
 
-  public abstract boolean isGrpcApiEnabled();
+  public abstract boolean isGrpcEnabled();
 
   public abstract String getStorageRootUrl();
 
@@ -176,7 +176,7 @@ public abstract class GoogleCloudStorageOptions {
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract Builder setGrpcApiEnabled(boolean grpcApiEnabled);
+    public abstract Builder setGrpcEnabled(boolean grpcEnabled);
 
     public abstract Builder setStorageRootUrl(String rootUrl);
 


### PR DESCRIPTION
Added the `GrpcEnabled` field to `GoogleCloudStorageOptions` with no-op when enabled. This is for https://github.com/apache/beam/pull/10786 to get merged even before the new release of gcsio with actual gRPC support.