### PR TITLE
Fix the read logic with a forward seek.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -152,25 +152,29 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private int readBufferedContentInto(ByteBuffer byteBuffer) {
     // Handle skipping forward through the buffer for a seek.
-    long remainingBufferedBytes = bufferedContent.size() - bufferedContentReadOffset;
-    long bufferSkip = Math.min(remainingBufferedBytes, bytesToSkipBeforeReading);
+    long bufferSkip =
+        Math.min(bufferedContent.size() - bufferedContentReadOffset, bytesToSkipBeforeReading);
     bufferedContentReadOffset += bufferSkip;
     bytesToSkipBeforeReading -= bufferSkip;
+    int remainingBufferedBytes = bufferedContent.size() - bufferedContentReadOffset;
 
-    if (remainingBufferedBytes <= byteBuffer.remaining()) {
-      int bytesToWrite = bufferedContent.size() - bufferedContentReadOffset;
-      byteBuffer.put(bufferedContent.toByteArray(), bufferedContentReadOffset, bytesToWrite);
-      position += bytesToWrite;
+    Boolean isRemainingBufferedContentLargerThanByteBuffer =
+        remainingBufferedBytes > byteBuffer.remaining();
+    int bytesToWrite =
+        isRemainingBufferedContentLargerThanByteBuffer
+            ? byteBuffer.remaining()
+            : remainingBufferedBytes;
+    byteBuffer.put(bufferedContent.toByteArray(), bufferedContentReadOffset, bytesToWrite);
+    position += bytesToWrite;
+
+    if (isRemainingBufferedContentLargerThanByteBuffer) {
+      bufferedContentReadOffset += bytesToWrite;
+    } else {
       bufferedContent = null;
       bufferedContentReadOffset = 0;
-      return bytesToWrite;
-    } else {
-      int bytesToWrite = byteBuffer.remaining();
-      byteBuffer.put(bufferedContent.toByteArray(), bufferedContentReadOffset, bytesToWrite);
-      position += bytesToWrite;
-      bufferedContentReadOffset += bytesToWrite;
-      return bytesToWrite;
     }
+
+    return bytesToWrite;
   }
 
   @Override
@@ -206,11 +210,11 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       }
       requestObjectMedia(bytesToRead);
     }
-    while (moreServerContent()) {
+    while (moreServerContent() && byteBuffer.hasRemaining()) {
       GetObjectMediaResponse res = resIterator.next();
 
       ByteString content = res.getChecksummedData().getContent();
-      if (bytesToSkipBeforeReading > 0 && bytesToSkipBeforeReading < content.size()) {
+      if (bytesToSkipBeforeReading >= 0 && bytesToSkipBeforeReading < content.size()) {
         content = res.getChecksummedData().getContent().substring((int) bytesToSkipBeforeReading);
         bytesToSkipBeforeReading = 0;
       } else if (bytesToSkipBeforeReading >= content.size()) {
@@ -232,24 +236,16 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
         }
       }
 
-      int responseSize = content.size();
-      if (responseSize > byteBuffer.remaining()) {
-        int bytesToWrite = byteBuffer.remaining();
-        byteBuffer.put(content.toByteArray(), 0, bytesToWrite);
-        position += bytesToWrite;
-        bytesRead += bytesToWrite;
+      Boolean isResponseSizeLargerThanRemainingBuffer = content.size() > byteBuffer.remaining();
+      int bytesToWrite =
+          isResponseSizeLargerThanRemainingBuffer ? byteBuffer.remaining() : content.size();
+      byteBuffer.put(content.toByteArray(), 0, bytesToWrite);
+      bytesRead += bytesToWrite;
+      position += bytesToWrite;
 
-        int bytesToStore = responseSize - byteBuffer.remaining();
+      if (isResponseSizeLargerThanRemainingBuffer) {
         bufferedContent = content;
         bufferedContentReadOffset = bytesToWrite;
-        break;
-      }
-      // System.arraycopy() would also work,but a quick performance test suggests this is equivalent
-      byteBuffer.put(content.toByteArray(), 0, responseSize);
-      bytesRead += responseSize;
-      position += responseSize;
-      if (!byteBuffer.hasRemaining()) {
-        break;
       }
     }
     return bytesRead;
@@ -347,7 +343,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       }
     }
 
-    if (seekDistance > 0 && seekDistance < readOptions.getInplaceSeekLimit()) {
+    if (seekDistance > 0 && seekDistance <= readOptions.getInplaceSeekLimit()) {
       bytesToSkipBeforeReading = seekDistance;
       return this;
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -158,16 +158,16 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     bytesToSkipBeforeReading -= bufferSkip;
     int remainingBufferedBytes = bufferedContent.size() - bufferedContentReadOffset;
 
-    Boolean isRemainingBufferedContentLargerThanByteBuffer =
+    boolean remainingBufferedContentLargerThanByteBuffer =
         remainingBufferedBytes > byteBuffer.remaining();
     int bytesToWrite =
-        isRemainingBufferedContentLargerThanByteBuffer
+        remainingBufferedContentLargerThanByteBuffer
             ? byteBuffer.remaining()
             : remainingBufferedBytes;
     byteBuffer.put(bufferedContent.toByteArray(), bufferedContentReadOffset, bytesToWrite);
     position += bytesToWrite;
 
-    if (isRemainingBufferedContentLargerThanByteBuffer) {
+    if (remainingBufferedContentLargerThanByteBuffer) {
       bufferedContentReadOffset += bytesToWrite;
     } else {
       bufferedContent = null;
@@ -236,14 +236,14 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
         }
       }
 
-      Boolean isResponseSizeLargerThanRemainingBuffer = content.size() > byteBuffer.remaining();
+      boolean responseSizeLargerThanRemainingBuffer = content.size() > byteBuffer.remaining();
       int bytesToWrite =
-          isResponseSizeLargerThanRemainingBuffer ? byteBuffer.remaining() : content.size();
+          responseSizeLargerThanRemainingBuffer ? byteBuffer.remaining() : content.size();
       byteBuffer.put(content.toByteArray(), 0, bytesToWrite);
       bytesRead += bytesToWrite;
       position += bytesToWrite;
 
-      if (isResponseSizeLargerThanRemainingBuffer) {
+      if (responseSizeLargerThanRemainingBuffer) {
         bufferedContent = content;
         bufferedContentReadOffset = bytesToWrite;
       }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -127,8 +127,11 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer bufferAtBeginning = ByteBuffer.allocate(20);
     readChannel.read(bufferAtBeginning);
     readChannel.position(25);
-    ByteBuffer bufferFromSkippedSection = ByteBuffer.allocate(5);
-    readChannel.read(bufferFromSkippedSection);
+    ByteBuffer bufferFromSkippedSection1 = ByteBuffer.allocate(5);
+    readChannel.read(bufferFromSkippedSection1);
+    readChannel.position(35);
+    ByteBuffer bufferFromSkippedSection2 = ByteBuffer.allocate(10);
+    readChannel.read(bufferFromSkippedSection2);
     ByteBuffer bufferFromReposition = ByteBuffer.allocate(10);
     readChannel.position(1);
     readChannel.read(bufferFromReposition);
@@ -137,7 +140,9 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     verify(fakeService, times(1)).getObjectMedia(eq(GET_OBJECT_MEDIA_REQUEST), any());
     assertArrayEquals(fakeService.data.substring(0, 20).toByteArray(), bufferAtBeginning.array());
     assertArrayEquals(
-        fakeService.data.substring(25, 30).toByteArray(), bufferFromSkippedSection.array());
+        fakeService.data.substring(25, 30).toByteArray(), bufferFromSkippedSection1.array());
+    assertArrayEquals(
+        fakeService.data.substring(40, 50).toByteArray(), bufferFromSkippedSection2.array());
     assertArrayEquals(
         fakeService.data.substring(1, 11).toByteArray(), bufferFromReposition.array());
   }


### PR DESCRIPTION
1. when `readBufferedContentInto(ByteBuffer)`, the remaining byte buffer from the buffered content didn't count the buffer skipped through seek. This changed that.
2. `seekDistance` can be exactly the `getInplaceSeekLimit` set in `readOptions`, but it was ignored.
3. Currently missing tests for these two cases.