### PR TITLE
Make tests run on Windows OS family.

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -102,7 +102,9 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
     assertThat(exception)
         .hasCauseThat()
         .hasMessageThat()
-        .isEqualTo("non-existent.json (No such file or directory)");
+        .isAnyOf(
+            "non-existent.json (No such file or directory)",
+            "non-existent.json (The system cannot find the file specified)");
 
     lazyFs.close();
   }
@@ -123,7 +125,9 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
 
     assertThat(exception)
         .hasMessageThat()
-        .isEqualTo("non-existent.json (No such file or directory)");
+        .isAnyOf(
+            "non-existent.json (No such file or directory)",
+            "non-existent.json (The system cannot find the file specified)");
   }
 
   // -----------------------------------------------------------------

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -250,6 +250,10 @@ public class HadoopCredentialConfigurationTest {
   }
 
   private static Path getPath(String resource) throws Exception {
-    return Paths.get(Resources.getResource(resource).getFile());
+    String filePath = Resources.getResource(resource).getFile();
+    return (System.getProperty("os.name").toLowerCase().contains("win")
+            && filePath.charAt(0) == '/')
+        ? Paths.get(filePath.substring(1))
+        : Paths.get(filePath);
   }
 }

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -251,9 +251,9 @@ public class HadoopCredentialConfigurationTest {
 
   private static Path getPath(String resource) throws Exception {
     String filePath = Resources.getResource(resource).getFile();
-    return (System.getProperty("os.name").toLowerCase().contains("win")
-            && filePath.charAt(0) == '/')
-        ? Paths.get(filePath.substring(1))
-        : Paths.get(filePath);
+    return Paths.get(
+        System.getProperty("os.name").toLowerCase().contains("win") && filePath.startsWith("/")
+            ? filePath.substring(1)
+            : filePath);
   }
 }


### PR DESCRIPTION
- HadoopCredentialConfigurationTest -> getPath: If OS windows - remove first symbol ("/"), because paths start with drive letter om this system.

- GoogleHadoopFileSystemTest -> lazyInitialization_deleteCall_fails_withInvalidCredentialsConfiguration, eagerInitialization_fails_withInvalidCredentialsConfiguration: change assertion for file absence from isEqualTo("non-existent.json (No such file or directory)") to .isAnyOf("non-existent.json (No such file or directory)", "non-existent.json (The system cannot find the file specified)");