### PR TITLE
Add option to support grpc auto flowcontrol window (branch-2.1.x-grpc)

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -348,6 +348,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.enable", false);
 
+  /** Configuration key for enabling auto-tuning flow-control window size. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_AUTO_WINDOW_ENABLE =
+      new HadoopConfigurationProperty<>("fs.gs.grpc.auto.window.enable", false);
+
   /** Configuration key for enabling checksum validation for the gRPC API. */
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_CHECKSUMS_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.checksums.enable", false);
@@ -437,7 +441,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setRequesterPaysOptions(getRequesterPaysOptions(config, projectId))
         .setCooperativeLockingOptions(getCooperativeLockingOptions(config))
         .setHttpRequestHeaders(GCS_HTTP_HEADERS.getPropsWithPrefix(config))
-        .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean));
+        .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean))
+        .setGrpcAutoWindowEnabled(GCS_GRPC_AUTO_WINDOW_ENABLE.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -101,6 +101,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.cooperative.locking.max.concurrent.operations", 20);
           put("fs.gs.storage.http.headers.", ImmutableMap.of());
           put("fs.gs.grpc.enable", false);
+          put("fs.gs.grpc.auto.window.enable", false);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.server.address", null);
         }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -69,6 +69,7 @@ import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.grpc.netty.shaded.io.grpc.netty.InternalHandlerSettings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -249,6 +250,11 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     if (storageOptions.isGrpcEnabled()) {
       this.storageStubProvider =
           new StorageStubProvider(options.getReadChannelOptions(), backgroundTasksThreadPool);
+      // Enable gRPC auto flow-control window if set.
+      if (storageOptions.isGrpcAutoWindowEnabled()) {
+        InternalHandlerSettings.enable(true);
+        InternalHandlerSettings.autoWindowOn(true);
+      }
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -34,6 +34,9 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for enabling use of GCS gRPC API. */
   public static final boolean ENABLE_GRPC_DEFAULT = false;
 
+  /** Default setting for enabling gRPC auto flow-control window. */
+  public static final boolean ENABLE_GRPC_AUTO_WINDOW_DEFAULT = false;
+
   /** Default root URL for Cloud Storage API endpoint. */
   public static final String STORAGE_ROOT_URL_DEFAULT = Storage.DEFAULT_ROOT_URL;
 
@@ -96,6 +99,7 @@ public abstract class GoogleCloudStorageOptions {
   public static Builder builder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
         .setGrpcEnabled(ENABLE_GRPC_DEFAULT)
+        .setGrpcAutoWindowEnabled(ENABLE_GRPC_AUTO_WINDOW_DEFAULT)
         .setStorageRootUrl(STORAGE_ROOT_URL_DEFAULT)
         .setStorageServicePath(STORAGE_SERVICE_PATH_DEFAULT)
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -120,6 +124,8 @@ public abstract class GoogleCloudStorageOptions {
   }
 
   public abstract boolean isGrpcEnabled();
+
+  public abstract boolean isGrpcAutoWindowEnabled();
 
   public abstract String getStorageRootUrl();
 
@@ -189,6 +195,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract static class Builder {
 
     public abstract Builder setGrpcEnabled(boolean grpcEnabled);
+
+    public abstract Builder setGrpcAutoWindowEnabled(boolean grpcAutoWindowEnabled);
 
     public abstract Builder setStorageRootUrl(String rootUrl);
 


### PR DESCRIPTION
- Add option `fs.gs.grpc.auto.window.enable` in `GoogleHadoopFileSystemConfiguration`.
- Manually set this feature by using `InternalHandlerSettings` when flag is enabled.
- This feature will be enabled by default in future grpc-java release. So this is a temporary change used for benchmarking test.