### PR TITLE
Add retries for getUploadID and getCommitedSize

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -69,7 +69,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
   private static final Duration WRITE_STREAM_TIMEOUT = Duration.ofSeconds(20);
   // Maximum number of automatic retries for each data chunk
   // when writing to underlying channel raises error.
-  private static final int WRITE_CHUNK_RETRIES = 10;
+  private static final int UPLOAD_RETRIES = 10;
 
   private final StorageStub stub;
   private final StorageResourceId resourceId;
@@ -182,9 +182,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
       int retriesAttempted = 0;
       Hasher objectHasher = Hashing.crc32c().newHasher();
       do {
-        ByteString chunkData = ByteString.EMPTY;
-        responseObserver =
-            new InsertChunkResponseObserver(uploadId, chunkData, writeOffset, objectHasher);
+        responseObserver = new InsertChunkResponseObserver(uploadId, writeOffset, objectHasher);
         // TODO(b/151184800): Implement per-message timeout, in addition to stream timeout.
         stub.withDeadlineAfter(WRITE_STREAM_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
             .insertObject(responseObserver);
@@ -207,7 +205,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
           retriesAttempted = 0;
         }
 
-        if (retriesAttempted >= WRITE_CHUNK_RETRIES) {
+        if (retriesAttempted >= UPLOAD_RETRIES) {
           throw new IOException(
               String.format("Insert failed for '%s'", resourceId), responseObserver.getError());
         }
@@ -234,10 +232,9 @@ public final class GoogleCloudStorageGrpcWriteChannel
       // stream is closed.
       final CountDownLatch done = new CountDownLatch(1);
 
-      InsertChunkResponseObserver(
-          String uploadId, ByteString chunkData, long writeOffset, Hasher objectHasher) {
+      InsertChunkResponseObserver(String uploadId, long writeOffset, Hasher objectHasher) {
         this.uploadId = uploadId;
-        this.chunkData = chunkData;
+        this.chunkData = ByteString.EMPTY;
         this.writeOffset = writeOffset;
         this.objectHasher = objectHasher;
       }
@@ -357,6 +354,23 @@ public final class GoogleCloudStorageGrpcWriteChannel
       }
     }
 
+    private void runWithRetries(Runnable block, SimpleResponseObserver responseObserver)
+        throws IOException {
+      for (int attemptedRetries = 0; ; attemptedRetries++) {
+        block.run();
+        if (responseObserver.hasError()) {
+          if (attemptedRetries >= UPLOAD_RETRIES) {
+            throw new IOException(
+                String.format("Failed to start resumable upload for '%s'", resourceId),
+                responseObserver.getError());
+          }
+          continue;
+        } else {
+          break;
+        }
+      }
+    }
+
     /** Send a StartResumableWriteRequest and return the uploadId of the resumable write. */
     private String startResumableUpload() throws InterruptedException, IOException {
       InsertObjectSpec.Builder insertObjectSpecBuilder =
@@ -386,16 +400,18 @@ public final class GoogleCloudStorageGrpcWriteChannel
 
       SimpleResponseObserver<StartResumableWriteResponse> responseObserver =
           new SimpleResponseObserver<>();
-
-      stub.withDeadlineAfter(START_RESUMABLE_WRITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
-          .startResumableWrite(request, responseObserver);
-      responseObserver.done.await();
-
-      if (responseObserver.hasError()) {
-        throw new IOException(
-            String.format("Failed to start resumable upload for '%s'", resourceId),
-            responseObserver.getError());
-      }
+      runWithRetries(
+          () -> {
+            stub.withDeadlineAfter(START_RESUMABLE_WRITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+                .startResumableWrite(request, responseObserver);
+            try {
+              responseObserver.done.await();
+            } catch (InterruptedException e) {
+              // Do not throw here since it will eventually throw if all retries fail.
+              e.printStackTrace();
+            }
+          },
+          responseObserver);
 
       return responseObserver.getResponse().getUploadId();
     }
@@ -408,15 +424,18 @@ public final class GoogleCloudStorageGrpcWriteChannel
       SimpleResponseObserver<QueryWriteStatusResponse> responseObserver =
           new SimpleResponseObserver<>();
 
-      stub.withDeadlineAfter(QUERY_WRITE_STATUS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
-          .queryWriteStatus(request, responseObserver);
-      responseObserver.done.await();
-
-      if (responseObserver.hasError()) {
-        throw new IOException(
-            String.format("Failed to get committed write size '%s'", resourceId),
-            responseObserver.getError());
-      }
+      runWithRetries(
+          () -> {
+            stub.withDeadlineAfter(QUERY_WRITE_STATUS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+                .queryWriteStatus(request, responseObserver);
+            try {
+              responseObserver.done.await();
+            } catch (InterruptedException e) {
+              // Do not throw here since it will eventually throw if all retries fail.
+              e.printStackTrace();
+            }
+          },
+          responseObserver);
 
       return responseObserver.getResponse().getCommittedSize();
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -19,8 +19,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.google.storage.v1.ServiceConstants.Values.MAX_WRITE_CHUNK_BYTES;
 import static java.util.stream.Collectors.toMap;
 
+import com.google.api.client.util.Sleeper;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.BackOffFactory;
+import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.BaseAbstractGoogleAsyncWriteChannel;
+import com.google.cloud.hadoop.util.ResilientOperation;
+import com.google.cloud.hadoop.util.ResilientOperation.CheckedCallable;
+import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hasher;
@@ -77,6 +83,16 @@ public final class GoogleCloudStorageGrpcWriteChannel
   private final Optional<String> requesterPaysProject;
   private final ImmutableMap<String, String> metadata;
   private final boolean checksumsEnabled;
+
+  // Helper delegate for turning IOExceptions from API calls into higher-level semantics.
+  private ApiErrorExtractor errorExtractor = ApiErrorExtractor.INSTANCE;
+  // Determine if a given IOException is due to rate-limiting.
+  private RetryDeterminer<IOException> rateLimitedRetryDeterminer =
+      RetryDeterminer.createRateLimitedRetryDeterminer(errorExtractor);
+  // Object to use to perform sleep operations
+  private Sleeper sleeper = Sleeper.DEFAULT;
+  // BackOff objects are per-request, use this to make new ones.
+  private BackOffFactory backOffFactory = BackOffFactory.DEFAULT;
 
   private GoogleCloudStorageItemInfo completedItemInfo = null;
 
@@ -354,23 +370,6 @@ public final class GoogleCloudStorageGrpcWriteChannel
       }
     }
 
-    private void runWithRetries(Runnable block, SimpleResponseObserver responseObserver)
-        throws IOException {
-      for (int attemptedRetries = 0; ; attemptedRetries++) {
-        block.run();
-        if (responseObserver.hasError()) {
-          if (attemptedRetries >= UPLOAD_RETRIES) {
-            throw new IOException(
-                String.format("Failed to start resumable upload for '%s'", resourceId),
-                responseObserver.getError());
-          }
-          continue;
-        } else {
-          break;
-        }
-      }
-    }
-
     /** Send a StartResumableWriteRequest and return the uploadId of the resumable write. */
     private String startResumableUpload() throws InterruptedException, IOException {
       InsertObjectSpec.Builder insertObjectSpecBuilder =
@@ -400,18 +399,19 @@ public final class GoogleCloudStorageGrpcWriteChannel
 
       SimpleResponseObserver<StartResumableWriteResponse> responseObserver =
           new SimpleResponseObserver<>();
-      runWithRetries(
-          () -> {
-            stub.withDeadlineAfter(START_RESUMABLE_WRITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
-                .startResumableWrite(request, responseObserver);
-            try {
-              responseObserver.done.await();
-            } catch (InterruptedException e) {
-              // Do not throw here since it will eventually throw if all retries fail.
-              e.printStackTrace();
-            }
-          },
-          responseObserver);
+      GrpcStartResumableWriteRequestExecutor requestExecutor =
+          new GrpcStartResumableWriteRequestExecutor<>(request, responseObserver);
+      try {
+        ResilientOperation.retry(
+            requestExecutor,
+            backOffFactory.newBackOff(),
+            rateLimitedRetryDeterminer,
+            IOException.class,
+            sleeper);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Failed to get upload id.", e);
+      }
 
       return responseObserver.getResponse().getUploadId();
     }
@@ -423,21 +423,65 @@ public final class GoogleCloudStorageGrpcWriteChannel
 
       SimpleResponseObserver<QueryWriteStatusResponse> responseObserver =
           new SimpleResponseObserver<>();
-
-      runWithRetries(
-          () -> {
-            stub.withDeadlineAfter(QUERY_WRITE_STATUS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
-                .queryWriteStatus(request, responseObserver);
-            try {
-              responseObserver.done.await();
-            } catch (InterruptedException e) {
-              // Do not throw here since it will eventually throw if all retries fail.
-              e.printStackTrace();
-            }
-          },
-          responseObserver);
+      GrpcQueryWriteStatusRequestExecutor requestExecutor =
+          new GrpcQueryWriteStatusRequestExecutor<>(request, responseObserver);
+      try {
+        ResilientOperation.retry(
+            requestExecutor,
+            backOffFactory.newBackOff(),
+            rateLimitedRetryDeterminer,
+            IOException.class,
+            sleeper);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Failed to get committed write size.", e);
+      }
 
       return responseObserver.getResponse().getCommittedSize();
+    }
+
+    /** Simple class to create a {@link CheckedCallable} from a {@link QueryWriteStatusRequest}. */
+    private class GrpcQueryWriteStatusRequestExecutor<T>
+        implements CheckedCallable<T, InterruptedException> {
+      private final SimpleResponseObserver responseObserver;
+      private final QueryWriteStatusRequest request;
+
+      private GrpcQueryWriteStatusRequestExecutor(
+          QueryWriteStatusRequest request, SimpleResponseObserver responseObserver) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+      }
+
+      @Override
+      public T call() throws InterruptedException {
+        stub.withDeadlineAfter(QUERY_WRITE_STATUS_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+            .queryWriteStatus(request, responseObserver);
+        responseObserver.done.await();
+        return null;
+      }
+    }
+
+    /**
+     * Simple class to create a {@link CheckedCallable} from a {@link StartResumableWriteRequest}.
+     */
+    private class GrpcStartResumableWriteRequestExecutor<T>
+        implements CheckedCallable<T, InterruptedException> {
+      private final SimpleResponseObserver responseObserver;
+      private final StartResumableWriteRequest request;
+
+      private GrpcStartResumableWriteRequestExecutor(
+          StartResumableWriteRequest request, SimpleResponseObserver responseObserver) {
+        this.request = request;
+        this.responseObserver = responseObserver;
+      }
+
+      @Override
+      public T call() throws InterruptedException {
+        stub.withDeadlineAfter(START_RESUMABLE_WRITE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+            .startResumableWrite(request, responseObserver);
+        responseObserver.done.await();
+        return null;
+      }
     }
 
     /** Stream observer for single response RPCs. */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -89,10 +89,6 @@ public final class GoogleCloudStorageGrpcWriteChannel
   // Determine if a given IOException is due to rate-limiting.
   private RetryDeterminer<IOException> rateLimitedRetryDeterminer =
       RetryDeterminer.createRateLimitedRetryDeterminer(errorExtractor);
-  // Object to use to perform sleep operations
-  private Sleeper sleeper = Sleeper.DEFAULT;
-  // BackOff objects are per-request, use this to make new ones.
-  private BackOffFactory backOffFactory = BackOffFactory.DEFAULT;
 
   private GoogleCloudStorageItemInfo completedItemInfo = null;
 
@@ -401,13 +397,14 @@ public final class GoogleCloudStorageGrpcWriteChannel
           new SimpleResponseObserver<>();
       GrpcStartResumableWriteRequestExecutor requestExecutor =
           new GrpcStartResumableWriteRequestExecutor<>(request, responseObserver);
+
       try {
         ResilientOperation.retry(
             requestExecutor,
-            backOffFactory.newBackOff(),
+            BackOffFactory.DEFAULT.newBackOff(),
             rateLimitedRetryDeterminer,
             IOException.class,
-            sleeper);
+            Sleeper.DEFAULT);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IOException("Failed to get upload id.", e);
@@ -428,10 +425,10 @@ public final class GoogleCloudStorageGrpcWriteChannel
       try {
         ResilientOperation.retry(
             requestExecutor,
-            backOffFactory.newBackOff(),
+            BackOffFactory.DEFAULT.newBackOff(),
             rateLimitedRetryDeterminer,
             IOException.class,
-            sleeper);
+            Sleeper.DEFAULT);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IOException("Failed to get committed write size.", e);


### PR DESCRIPTION
Right now there are errors in dfsio write jobs that are caused by failure to getUploadId from server and we are missing retries for it. Haven't seen any data upload failure for a particular data chunk after retry for that case is added so it might also help to retry getUploadId erros to get rid of some of upload failures caused by this. 