### PR TITLE
Raise errors in getResponse() for failed calls.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -181,11 +181,6 @@ public final class GoogleCloudStorageGrpcWriteChannel
       // the writer at the other end will not hang indefinitely.
       try (InputStream toClose = pipeSource) {
         return doResumableUpload();
-      } catch (IOException e) {
-        throw e;
-      } catch (Exception e) {
-        throw new IOException(
-            String.format("Caught exception during upload for '%s'", resourceId), e);
       }
     }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -225,7 +225,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
           throw new IOException(
               String.format("Insert failed for '%s'", resourceId), responseObserver.getError());
         }
-      } while (!responseObserver.isFinished());
+      } while (!responseObserver.hasFinalized());
 
       return responseObserver.getResponse();
     }
@@ -347,8 +347,8 @@ public final class GoogleCloudStorageGrpcWriteChannel
         return checkNotNull(error, "Error not present for '%s'", resourceId);
       }
 
-      boolean isFinished() {
-        return objectFinalized || hasError();
+      boolean hasFinalized() {
+        return objectFinalized;
       }
 
       @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -365,7 +365,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
             new IOException(
                 String.format(
                     "Caught exception for '%s', while uploading to uploadId %s at writeOffset %d."
-                        + "Status: %s",
+                        + " Status: %s",
                     resourceId, uploadId, writeOffset, statusDesc),
                 t);
         done.countDown();


### PR DESCRIPTION
In the gRPC write channel, if the server returns an error, the client currently ends up attempting to read a nonexistent response message and failing out. This change has it instead raise an IOException with a meaningful error message.

It might make sense to return the gRPC status error directly, but wrapping it allows us to add useful additional error details, like the name of the object and the upload ID.