### PR TITLE
fix a RejectedExecutionException at googleCloudStorageImpl.close()

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1877,10 +1877,13 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     try {
       // TODO: add try-catch around each shutdown() call to make sure
       //  that all resources are shut down
-      backgroundTasksThreadPool.shutdown();
-      manualBatchingThreadPool.shutdown();
-      if (storageStubProvider != null) {
-        storageStubProvider.shutdown();
+      try {
+        if (storageStubProvider != null) {
+          storageStubProvider.shutdown();
+        }
+      } finally {
+        backgroundTasksThreadPool.shutdown();
+        manualBatchingThreadPool.shutdown();
       }
     } finally {
       backgroundTasksThreadPool = null;


### PR DESCRIPTION
This is a problem right now when shutdown() is called, more tasks are executed on executor which raises exception. This change make sure excutor service is shut down after channel is shut down.