### PR TITLE
remove autowindow settings from connector

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -358,10 +358,6 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.enable", false);
 
-  /** Configuration key for enabling auto-tuning flow-control window size. */
-  public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_AUTO_WINDOW_ENABLE =
-      new HadoopConfigurationProperty<>("fs.gs.grpc.auto.window.enable", false);
-
   /** Configuration key for enabling checksum validation for the gRPC API. */
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_CHECKSUMS_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.checksums.enable", false);
@@ -468,8 +464,7 @@ public class GoogleHadoopFileSystemConfiguration {
         .setEncryptionAlgorithm(GCS_ENCRYPTION_ALGORITHM.get(config, config::get))
         .setEncryptionKey(RedactedString.create(GCS_ENCRYPTION_KEY.getPassword(config)))
         .setEncryptionKeyHash(RedactedString.create(GCS_ENCRYPTION_KEY_HASH.getPassword(config)))
-        .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean))
-        .setGrpcAutoWindowEnabled(GCS_GRPC_AUTO_WINDOW_ENABLE.get(config, config::getBoolean));
+        .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -107,7 +107,6 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.encryption.key", null);
           put("fs.gs.encryption.key.hash", null);
           put("fs.gs.grpc.enable", false);
-          put("fs.gs.grpc.auto.window.enable", false);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.server.address", null);
         }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -69,7 +69,6 @@ import com.google.common.collect.Maps;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.grpc.netty.shaded.io.grpc.netty.InternalHandlerSettings;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -250,11 +249,6 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     if (storageOptions.isGrpcEnabled()) {
       this.storageStubProvider =
           new StorageStubProvider(options.getReadChannelOptions(), backgroundTasksThreadPool);
-      // Enable gRPC auto flow-control window if set.
-      if (storageOptions.isGrpcAutoWindowEnabled()) {
-        InternalHandlerSettings.enable(true);
-        InternalHandlerSettings.autoWindowOn(true);
-      }
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -35,9 +35,6 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for enabling use of GCS gRPC API. */
   public static final boolean ENABLE_GRPC_DEFAULT = false;
 
-  /** Default setting for enabling gRPC auto flow-control window. */
-  public static final boolean ENABLE_GRPC_AUTO_WINDOW_DEFAULT = false;
-
   /** Default root URL for Cloud Storage API endpoint. */
   public static final String STORAGE_ROOT_URL_DEFAULT = Storage.DEFAULT_ROOT_URL;
 
@@ -94,7 +91,6 @@ public abstract class GoogleCloudStorageOptions {
   public static Builder builder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
         .setGrpcEnabled(ENABLE_GRPC_DEFAULT)
-        .setGrpcAutoWindowEnabled(ENABLE_GRPC_AUTO_WINDOW_DEFAULT)
         .setStorageRootUrl(STORAGE_ROOT_URL_DEFAULT)
         .setStorageServicePath(STORAGE_SERVICE_PATH_DEFAULT)
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -121,8 +117,6 @@ public abstract class GoogleCloudStorageOptions {
   public abstract Builder toBuilder();
 
   public abstract boolean isGrpcEnabled();
-
-  public abstract boolean isGrpcAutoWindowEnabled();
 
   public abstract String getStorageRootUrl();
 
@@ -199,8 +193,6 @@ public abstract class GoogleCloudStorageOptions {
   public abstract static class Builder {
 
     public abstract Builder setGrpcEnabled(boolean grpcEnabled);
-
-    public abstract Builder setGrpcAutoWindowEnabled(boolean grpcAutoWindowEnabled);
 
     public abstract Builder setStorageRootUrl(String rootUrl);
 


### PR DESCRIPTION
Removed autowindow settings from connector bcuz it will be by default to true in grpc library from next release. Plus it's an internal API that should not be called directly from client, which could even cause problem if directly call it based on [this comment](https://github.com/grpc/grpc-java/issues/7007#issuecomment-625368425).

Also suspect that the fact this brings extra grpc internal package dependency may cause the problem when working/building with hadoop job somehow, which causes some `class not found` exception, given the fact adding back this grpc internal settings is one of the only 3 changes that are made after GCS connector 2.1.3 (above exception is not seen) and before the GCS connector RC7 (above exception is seen).