### PR TITLE
Expose HadoopCredentialConfiguration class in connectors public API

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/HadoopCredentialConfiguration.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/HadoopCredentialConfiguration.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hadoop.io.bigquery;
+
+/** Hadoop credential configuration for BigQuery Connector */
+public class HadoopCredentialConfiguration
+    extends com.google.cloud.hadoop.util.HadoopCredentialConfiguration {}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/HadoopCredentialConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/HadoopCredentialConfiguration.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hadoop.fs.gcs;
+
+/** Hadoop credential configuration for Google Cloud Storage Connector */
+public class HadoopCredentialConfiguration
+    extends com.google.cloud.hadoop.util.HadoopCredentialConfiguration {}

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
@@ -227,5 +227,5 @@ public class HadoopCredentialConfiguration {
     return ImmutableList.<String>builder().add(keyPrefixes).add(BASE_KEY_PREFIX).build();
   }
 
-  private HadoopCredentialConfiguration() {}
+  protected HadoopCredentialConfiguration() {}
 }


### PR DESCRIPTION
`HadoopCredentialConfiguration` is a part of connectors public API and should be accessible as a not shaded class to ensure interoperability between shaded and non-shaded jars.