### PR TITLE
Add an option to use Java NIO Pipe in Cloud Storage output stream

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -40,6 +40,22 @@
     wait between syncs. `hsync()` when rate limited will block on waiting for
     the permits, but `hflush()` will simply perform nothing and return.
 
+1.  Added a new parameter to configure output stream pipe type:
+
+    ```
+    fs.gs.outputstream.pipe.type (default: IO_STREAM_PIPE)
+    ```
+
+    Valid values are `NIO_CHANNEL_PIPE` and `IO_STREAM_PIPE`.
+
+    Output stream now supports (when property value set to `NIO_CHANNEL_PIPE`)
+    [Java NIO Pipe](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/Pipe.html)
+    that allows to reliably write in the output stream from multiple threads
+    without *"Pipe broken"* exceptions.
+
+    Note that when using `NIO_CHANNEL_PIPE` option maximum upload throughput can
+    decrease by 10%.
+
 ### 2.1.1 - 2020-03-11
 
 1.  Add upload cache to support high-level retries of failed uploads. Cache size

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -280,6 +280,27 @@ is `false`.
 
     Pipe buffer size used for uploading Cloud Storage objects.
 
+*   `fs.gs.outputstream.pipe.type` (default: `IO_STREAM_PIPE`)
+
+    Pipe type used for uploading Cloud Storage objects.
+
+    Valid values:
+
+    *   `NIO_CHANNEL_PIPE` - use
+        [Java NIO Pipe](https://docs.oracle.com/javase/8/docs/api/java/nio/channels/Pipe.html)
+        in output stream that writes to Cloud Storage. When using this pipe type
+        client can reliably write in the output stream from multiple threads
+        without *"Pipe broken"* exceptions. Note that when using this pipe type
+        Cloud Storage upload throughput can decrease by 10%;
+
+    *   `IO_STREAM_PIPE` - use
+        [PipedInputStream](https://docs.oracle.com/javase/8/docs/api/java/io/PipedInputStream.html)
+        and
+        [PipedOutputStream](https://docs.oracle.com/javase/8/docs/api/java/io/PipedOutputStream.html)
+        in output stream that writes to Cloud Storage. When using this pipe type
+        client cannot reliably write in the output stream from multiple threads
+        without triggering *"Pipe broken"* exceptions;
+
 *   `fs.gs.outputstream.upload.chunk.size` (default: `67108864`)
 
     The number of bytes in one GCS upload request.

--- a/gcs/conf/gcs-core-default.xml
+++ b/gcs/conf/gcs-core-default.xml
@@ -503,6 +503,12 @@
   </property>
 
   <property>
+    <name>fs.gs.outputstream.pipe.type</name>
+    <value>IO_STREAM_PIPE</value>
+    <description>Pipe type used for uploading Cloud Storage objects.</description>
+  </property>
+
+  <property>
     <name>fs.gs.outputstream.direct.upload.enable</name>
     <value>false</value>
     <description>Enables Cloud Storage direct upload.</description>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -289,7 +289,7 @@ public class GoogleHadoopFileSystemConfiguration {
 
   /** Configuration key for setting pipe type. */
   public static final HadoopConfigurationProperty<PipeType> GCS_OUTPUT_STREAM_PIPE_TYPE =
-      new HadoopConfigurationProperty<>("fs.gs.outputstream.pipe.type", PipeType.NIO_CHANNEL_PIPE);
+      new HadoopConfigurationProperty<>("fs.gs.outputstream.pipe.type", PipeType.IO_STREAM_PIPE);
 
   /** Configuration key for setting GCS upload chunk size. */
   // chunk size etc. Get the following value from GCSWC class in a better way. For now, we hard code

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -32,6 +32,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.PerformanceCachingGoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.cooplock.CooperativeLockingOptions;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PipeType;
 import com.google.cloud.hadoop.util.RedactedString;
 import com.google.cloud.hadoop.util.RequesterPaysOptions;
 import com.google.cloud.hadoop.util.RequesterPaysOptions.RequesterPaysMode;
@@ -286,6 +287,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Integer> GCS_OUTPUT_STREAM_PIPE_BUFFER_SIZE =
       new HadoopConfigurationProperty<>("fs.gs.outputstream.pipe.buffer.size", 1024 * 1024);
 
+  /** Configuration key for setting pipe type. */
+  public static final HadoopConfigurationProperty<PipeType> GCS_OUTPUT_STREAM_PIPE_TYPE =
+      new HadoopConfigurationProperty<>("fs.gs.outputstream.pipe.type", PipeType.NIO_CHANNEL_PIPE);
+
   /** Configuration key for setting GCS upload chunk size. */
   // chunk size etc. Get the following value from GCSWC class in a better way. For now, we hard code
   // it to a known good value.
@@ -501,6 +506,7 @@ public class GoogleHadoopFileSystemConfiguration {
     return AsyncWriteChannelOptions.builder()
         .setBufferSize(GCS_OUTPUT_STREAM_BUFFER_SIZE.get(config, config::getInt))
         .setPipeBufferSize(GCS_OUTPUT_STREAM_PIPE_BUFFER_SIZE.get(config, config::getInt))
+        .setPipeType(GCS_OUTPUT_STREAM_PIPE_TYPE.get(config, config::getEnum))
         .setUploadChunkSize(GCS_OUTPUT_STREAM_UPLOAD_CHUNK_SIZE.get(config, config::getInt))
         .setUploadCacheSize(GCS_OUTPUT_STREAM_UPLOAD_CACHE_SIZE.get(config, config::getInt))
         .setDirectUploadEnabled(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStreamIntegrationTest.java
@@ -100,7 +100,7 @@ public class GoogleHadoopFSInputStreamIntegrationTest {
     gcsFsIHelper.writeTextFile(path, testContent);
 
     GoogleHadoopFSInputStream in = createGhfsInputStream(ghfs, path);
-    try (GoogleHadoopFSInputStream toClose = in) {
+    try (GoogleHadoopFSInputStream ignore = in) {
       assertThat(in.available()).isEqualTo(0);
     }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -33,6 +33,7 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.OutputStreamTyp
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PipeType;
 import com.google.cloud.hadoop.util.RequesterPaysOptions.RequesterPaysMode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -81,6 +82,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.inputstream.support.gzip.encoding.enable", false);
           put("fs.gs.outputstream.buffer.size", 8 * 1024 * 1024);
           put("fs.gs.outputstream.pipe.buffer.size", 1024 * 1024);
+          put("fs.gs.outputstream.pipe.type", PipeType.IO_STREAM_PIPE);
           put("fs.gs.outputstream.upload.chunk.size", 64 * 1024 * 1024);
           put("fs.gs.outputstream.upload.cache.size", 0);
           put("fs.gs.io.buffersize.write", 64 * 1024 * 1024);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamIntegrationTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.hadoop.fs.gcs;
 
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_PIPE_TYPE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_TYPE;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -21,6 +22,7 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.OutputStreamTyp
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationHelper;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PipeType;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,20 +57,25 @@ public class GoogleHadoopOutputStreamIntegrationTest {
   @Parameters
   public static Collection<Object[]> getConstructorArguments() {
     return Arrays.asList(
-        new Object[] {OutputStreamType.BASIC},
-        new Object[] {OutputStreamType.FLUSHABLE_COMPOSITE},
-        new Object[] {OutputStreamType.SYNCABLE_COMPOSITE});
+        new Object[] {OutputStreamType.BASIC, PipeType.IO_STREAM_PIPE},
+        new Object[] {OutputStreamType.BASIC, PipeType.NIO_CHANNEL_PIPE},
+        new Object[] {OutputStreamType.FLUSHABLE_COMPOSITE, PipeType.IO_STREAM_PIPE},
+        new Object[] {OutputStreamType.SYNCABLE_COMPOSITE, PipeType.IO_STREAM_PIPE});
   }
 
   private final OutputStreamType outputStreamType;
+  private final PipeType pipeType;
 
-  public GoogleHadoopOutputStreamIntegrationTest(OutputStreamType outputStreamType) {
+  public GoogleHadoopOutputStreamIntegrationTest(
+      OutputStreamType outputStreamType, PipeType pipeType) {
     this.outputStreamType = outputStreamType;
+    this.pipeType = pipeType;
   }
 
   private Configuration getTestConfig() {
     Configuration conf = GoogleHadoopFileSystemIntegrationHelper.getTestConfig();
     conf.setEnum(GCS_OUTPUT_STREAM_TYPE.getKey(), outputStreamType);
+    conf.setEnum(GCS_OUTPUT_STREAM_PIPE_TYPE.getKey(), pipeType);
     return conf;
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -50,8 +50,6 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -143,7 +141,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
   }
 
   @Override
-  public void startUpload(ReadableByteChannel pipeSource) {
+  public void startUpload(InputStream pipeSource) {
     // Given that the two ends of the pipe must operate asynchronous relative
     // to each other, we need to start the upload operation on a separate thread.
     try {
@@ -159,9 +157,8 @@ public final class GoogleCloudStorageGrpcWriteChannel
     private final BufferedInputStream pipeSource;
     private final int MAX_BYTES_PER_MESSAGE = MAX_WRITE_CHUNK_BYTES.getNumber();
 
-    UploadOperation(ReadableByteChannel pipeSource) {
-      this.pipeSource =
-          new BufferedInputStream(Channels.newInputStream(pipeSource), MAX_BYTES_PER_MESSAGE);
+    UploadOperation(InputStream pipeSource) {
+      this.pipeSource = new BufferedInputStream(pipeSource, MAX_BYTES_PER_MESSAGE);
     }
 
     @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -165,7 +165,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
     public Object call() throws IOException {
       // Try-with-resource will close this end of the pipe so that
       // the writer at the other end will not hang indefinitely.
-      try (InputStream toClose = pipeSource) {
+      try (InputStream ignore = pipeSource) {
         return doResumableUpload();
       }
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -49,8 +49,9 @@ import io.grpc.stub.StreamObserver;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PipedInputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -142,7 +143,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
   }
 
   @Override
-  public void startUpload(PipedInputStream pipeSource) {
+  public void startUpload(ReadableByteChannel pipeSource) {
     // Given that the two ends of the pipe must operate asynchronous relative
     // to each other, we need to start the upload operation on a separate thread.
     try {
@@ -158,8 +159,9 @@ public final class GoogleCloudStorageGrpcWriteChannel
     private final BufferedInputStream pipeSource;
     private final int MAX_BYTES_PER_MESSAGE = MAX_WRITE_CHUNK_BYTES.getNumber();
 
-    UploadOperation(PipedInputStream pipeSource) {
-      this.pipeSource = new BufferedInputStream(pipeSource, MAX_BYTES_PER_MESSAGE);
+    UploadOperation(ReadableByteChannel pipeSource) {
+      this.pipeSource =
+          new BufferedInputStream(Channels.newInputStream(pipeSource), MAX_BYTES_PER_MESSAGE);
     }
 
     @Override

--- a/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
@@ -60,7 +60,7 @@ public abstract class AbstractGoogleAsyncWriteChannel<T extends AbstractGoogleCl
     request.setDisableGZipContent(true);
 
     // Change chunk size from default value (10MB) to one that yields higher performance.
-    clientRequestHelper.setChunkSize(request, uploadChunkSize);
+    clientRequestHelper.setChunkSize(request, options.getUploadChunkSize());
 
     // Given that the two ends of the pipe must operate asynchronous relative
     // to each other, we need to start the upload operation on a separate thread.
@@ -84,7 +84,7 @@ public abstract class AbstractGoogleAsyncWriteChannel<T extends AbstractGoogleCl
     public S call() throws Exception {
       // Try-with-resource will close this end of the pipe so that
       // the writer at the other end will not hang indefinitely.
-      try (InputStream uploadPipeSource = pipeSource) {
+      try (InputStream ignore = pipeSource) {
         return uploadObject.execute();
       } catch (IOException ioe) {
         S response = createResponseFromException(ioe);

--- a/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
@@ -18,8 +18,7 @@ import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
 import com.google.api.client.http.InputStreamContent;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
+import java.io.InputStream;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 
@@ -50,10 +49,9 @@ public abstract class AbstractGoogleAsyncWriteChannel<T extends AbstractGoogleCl
   public abstract T createRequest(InputStreamContent inputStream) throws IOException;
 
   @Override
-  public void startUpload(ReadableByteChannel pipeSource) throws IOException {
+  public void startUpload(InputStream pipeSource) throws IOException {
     // Connect pipe-source to the stream used by uploader.
-    InputStreamContent objectContentStream =
-        new InputStreamContent(contentType, Channels.newInputStream(pipeSource));
+    InputStreamContent objectContentStream = new InputStreamContent(contentType, pipeSource);
     // Indicate that we do not know length of file in advance.
     objectContentStream.setLength(-1);
     objectContentStream.setCloseInputStream(false);
@@ -74,10 +72,10 @@ public abstract class AbstractGoogleAsyncWriteChannel<T extends AbstractGoogleCl
     private final T uploadObject;
 
     // Read end of the pipe. This object declared final for safe object publishing.
-    private final ReadableByteChannel pipeSource;
+    private final InputStream pipeSource;
 
     /** Constructs an instance of UploadOperation. */
-    public UploadOperation(T uploadObject, ReadableByteChannel pipeSource) {
+    public UploadOperation(T uploadObject, InputStream pipeSource) {
       this.uploadObject = uploadObject;
       this.pipeSource = pipeSource;
     }
@@ -86,7 +84,7 @@ public abstract class AbstractGoogleAsyncWriteChannel<T extends AbstractGoogleCl
     public S call() throws Exception {
       // Try-with-resource will close this end of the pipe so that
       // the writer at the other end will not hang indefinitely.
-      try (ReadableByteChannel uploadPipeSource = pipeSource) {
+      try (InputStream uploadPipeSource = pipeSource) {
         return uploadObject.execute();
       } catch (IOException ioe) {
         S response = createResponseFromException(ioe);

--- a/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
@@ -26,6 +26,12 @@ public abstract class AsyncWriteChannelOptions {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
+  /** Pipe used for output stream. */
+  public enum PipeType {
+    NIO_CHANNEL_PIPE,
+    IO_STREAM_PIPE,
+  }
+
   /** Default upload buffer size. */
   public static final int BUFFER_SIZE_DEFAULT = 8 * 1024 * 1024;
 
@@ -50,12 +56,15 @@ public abstract class AsyncWriteChannelOptions {
   /** Default of whether to enabled checksums for gRPC. */
   public static final boolean GRPC_CHECKSUMS_ENABLED_DEFAULT = true;
 
+  public static final PipeType PIPE_TYPE_DEFAULT = PipeType.IO_STREAM_PIPE;
+
   public static final AsyncWriteChannelOptions DEFAULT = builder().build();
 
   public static Builder builder() {
     return new AutoValue_AsyncWriteChannelOptions.Builder()
         .setBufferSize(BUFFER_SIZE_DEFAULT)
         .setPipeBufferSize(PIPE_BUFFER_SIZE_DEFAULT)
+        .setPipeType(PIPE_TYPE_DEFAULT)
         .setUploadChunkSize(UPLOAD_CHUNK_SIZE_DEFAULT)
         .setUploadCacheSize(UPLOAD_CACHE_SIZE_DEFAULT)
         .setDirectUploadEnabled(DIRECT_UPLOAD_ENABLED_DEFAULT)
@@ -67,6 +76,8 @@ public abstract class AsyncWriteChannelOptions {
   public abstract int getBufferSize();
 
   public abstract int getPipeBufferSize();
+
+  public abstract PipeType getPipeType();
 
   public abstract int getUploadChunkSize();
 
@@ -83,6 +94,8 @@ public abstract class AsyncWriteChannelOptions {
     public abstract Builder setBufferSize(int bufferSize);
 
     public abstract Builder setPipeBufferSize(int pipeBufferSize);
+
+    public abstract Builder setPipeType(PipeType pipeType);
 
     public abstract Builder setUploadChunkSize(int uploadChunkSize);
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/BaseAbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/BaseAbstractGoogleAsyncWriteChannel.java
@@ -17,12 +17,14 @@ package com.google.cloud.hadoop.util;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.flogger.GoogleLogger;
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.ClosedByInterruptException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.Pipe;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -218,7 +220,8 @@ public abstract class BaseAbstractGoogleAsyncWriteChannel<T> implements Writable
     // the uploader and the other end is the write channel used by the caller.
     Pipe pipe = Pipe.open();
     pipeSink = pipe.sink();
-    ReadableByteChannel pipeSource = pipe.source();
+    InputStream pipeSource =
+        new BufferedInputStream(Channels.newInputStream(pipe.source()), pipeBufferSize);
 
     startUpload(pipeSource);
 
@@ -226,7 +229,7 @@ public abstract class BaseAbstractGoogleAsyncWriteChannel<T> implements Writable
   }
 
   /** Create a new thread which handles the upload. */
-  public abstract void startUpload(ReadableByteChannel pipeSource) throws IOException;
+  public abstract void startUpload(InputStream pipeSource) throws IOException;
 
   /** Sets the contentType. This must be called before {@link #initialize()} for any effect. */
   protected void setContentType(String contentType) {

--- a/util/src/main/java/com/google/cloud/hadoop/util/BaseAbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/BaseAbstractGoogleAsyncWriteChannel.java
@@ -220,10 +220,11 @@ public abstract class BaseAbstractGoogleAsyncWriteChannel<T> implements Writable
     // the uploader and the other end is the write channel used by the caller.
     Pipe pipe = Pipe.open();
     pipeSink = pipe.sink();
-    InputStream pipeSource =
-        new BufferedInputStream(Channels.newInputStream(pipe.source()), pipeBufferSize);
+    InputStream pipeSource = Channels.newInputStream(pipe.source());
+    InputStream bufferedPipeSource =
+        pipeBufferSize > 0 ? new BufferedInputStream(pipeSource, pipeBufferSize) : pipeSource;
 
-    startUpload(pipeSource);
+    startUpload(bufferedPipeSource);
 
     initialized = true;
   }


### PR DESCRIPTION
In contrast to `PipedInputStream`/`PipedOutputStream` pipe, Java NIO `Pipe` supports multiple writers and does not throw *"Pipe broken"* exception in this case (see #103 for an example).

Note that according to `TestDFSIO` HCFS test Java NIO `Pipe` has 10% lower throughput when writing to GCS than current implementation - that's why Java NIO `Pipe` is not used by default.

Fixes #104 (?)