### PR TITLE
Rewrite retry mechanism for gRPC write in gcsio

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -169,6 +169,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
     // Read end of the pipe.
     private final BufferedInputStream pipeSource;
     private final int MAX_BYTES_PER_MESSAGE = MAX_WRITE_CHUNK_BYTES.getNumber();
+    // A map mapping from write offset to retries that have been made to the corresponding offset.
     private final Map<Long, Integer> retryMap = new HashMap<>();
 
     UploadOperation(InputStream pipeSource) {
@@ -225,6 +226,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
 
       private final long writeOffset;
       private final String uploadId;
+      // A map holding cached data chunks, keyed by the offset to start writing each data chunk.
       private final TreeMap<Long, ByteString> dataChunkMap;
       private volatile boolean objectFinalized = false;
       // The last transient error to occur during the streaming RPC.

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
@@ -677,7 +677,6 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
       private Object object = DEFAULT_OBJECT;
       Throwable insertRequestException;
       boolean resumeFromInsertException = false;
-      boolean hasOnNextBeenCalled = false;
 
       @Override
       public void onNext(InsertObjectRequest request) {


### PR DESCRIPTION
This change mainly solves 2 issues:

1. After resumable write failed due to transient error, e.g. DEADLINE_EXCEED, committed size queried from server can be less than the size that has been uploaded thru client request. Current implementation doesn't handle this case. New implementation handles this by cached the past `numberOfRequestsToRetain` number of data chunk for later resume if needed.
2. This also fixes a bug of current retry mechanism that the bufferedInputStream could be reset to an invalid position