### PR TITLE
Revert "Enable upload cache for HCFS contract tests to workaround GCS flakiness (#365)"

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/GoogleContract.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/GoogleContract.java
@@ -36,8 +36,6 @@ public class GoogleContract extends AbstractBondedFSContract {
     super(conf);
     addConfResource(CONTRACT_XML);
     conf.set("fs.contract.test.fs.gs", "gs://" + bucketHelper.getUniqueBucketPrefix());
-    // TODO: remove when GCS fixes non-retriable "410 Gone" responses
-    conf.setInt("fs.gs.outputstream.upload.cache.size", 1024 * 1024);
 
     TestConfiguration testConf = TestConfiguration.getInstance();
     if (testConf.getProjectId() != null) {


### PR DESCRIPTION
This reverts commit 1d1060bb03576870ec622fac70c51cc1df5fbc91.