### PR TITLE
Fix per-user/group SA impersonation

### DIFF
--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -247,21 +247,34 @@ is `false`.
 
 #### Service account impersonation
 
-If the following property is set, the service account specified will be
-impersonated by generating a short-lived credential when accessing GCS.
-Configured authentication method authentications will be used to authenticate
-the request to generate this short-lived credential.
+Service account impersonation can be configured for a specific user name and a
+group name, or for all users by default using below properties:
+
+*   `fs.gs.auth.impersonation.service.account.for.user.<USER_NAME>` (not set by
+    default)
+
+    The service account impersonation for a specific user.
+
+*   `fs.gs.auth.impersonation.service.account.for.group.<GROUP_NAME>` (not set
+    by default)
+
+    The service account impersonation for a specific group.
 
 *   `fs.gs.auth.impersonation.service.account` (not set by default)
 
-If any of the following properties is set, the service account specified will be
-impersonated by generating a short-lived credential when accessing GCS if the
-current user or group name matches with specified user or group name.
-If both are set, then the service account associated with the user name will
-take precedence over the service account associated with the group name.
+    Default service account impersonation for all users.
 
-*   `fs.gs.auth.impersonation.service.account.for.user.<USER_NAME>` (not set by default)
-*   `fs.gs.auth.impersonation.service.account.for.group.<GROUP_NAME>` (not set by default)
+If any of the above properties are set then the service account specified will
+be impersonated by generating a short-lived credential when accessing Google
+Cloud Storage.
+
+Configured authentication method will be used to authenticate the request to
+generate this short-lived credential.
+
+If more than one property is set then the service account associated with the
+user name will take precedence over the service account associated with the
+group name for a matching user and group, which in turn will take precedence
+over default service account impersonation.
 
 ### IO configuration
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -17,8 +17,6 @@
 package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.HTTP_TRANSPORT_SUFFIX;
-import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX;
-import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_ADDRESS_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_PASSWORD_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_USERNAME_SUFFIX;
@@ -471,15 +469,7 @@ public class GoogleHadoopFileSystemConfiguration {
         .setEncryptionAlgorithm(GCS_ENCRYPTION_ALGORITHM.get(config, config::get))
         .setEncryptionKey(RedactedString.create(GCS_ENCRYPTION_KEY.getPassword(config)))
         .setEncryptionKeyHash(RedactedString.create(GCS_ENCRYPTION_KEY_HASH.getPassword(config)))
-        .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean))
-        .setUserImpersonationServiceAccounts(
-            IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX
-                .withPrefixes(CONFIG_KEY_PREFIXES)
-                .getPropsWithPrefix(config))
-        .setGroupImpersonationServiceAccounts(
-            IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX
-                .withPrefixes(CONFIG_KEY_PREFIXES)
-                .getPropsWithPrefix(config));
+        .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -21,11 +21,11 @@ import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_HTTP_HEADERS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ROOT_URL;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_SERVICE_PATH;
-import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX;
-import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX;
+import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_ADDRESS_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_PASSWORD_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_USERNAME_SUFFIX;
+import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.cloud.hadoop.util.testing.HadoopConfigurationUtils.getDefaultProperties;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -274,18 +274,21 @@ public class GoogleHadoopFileSystemConfigurationTest {
   public void testImpersonationIdentifier() {
     Configuration config = new Configuration();
     config.set(
-        GCS_CONFIG_PREFIX + IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX.getKey() + "test-user",
+        GCS_CONFIG_PREFIX + USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey() + "test-user",
         "test-service-account1");
     config.set(
-        GCS_CONFIG_PREFIX + IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX.getKey() + "test-grp",
+        GCS_CONFIG_PREFIX + GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey() + "test-grp",
         "test-service-account2");
 
-    GoogleCloudStorageFileSystemOptions options =
-        GoogleHadoopFileSystemConfiguration.getGcsFsOptionsBuilder(config).build();
-
-    assertThat(options.getCloudStorageOptions().getUserImpersonationServiceAccounts())
+    assertThat(
+            USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX
+                .withPrefixes(ImmutableList.of(GCS_CONFIG_PREFIX))
+                .getPropsWithPrefix(config))
         .containsExactly("test-user", "test-service-account1");
-    assertThat(options.getCloudStorageOptions().getGroupImpersonationServiceAccounts())
+    assertThat(
+            GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX
+                .withPrefixes(ImmutableList.of(GCS_CONFIG_PREFIX))
+                .getPropsWithPrefix(config))
         .containsExactly("test-grp", "test-service-account2");
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -16,10 +16,10 @@ package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_CONFIG_PREFIX;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_LAZY_INITIALIZATION_ENABLE;
-import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX;
-import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX;
+import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.SERVICE_ACCOUNT_JSON_KEYFILE_SUFFIX;
+import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -226,7 +226,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
         AccessTokenProvider.class);
     config.set(
         GCS_CONFIG_PREFIX
-            + IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX.getKey()
+            + USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey()
             + UserGroupInformation.getCurrentUser().getShortUserName(),
         "test-service-account");
 
@@ -251,7 +251,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
         AccessTokenProvider.class);
     config.set(
         GCS_CONFIG_PREFIX
-            + IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX.getKey()
+            + GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey()
             + UserGroupInformation.getCurrentUser().getGroupNames()[0],
         "test-service-account");
 
@@ -276,12 +276,12 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
         AccessTokenProvider.class);
     config.set(
         GCS_CONFIG_PREFIX
-            + IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX.getKey()
+            + USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey()
             + UserGroupInformation.getCurrentUser().getShortUserName(),
         "test-service-account1");
     config.set(
         GCS_CONFIG_PREFIX
-            + IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX.getKey()
+            + GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey()
             + UserGroupInformation.getCurrentUser().getGroupNames()[0],
         "test-service-account2");
 
@@ -308,12 +308,12 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
         GCS_CONFIG_PREFIX + IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey(), "test-service-account1");
     config.set(
         GCS_CONFIG_PREFIX
-            + IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX.getKey()
+            + USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey()
             + UserGroupInformation.getCurrentUser().getShortUserName(),
         "test-service-account2");
     config.set(
         GCS_CONFIG_PREFIX
-            + IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX.getKey()
+            + GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey()
             + UserGroupInformation.getCurrentUser().getGroupNames()[0],
         "test-service-account3");
 
@@ -337,7 +337,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
         TestingAccessTokenProvider.class,
         AccessTokenProvider.class);
     config.set(
-        GCS_CONFIG_PREFIX + IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX.getKey() + "invalid-user",
+        GCS_CONFIG_PREFIX + USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX.getKey() + "invalid-user",
         "test-service-account");
 
     URI gsUri = new URI("gs://foobar/");

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -88,10 +88,6 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for GCS HTTP request headers. */
   public static final ImmutableMap<String, String> HTTP_REQUEST_HEADERS_DEFAULT = ImmutableMap.of();
 
-  /** Default setting for impersonation service accounts. */
-  public static final ImmutableMap<String, String> IMPERSONATION_SERVICE_ACCOUNTS =
-      ImmutableMap.of();
-
   public static final GoogleCloudStorageOptions DEFAULT = builder().build();
 
   public static Builder builder() {
@@ -117,9 +113,7 @@ public abstract class GoogleCloudStorageOptions {
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setRequesterPaysOptions(RequesterPaysOptions.DEFAULT)
         .setCooperativeLockingOptions(CooperativeLockingOptions.DEFAULT)
-        .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT)
-        .setUserImpersonationServiceAccounts(IMPERSONATION_SERVICE_ACCOUNTS)
-        .setGroupImpersonationServiceAccounts(IMPERSONATION_SERVICE_ACCOUNTS);
+        .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT);
   }
 
   public abstract Builder toBuilder();
@@ -191,12 +185,6 @@ public abstract class GoogleCloudStorageOptions {
 
   @Nullable
   public abstract RedactedString getEncryptionKeyHash();
-
-  @Nullable
-  public abstract Map<String, String> getUserImpersonationServiceAccounts();
-
-  @Nullable
-  public abstract Map<String, String> getGroupImpersonationServiceAccounts();
 
   public RetryHttpInitializerOptions toRetryHttpInitializerOptions() {
     return RetryHttpInitializerOptions.builder()
@@ -278,12 +266,6 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setEncryptionKey(RedactedString encryptionKey);
 
     public abstract Builder setEncryptionKeyHash(RedactedString encryptionKeyHash);
-
-    public abstract Builder setUserImpersonationServiceAccounts(
-        Map<String, String> userImpersonationServiceAccounts);
-
-    public abstract Builder setGroupImpersonationServiceAccounts(
-        Map<String, String> groupImpersonationServiceAccounts);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
+++ b/util-hadoop/src/main/java/com/google/cloud/hadoop/util/HadoopCredentialConfiguration.java
@@ -172,7 +172,7 @@ public class HadoopCredentialConfiguration {
    * accessing GCS.
    */
   public static final HadoopConfigurationProperty<Map<String, String>>
-      IMPERSONATION_SERVICE_ACCOUNT_FOR_USER_SUFFIX =
+      USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX =
           new HadoopConfigurationProperty<>(
               ".auth.impersonation.service.account.for.user.", ImmutableMap.of());
 
@@ -181,7 +181,7 @@ public class HadoopCredentialConfiguration {
    * accessing GCS.
    */
   public static final HadoopConfigurationProperty<Map<String, String>>
-      IMPERSONATION_SERVICE_ACCOUNT_FOR_GROUP_SUFFIX =
+      GROUP_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX =
           new HadoopConfigurationProperty<>(
               ".auth.impersonation.service.account.for.group.", ImmutableMap.of());
 


### PR DESCRIPTION
Changes:

1. Do not override per-user/group impersonation configuration with generic impersonation.
1. Code cleanup