### PR TITLE
Use System Lambda's withEnvironmentVariable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
     <hadoop.two.version>2.10.0</hadoop.two.version>
     <hadoop.three.version>3.2.1</hadoop.three.version>
     <junit.version>4.13</junit.version>
-    <junit.system-rules.version>1.19.0</junit.system-rules.version>
     <mockito.version>3.4.0</mockito.version>
+    <system-lambda.version>1.1.0</system-lambda.version>
   </properties>
 
   <modules>
@@ -514,8 +514,8 @@
       </dependency>
       <dependency>
         <groupId>com.github.stefanbirkner</groupId>
-        <artifactId>system-rules</artifactId>
-        <version>${junit.system-rules.version}</version>
+        <artifactId>system-lambda</artifactId>
+        <version>${system-lambda.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/util-hadoop/pom.xml
+++ b/util-hadoop/pom.xml
@@ -118,7 +118,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
+      <artifactId>system-lambda</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -159,7 +159,7 @@ public class HadoopCredentialConfigurationTest {
 
     GoogleCredentialWithRetry credential =
         (GoogleCredentialWithRetry)
-        withEnvironmentVariable(CREDENTIAL_ENV_VAR, getStringPath("test-credential.json"))
+            withEnvironmentVariable(CREDENTIAL_ENV_VAR, getStringPath("test-credential.json"))
                 .execute(() -> credentialFactory.getCredential(TEST_SCOPES));
 
     assertThat(credential.getServiceAccountId()).isEqualTo("test-email@gserviceaccount.com");

--- a/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
+++ b/util-hadoop/src/test/java/com/google/cloud/hadoop/util/HadoopCredentialConfigurationTest.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.hadoop.util;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static com.google.cloud.hadoop.util.CredentialFactory.CREDENTIAL_ENV_VAR;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.CLIENT_ID_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.CLIENT_SECRET_SUFFIX;
@@ -48,9 +49,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -89,8 +88,6 @@ public class HadoopCredentialConfigurationTest {
       };
 
   private static final ImmutableList<String> TEST_SCOPES = ImmutableList.of("scope1", "scope2");
-
-  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   private Configuration configuration;
 
@@ -158,12 +155,12 @@ public class HadoopCredentialConfigurationTest {
 
   @Test
   public void applicationDefaultServiceAccountWhenConfigured() throws Exception {
-    environmentVariables.set(CREDENTIAL_ENV_VAR, getStringPath("test-credential.json"));
-
     CredentialFactory credentialFactory = getCredentialFactory();
 
     GoogleCredentialWithRetry credential =
-        (GoogleCredentialWithRetry) credentialFactory.getCredential(TEST_SCOPES);
+        (GoogleCredentialWithRetry)
+        withEnvironmentVariable(CREDENTIAL_ENV_VAR, getStringPath("test-credential.json"))
+                .execute(() -> credentialFactory.getCredential(TEST_SCOPES));
 
     assertThat(credential.getServiceAccountId()).isEqualTo("test-email@gserviceaccount.com");
     assertThat(credential.getServiceAccountPrivateKeyId()).isEqualTo("test-key-id");


### PR DESCRIPTION
System Lambda is independent of the test framework and therefore no
obstacle for changing the test framework.
System Lambda is more local, too. It is only used for the single
statement that needs environment variables.