### PR TITLE
Set location when getting BigQuery job status

### DIFF
--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -349,8 +349,7 @@ public class BigQueryHelper {
         job.getJobReference());
     Job response;
     try {
-      response = service
-                    .jobs().insert(projectId, job).execute();
+      response = service.jobs().insert(projectId, job).execute();
       logger.atFine().log("Successfully inserted job '%s'. Response: '%s'", job, response);
     } catch (IOException insertJobException) {
       if (errorExtractor.itemAlreadyExists(insertJobException)) {
@@ -358,12 +357,15 @@ public class BigQueryHelper {
             "Fetching existing job after catching exception for duplicate jobId '%s'",
             job.getJobReference().getJobId());
         try {
-          response = 
-            service
-              .jobs()
-              .get(projectId, job.getJobReference().getJobId())
-              .setLocation(job.getJobReference().getLocation())
-              .execute();
+          if (job.getJobReference().getLocation()!=null) {
+            response = service
+                         .jobs()
+                         .get(projectId, job.getJobReference().getJobId())
+                         .setLocation(job.getJobReference().getLocation())
+                         .execute();
+          } else {
+            response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
+          }
         } catch (IOException getJobException) {
           getJobException.addSuppressed(insertJobException);
           throw new IOException(

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -349,7 +349,8 @@ public class BigQueryHelper {
         job.getJobReference());
     Job response;
     try {
-      response = service.jobs().insert(projectId, job).execute();
+      response = service
+                    .jobs().insert(projectId, job).execute();
       logger.atFine().log("Successfully inserted job '%s'. Response: '%s'", job, response);
     } catch (IOException insertJobException) {
       if (errorExtractor.itemAlreadyExists(insertJobException)) {
@@ -357,7 +358,12 @@ public class BigQueryHelper {
             "Fetching existing job after catching exception for duplicate jobId '%s'",
             job.getJobReference().getJobId());
         try {
-          response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
+          response = 
+            service
+              .jobs()
+              .get(projectId, job.getJobReference().getJobId())
+              .setLocation(job.getJobReference().getLocation())
+              .execute();
         } catch (IOException getJobException) {
           getJobException.addSuppressed(insertJobException);
           throw new IOException(


### PR DESCRIPTION
This fixes issue #431.  When getting a BigQuery job created outside of the default US location, we need to explicitly provide the job location in the get job request.