### PR TITLE
Set location when getting BigQuery job status

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -2,6 +2,8 @@
 
 1.  Update all dependencies to latest versions.
 
+1.  Fix BigQuery job status retrieval in non-US locations.
+
 ### 1.1.1 - 2020-03-11
 
 1.  Fix shaded jar - add back missing relocated dependencies.

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -357,16 +357,12 @@ public class BigQueryHelper {
             "Fetching existing job after catching exception for duplicate jobId '%s'",
             job.getJobReference().getJobId());
         try {
-          if (job.getJobReference().getLocation()!=null) {
-            response =
-                    service
-                            .jobs()
-                            .get(projectId, job.getJobReference().getJobId())
-                            .setLocation(job.getJobReference().getLocation())
-                            .execute();
-          } else {
-            response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
-          }
+          response =
+              service
+                  .jobs()
+                  .get(projectId, job.getJobReference().getJobId())
+                  .setLocation(job.getJobReference().getLocation())
+                  .execute();
         } catch (IOException getJobException) {
           getJobException.addSuppressed(insertJobException);
           throw new IOException(

--- a/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
+++ b/bigquery/src/main/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelper.java
@@ -357,7 +357,16 @@ public class BigQueryHelper {
             "Fetching existing job after catching exception for duplicate jobId '%s'",
             job.getJobReference().getJobId());
         try {
-          response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
+          if (job.getJobReference().getLocation()!=null) {
+            response =
+                    service
+                            .jobs()
+                            .get(projectId, job.getJobReference().getJobId())
+                            .setLocation(job.getJobReference().getLocation())
+                            .execute();
+          } else {
+            response = service.jobs().get(projectId, job.getJobReference().getJobId()).execute();
+          }
         } catch (IOException getJobException) {
           getJobException.addSuppressed(insertJobException);
           throw new IOException(

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelperTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/BigQueryHelperTest.java
@@ -116,7 +116,7 @@ public class BigQueryHelperTest {
     // Mock getting Bigquery job.
     when(mockBigqueryJobs.get(any(String.class), any(String.class)))
         .thenReturn(mockBigqueryJobsGet);
-    when(mockBigqueryJobsGet.setLocation(any(String.class))).thenReturn(mockBigqueryJobsGet);
+    when(mockBigqueryJobsGet.setLocation(any())).thenReturn(mockBigqueryJobsGet);
 
     // Mock inserting Bigquery job.
     when(mockBigqueryJobs.insert(any(String.class), any(Job.class)))
@@ -355,6 +355,7 @@ public class BigQueryHelperTest {
     assertThat(job).isEqualTo(jobHandle);
     verify(mockBigqueryJobsInsert, times(1)).execute();
     verify(mockBigqueryJobs, times(1)).get(eq(jobProjectId), eq(jobId));
+    verify(mockBigqueryJobsGet, times(1)).setLocation(eq(null));
     verify(mockBigqueryJobsGet, times(1)).execute();
     verify(mockErrorExtractor).itemAlreadyExists(eq(fakeConflictException));
   }


### PR DESCRIPTION
When getting a BigQuery job created outside of the default US location, we need to explicitly provide the job location in the get job request.

Fixes #431