### PR TITLE
Add interceptor to inject remote address to non-ok status discription

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -138,8 +138,11 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   private static IOException convertError(
       StatusRuntimeException error, String bucketName, String objectName) {
     Status.Code statusCode = Status.fromThrowable(error).getCode();
+    Status status = error.getStatus();
     String msg =
-        String.format("Error reading '%s'", StringPaths.fromComponents(bucketName, objectName));
+        String.format("Error reading '%s', got status: %s",
+            StringPaths.fromComponents(bucketName, objectName),
+            status.toString());
     if (statusCode == Status.Code.NOT_FOUND) {
       return GoogleCloudStorageExceptions.createFileNotFoundException(
           bucketName, objectName, new IOException(msg, error));

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -141,8 +141,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     Status status = error.getStatus();
     String msg =
         String.format("Error reading '%s', got status: %s",
-            StringPaths.fromComponents(bucketName, objectName),
-            status.toString());
+            StringPaths.fromComponents(bucketName, objectName), status);
     if (statusCode == Status.Code.NOT_FOUND) {
       return GoogleCloudStorageExceptions.createFileNotFoundException(
           bucketName, objectName, new IOException(msg, error));

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -407,7 +407,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
                   String.format(
                       "Caught exception for '%s', while uploading to uploadId %s at writeOffset %d."
                           + " Status: %s",
-                      resourceId, uploadId, writeOffset, s.toString()),
+                      resourceId, uploadId, writeOffset, s),
                   t);
         }
         done.countDown();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -376,7 +376,6 @@ public final class GoogleCloudStorageGrpcWriteChannel
       @Override
       public void onError(Throwable t) {
         Status s = Status.fromThrowable(t);
-        String statusDesc = s == null ? "" : s.getDescription();
 
         if (t.getClass() == StatusException.class || t.getClass() == StatusRuntimeException.class) {
           Code code =
@@ -393,7 +392,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
                   String.format(
                       "Caught exception for '%s', while uploading to uploadId %s at writeOffset %d."
                           + " Status: %s",
-                      resourceId, uploadId, writeOffset, statusDesc),
+                      resourceId, uploadId, writeOffset, s.toString()),
                   t);
         }
         done.countDown();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -17,11 +17,13 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.alts.GoogleDefaultChannelBuilder;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -115,6 +117,32 @@ public class StorageStubProvider {
     }
   }
 
+  // TODO(weiranf): Temporarily added for debugging, will be removed once GCS/DirectPath is stable.
+  final class RemoteAddressDebuggingInterceptor implements ClientInterceptor {
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions, Channel next) {
+      final ClientCall<ReqT, RespT> newCall = next.newCall(method, callOptions);
+      return new SimpleForwardingClientCall<ReqT, RespT>(newCall) {
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+              if (!status.isOk()) {
+                SocketAddress remoteAddr =
+                    newCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+                status = status.augmentDescription("Remote Address: " + remoteAddr.toString());
+              }
+              super.onClose(status, trailers);
+            }
+          }, headers);
+        }
+      };
+    }
+  }
+
   class ChannelAndRequestCounter {
     private final ManagedChannel channel;
     private final ActiveRequestCounter counter;
@@ -146,6 +174,9 @@ public class StorageStubProvider {
             .enableRetry()
             .defaultServiceConfig(getGrpcServiceConfig())
             .intercept(counter)
+            // TODO(weiranf): Temporarily added for debugging,
+            //                will be removed once GCS/DirectPath is stable.
+            .intercept(new RemoteAddressDebuggingInterceptor())
             .build();
     return new ChannelAndRequestCounter(channel, counter);
   }


### PR DESCRIPTION
For debugging purposes, when client receives non-ok status, we want to know the remote peer address.

To achieve this, we need add additional client interceptor to introspect the remote address before error got thrown out, and also inject the address string into the status description.

+cc @veblush 