### PR TITLE
Unescape line breaks in `fs.gs.auth.service.account.private.key`

### DIFF
--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -383,8 +383,8 @@ public class CredentialFactory {
 
   // TODO: Copied (mostly) over from Google Credential since it has private scope
   private static PrivateKey privateKeyFromPkcs8(String privateKeyPem) throws IOException {
-    privateKeyPem = privateKeyPem.replaceAll("\\n", System.lineSeparator());
-    Reader reader = new StringReader(privateKeyPem);
+    // Unescape new-line symbols in privateKeyPem string value
+    Reader reader = new StringReader(privateKeyPem.replaceAll("\\n", System.lineSeparator()));
     Section section = PemReader.readFirstSectionAndClose(reader, "PRIVATE KEY");
     if (section == null) {
       throw new IOException("Invalid PKCS8 data.");

--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -383,6 +383,7 @@ public class CredentialFactory {
 
   // TODO: Copied (mostly) over from Google Credential since it has private scope
   private static PrivateKey privateKeyFromPkcs8(String privateKeyPem) throws IOException {
+    privateKeyPem = privateKeyPem.replaceAll("\\n", System.lineSeparator());
     Reader reader = new StringReader(privateKeyPem);
     Section section = PemReader.readFirstSectionAndClose(reader, "PRIVATE KEY");
     if (section == null) {


### PR DESCRIPTION
Re-added escaped line break replace that was lost during a refactor.

Fixes #443