### PR TITLE
Refactor list object methods to use ListObjectOptions

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -64,13 +64,13 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public void createBucket(String bucketName) throws IOException {
-    logger.atFine().log("%s.create(%s)", delegateClassName, bucketName);
+    logger.atFine().log("%s.createBucket(%s)", delegateClassName, bucketName);
     delegate.createBucket(bucketName);
   }
 
   @Override
   public void createBucket(String bucketName, CreateBucketOptions options) throws IOException {
-    logger.atFine().log("%s.create(%s, %s)", delegateClassName, bucketName, options);
+    logger.atFine().log("%s.createBucket(%s, %s)", delegateClassName, bucketName, options);
     delegate.createBucket(bucketName, options);
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -63,15 +63,15 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public void create(String bucketName) throws IOException {
+  public void createBucket(String bucketName) throws IOException {
     logger.atFine().log("%s.create(%s)", delegateClassName, bucketName);
-    delegate.create(bucketName);
+    delegate.createBucket(bucketName);
   }
 
   @Override
-  public void create(String bucketName, CreateBucketOptions options) throws IOException {
+  public void createBucket(String bucketName, CreateBucketOptions options) throws IOException {
     logger.atFine().log("%s.create(%s, %s)", delegateClassName, bucketName, options);
-    delegate.create(bucketName, options);
+    delegate.createBucket(bucketName, options);
   }
 
   @Override
@@ -151,51 +151,49 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public List<String> listObjectNames(String bucketName, String objectNamePrefix, String delimiter)
+  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
       throws IOException {
     logger.atFine().log(
-        "%s.listObjectNames(%s, %s, %s)",
-        delegateClassName, bucketName, objectNamePrefix, delimiter);
-    return delegate.listObjectNames(bucketName, objectNamePrefix, delimiter);
+        "%s.listObjectNames(%s, %s)", delegateClassName, bucketName, objectNamePrefix);
+    return delegate.listObjectNames(bucketName, objectNamePrefix);
   }
 
   @Override
   public List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
     logger.atFine().log(
-        "%s.listObjectNames(%s, %s, %s, %s)",
-        delegateClassName, bucketName, objectNamePrefix, delimiter, maxResults);
-    return delegate.listObjectNames(bucketName, objectNamePrefix, delimiter, maxResults);
+        "%s.listObjectNames(%s, %s, %s)",
+        delegateClassName, bucketName, objectNamePrefix, listOptions);
+    return delegate.listObjectNames(bucketName, objectNamePrefix, listOptions);
+  }
+
+  @Override
+  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
+      throws IOException {
+    logger.atFine().log(
+        "%s.listObjectInfo(%s, %s)", delegateClassName, bucketName, objectNamePrefix);
+    return delegate.listObjectInfo(bucketName, objectNamePrefix);
   }
 
   @Override
   public List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter) throws IOException {
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
+      throws IOException {
     logger.atFine().log(
         "%s.listObjectInfo(%s, %s, %s)",
-        delegateClassName, bucketName, objectNamePrefix, delimiter);
-    return delegate.listObjectInfo(bucketName, objectNamePrefix, delimiter);
-  }
-
-  @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
-      throws IOException {
-    logger.atFine().log(
-        "%s.listObjectInfo(%s, %s, %s, %s)",
-        delegateClassName, bucketName, objectNamePrefix, delimiter, maxResults);
-    return delegate.listObjectInfo(bucketName, objectNamePrefix, delimiter, maxResults);
+        delegateClassName, bucketName, objectNamePrefix, listOptions);
+    return delegate.listObjectInfo(bucketName, objectNamePrefix, listOptions);
   }
 
   @Override
   public ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
-      String bucketName, String objectNamePrefix, String delimiter, String pageToken)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions, String pageToken)
       throws IOException {
     logger.atFine().log(
         "%s.listObjectInfoPage(%s, %s, %s, %s)",
-        delegateClassName, bucketName, objectNamePrefix, delimiter, pageToken);
-    return delegate.listObjectInfoPage(bucketName, objectNamePrefix, delimiter, pageToken);
+        delegateClassName, bucketName, objectNamePrefix, listOptions, pageToken);
+    return delegate.listObjectInfoPage(bucketName, objectNamePrefix, listOptions, pageToken);
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -30,24 +30,22 @@ import java.util.List;
  * https://developers.google.com/storage/docs/concepts-techniques
  */
 public interface GoogleCloudStorage {
-  // Pseudo path delimiter.
-  //
-  // GCS does not implement full concept of file system paths but it does expose
-  // some notion of a delimiter that can be used with Storage.Objects.List to
-  // control which items are listed.
-  public static final String PATH_DELIMITER = "/";
 
   /**
-   * Value indicating all objects should be returned from GCS, no limit.
+   * Pseudo path delimiter.
+   *
+   * <p>GCS does not implement full concept of file system paths but it does expose some notion of a
+   * delimiter that can be used with ${code Storage.Objects.List} to control which items are listed.
    */
-  public static final long MAX_RESULTS_UNLIMITED = -1;
+  String PATH_DELIMITER = "/";
+
+  /** Value indicating all objects should be returned from GCS, no limit. */
+  long MAX_RESULTS_UNLIMITED = -1;
 
   /** The maximum number of objects that can be composed in one operation. */
-  public static final int MAX_COMPOSE_OBJECTS = 32;
+  int MAX_COMPOSE_OBJECTS = 32;
 
-  /**
-   * Retrieve the options that were used to create this GoogleCloudStorage.
-   */
+  /** Retrieve the options that were used to create this GoogleCloudStorage. */
   GoogleCloudStorageOptions getOptions();
 
   /**
@@ -84,7 +82,7 @@ public interface GoogleCloudStorage {
    * @param bucketName name of the bucket to create
    * @throws IOException on IO error
    */
-  void create(String bucketName) throws IOException;
+  void createBucket(String bucketName) throws IOException;
 
   /**
    * Creates a bucket.
@@ -93,7 +91,7 @@ public interface GoogleCloudStorage {
    * @param options options to use when creating bucket
    * @throws IOException on IO error
    */
-  void create(String bucketName, CreateBucketOptions options) throws IOException;
+  void createBucket(String bucketName, CreateBucketOptions options) throws IOException;
 
   /**
    * Creates an empty object, useful for placeholders representing, for example, directories. The
@@ -214,104 +212,83 @@ public interface GoogleCloudStorage {
       throws IOException;
 
   /**
-   * Gets names of objects contained in the given bucket and whose names begin with
-   * the given prefix.
-   * <p>
-   * Note:
-   * Although GCS does not implement a file system, it treats objects that contain
-   * a delimiter as different from other objects when listing objects.
-   * This will be clearer with an example.
-   * <p>
-   * Consider a bucket with objects: o1, d1/, d1/o1, d1/o2
-   * With prefix == null and delimiter == /,    we get: d1/, o1
-   * With prefix == null and delimiter == null, we get: o1, d1/, d1/o1, d1/o2
-   * <p>
-   * Thus when delimiter is null, the entire key name is considered an opaque string,
-   * otherwise only the part up to the first delimiter is considered.
-   * <p>
-   * The default implementation of this method should turn around and call
-   * the version that takes {@code maxResults} so that inheriting classes
-   * need only implement that version.
+   * Gets names of objects contained in the given bucket and whose names begin with the given
+   * prefix.
    *
-   * @param bucketName bucket name
-   * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
-   * @param delimiter delimiter to use (typically "/"), otherwise null
-   * @return list of object names
-   * @throws IOException on IO error
-   */
-  List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter)
-      throws IOException;
-
-  /**
-   * Gets names of objects contained in the given bucket and whose names begin with
-   * the given prefix.
-   * <p>
-   * Note:
-   * Although GCS does not implement a file system, it treats objects that contain
-   * a delimiter as different from other objects when listing objects.
-   * This will be clearer with an example.
-   * <p>
-   * Consider a bucket with objects: o1, d1/, d1/o1, d1/o2
-   * With prefix == null and delimiter == /,    we get: d1/, o1
-   * With prefix == null and delimiter == null, we get: o1, d1/, d1/o1, d1/o2
-   * <p>
-   * Thus when delimiter is null, the entire key name is considered an opaque string,
+   * <p>Note: Although GCS does not implement a file system, it treats objects that contain a
+   * delimiter ({@link ListObjectOptions#getDelimiter()}) as different from other objects when
+   * listing objects. This will be clearer with an example.
+   *
+   * <p>Consider a bucket with objects: {@code o1}, {@code d1/}, {@code d1/o1}, {@code d1/o2}
+   *
+   * <ul>
+   *   <li/>With {@code prefix == null} and {@code delimiter == /}, we get: {@code d1/}, {@code o1}
+   *   <li/>With {@code prefix == null} and {@code delimiter == null}, we get: {@code o1}, {@code
+   *       d1/}, {@code d1/o1}, {@code d1/o2}
+   * </ul>
+   *
+   * <p>Thus when delimiter is {@code null}, the entire key name is considered an opaque string,
    * otherwise only the part up to the first delimiter is considered.
    *
    * @param bucketName bucket name
    * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
-   * @param delimiter delimiter to use (typically "/"), otherwise null
-   * @param maxResults maximum number of results to return,
-   *        unlimited if negative or zero
+   * @return list of object names
+   * @throws IOException on IO error
+   */
+  List<String> listObjectNames(String bucketName, String objectNamePrefix) throws IOException;
+
+  /**
+   * Gets names of objects contained in the given bucket and whose names begin with the given
+   * prefix.
+   *
+   * <p>Note: Although GCS does not implement a file system, it treats objects that contain a
+   * delimiter ({@link ListObjectOptions#getDelimiter()}) as different from other objects when
+   * listing objects. This will be clearer with an example.
+   *
+   * <p>Consider a bucket with objects: {@code o1}, {@code d1/}, {@code d1/o1}, {@code d1/o2}
+   *
+   * <ul>
+   *   <li/>With {@code prefix == null} and {@code delimiter == /}, we get: {@code d1/}, {@code o1}
+   *   <li/>With {@code prefix == null} and {@code delimiter == null}, we get: {@code o1}, {@code
+   *       d1/}, {@code d1/o1}, {@code d1/o2}
+   * </ul>
+   *
+   * <p>Thus when delimiter is {@code null}, the entire key name is considered an opaque string,
+   * otherwise only the part up to the first delimiter is considered.
+   *
+   * @param bucketName bucket name
+   * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
+   * @param listOptions options to use when listing objects
    * @return list of object names
    * @throws IOException on IO error
    */
   List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter,
-      long maxResults)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions) throws IOException;
+
+  /**
+   * Same name-matching semantics as {@link #listObjectNames} except this method retrieves the full
+   * {@link GoogleCloudStorageItemInfo} for each item as well.
+   *
+   * @param bucketName bucket name
+   * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
+   * @return list of object info
+   * @throws IOException on IO error
+   */
+  List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
       throws IOException;
 
   /**
    * Same name-matching semantics as {@link #listObjectNames} except this method retrieves the full
-   * GoogleCloudStorageFileInfo for each item as well.
-   *
-   * <p>Generally the info is already available from the same "list()" calls, so the only additional
-   * cost is dispatching an extra batch request to retrieve object metadata for all listed
-   * <b>directories</b>, since these are originally listed as String prefixes without attached
-   * metadata.
-   *
-   * <p>The default implementation of this method should turn around and call the version that takes
-   * {@code maxResults} so that inheriting classes need only implement that version.
+   * {@link GoogleCloudStorageItemInfo} for each item as well.
    *
    * @param bucketName bucket name
    * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
-   * @param delimiter delimiter to use (typically "/"), otherwise null
+   * @param listOptions options to use when listing objects
    * @return list of object info
    * @throws IOException on IO error
    */
   List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter) throws IOException;
-
-  /**
-   * Same name-matching semantics as {@link #listObjectNames} except this method retrieves the full
-   * GoogleCloudStorageFileInfo for each item as well.
-   *
-   * <p>Generally the info is already available from the same "list()" calls, so the only additional
-   * cost is dispatching an extra batch request to retrieve object metadata for all listed
-   * <b>directories</b>, since these are originally listed as String prefixes without attached
-   * metadata.
-   *
-   * @param bucketName bucket name
-   * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
-   * @param delimiter delimiter to use (typically "/"), otherwise null
-   * @param maxResults maximum number of results to return, unlimited if negative or zero
-   * @return list of object info
-   * @throws IOException on IO error
-   */
-  List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
-      throws IOException;
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions) throws IOException;
 
   /**
    * The same semantics as {@link #listObjectInfo}, but returns only result of single list request
@@ -319,14 +296,14 @@ public interface GoogleCloudStorage {
    *
    * @param bucketName bucket name
    * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
-   * @param delimiter delimiter to use (typically "/"), otherwise null
+   * @param listOptions options to use when listing objects
    * @param pageToken the page token
    * @return {@link ListPage} object with listed {@link GoogleCloudStorageItemInfo}s and next page
    *     token if any
    * @throws IOException on IO error
    */
   ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
-      String bucketName, String objectNamePrefix, String delimiter, String pageToken)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions, String pageToken)
       throws IOException;
 
   /**

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -447,7 +447,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
    */
   @Override
   public void createBucket(String bucketName, CreateBucketOptions options) throws IOException {
-    logger.atFine().log("create(%s)", bucketName);
+    logger.atFine().log("createBucket(%s)", bucketName);
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(bucketName), "bucketName must not be null or empty");
     checkNotNull(options, "options must not be null");

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -18,6 +18,7 @@ package com.google.cloud.hadoop.gcsio;
 
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createJsonResponseException;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo.createInferredDirectory;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
@@ -434,18 +435,18 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     return create(resourceId, CreateObjectOptions.DEFAULT_OVERWRITE);
   }
 
-  /** See {@link GoogleCloudStorage#create(String)} for details about expected behavior. */
+  /** See {@link GoogleCloudStorage#createBucket(String)} for details about expected behavior. */
   @Override
-  public void create(String bucketName) throws IOException {
-    create(bucketName, CreateBucketOptions.DEFAULT);
+  public void createBucket(String bucketName) throws IOException {
+    createBucket(bucketName, CreateBucketOptions.DEFAULT);
   }
 
   /**
-   * See {@link GoogleCloudStorage#create(String, CreateBucketOptions)} for details about expected
-   * behavior.
+   * See {@link GoogleCloudStorage#createBucket(String, CreateBucketOptions)} for details about
+   * expected behavior.
    */
   @Override
-  public void create(String bucketName, CreateBucketOptions options) throws IOException {
+  public void createBucket(String bucketName, CreateBucketOptions options) throws IOException {
     logger.atFine().log("create(%s)", bucketName);
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(bucketName), "bucketName must not be null or empty");
@@ -1210,26 +1211,23 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
    *
    * @param bucketName bucket name
    * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
-   * @param delimiter delimiter to use (typically "/"), otherwise null
+   * @param listOptions options to use when listing objects
    * @param includeTrailingDelimiter whether to include prefix objects into the {@code
    *     listedObjects}
-   * @param maxResults maximum number of results to return (total of both {@code listedObjects} and
-   *     {@code listedPrefixes}), unlimited if negative or zero
    * @param listedObjects output parameter into which retrieved StorageObjects will be added
    * @param listedPrefixes output parameter into which retrieved prefixes will be added
    */
   private void listStorageObjectsAndPrefixes(
       String bucketName,
       String objectNamePrefix,
-      String delimiter,
+      ListObjectOptions listOptions,
       boolean includeTrailingDelimiter,
-      long maxResults,
       List<StorageObject> listedObjects,
       List<String> listedPrefixes)
       throws IOException {
     logger.atFine().log(
-        "listStorageObjectsAndPrefixes(%s, %s, %s, %s, %d)",
-        bucketName, objectNamePrefix, delimiter, includeTrailingDelimiter, maxResults);
+        "listStorageObjectsAndPrefixes(%s, %s, %s, %s)",
+        bucketName, objectNamePrefix, listOptions, includeTrailingDelimiter);
 
     checkArgument(
         listedObjects != null && listedObjects.isEmpty(),
@@ -1240,7 +1238,11 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
 
     Storage.Objects.List listObject =
         createListRequest(
-            bucketName, objectNamePrefix, delimiter, includeTrailingDelimiter, maxResults);
+            bucketName,
+            objectNamePrefix,
+            listOptions.getDelimiter(),
+            includeTrailingDelimiter,
+            listOptions.getMaxResults());
 
     String pageToken = null;
     do {
@@ -1249,18 +1251,18 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
         listObject.setPageToken(pageToken);
       }
       pageToken =
-          listStorageObjectsAndPrefixesPage(listObject, maxResults, listedObjects, listedPrefixes);
+          listStorageObjectsAndPrefixesPage(listObject, listOptions, listedObjects, listedPrefixes);
     } while (pageToken != null
-        && getMaxRemainingResults(maxResults, listedPrefixes, listedObjects) > 0);
+        && getMaxRemainingResults(listOptions.getMaxResults(), listedPrefixes, listedObjects) > 0);
   }
 
   private String listStorageObjectsAndPrefixesPage(
       Storage.Objects.List listObject,
-      long maxResults,
+      ListObjectOptions listOptions,
       List<StorageObject> listedObjects,
       List<String> listedPrefixes)
       throws IOException {
-    logger.atFine().log("listStorageObjectsAndPrefixesPage(%s, %d)", listObject, maxResults);
+    logger.atFine().log("listStorageObjectsAndPrefixesPage(%s, %s)", listObject, listOptions);
 
     checkNotNull(listedObjects, "Must provide a non-null container for listedObjects.");
     checkNotNull(listedPrefixes, "Must provide a non-null container for listedPrefixes.");
@@ -1276,7 +1278,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       String resource = StringPaths.fromComponents(listObject.getBucket(), listObject.getPrefix());
       if (errorExtractor.itemNotFound(e)) {
         logger.atFine().withCause(e).log(
-            "listStorageObjectsAndPrefixesPage(%s, %d): item not found", resource, maxResults);
+            "listStorageObjectsAndPrefixesPage(%s, %s): item not found", resource, listOptions);
         return null;
       }
       throw new IOException("Error listing " + resource, e);
@@ -1285,17 +1287,22 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     // Add prefixes (if any).
     List<String> pagePrefixes = items.getPrefixes();
     if (pagePrefixes != null) {
-      logger.atFine().log("listed %s prefixes", pagePrefixes.size());
-      long maxRemainingResults = getMaxRemainingResults(maxResults, prefixes, listedObjects);
+      logger.atFine().log(
+          "listStorageObjectsAndPrefixesPage(%s, %s): listed %s prefixes",
+          listObject, listOptions, pagePrefixes.size());
+      long maxRemainingResults =
+          getMaxRemainingResults(listOptions.getMaxResults(), prefixes, listedObjects);
       // Do not cast 'maxRemainingResults' to int here, it could overflow
-      long maxPrefixes = Math.min(maxRemainingResults, (long) pagePrefixes.size());
+      long maxPrefixes = Math.min(maxRemainingResults, pagePrefixes.size());
       prefixes.addAll(pagePrefixes.subList(0, (int) maxPrefixes));
     }
 
     // Add object names (if any).
     List<StorageObject> objects = items.getItems();
     if (objects != null) {
-      logger.atFine().log("listed %s objects", objects.size());
+      logger.atFine().log(
+          "listStorageObjectsAndPrefixesPage(%s, %s): listed %d objects",
+          listObject, listOptions, objects.size());
 
       // Although GCS does not implement a file system, it treats objects that end
       // in delimiter as different from other objects when listing objects.
@@ -1313,11 +1320,11 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       boolean objectPrefixEndsWithDelimiter =
           !Strings.isNullOrEmpty(objectNamePrefix) && objectNamePrefix.endsWith(PATH_DELIMITER);
 
-      long maxRemainingResults = getMaxRemainingResults(maxResults, prefixes, listedObjects);
+      long maxRemainingResults =
+          getMaxRemainingResults(listOptions.getMaxResults(), prefixes, listedObjects);
       for (StorageObject object : objects) {
-        String objectName = object.getName();
-        if (!objectPrefixEndsWithDelimiter || !objectName.equals(objectNamePrefix)) {
-          if (prefixes.remove(objectName)) {
+        if (!objectPrefixEndsWithDelimiter || !object.getName().equals(objectNamePrefix)) {
+          if (prefixes.remove(object.getName())) {
             listedObjects.add(object);
           } else if (maxRemainingResults > 0) {
             listedObjects.add(object);
@@ -1380,28 +1387,19 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     return maxResults - numResults;
   }
 
-  /**
-   * See {@link GoogleCloudStorage#listObjectNames(String, String, String)}
-   * for details about expected behavior.
-   */
+  /** @see GoogleCloudStorage#listObjectNames(String, String) */
   @Override
-  public List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter)
+  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
       throws IOException {
-    return listObjectNames(
-        bucketName, objectNamePrefix, delimiter, GoogleCloudStorage.MAX_RESULTS_UNLIMITED);
+    return listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
-  /**
-   * See {@link GoogleCloudStorage#listObjectNames(String, String, String, long)} for details about
-   * expected behavior.
-   */
+  /** @see GoogleCloudStorage#listObjectNames(String, String, ListObjectOptions) */
   @Override
   public List<String> listObjectNames(
-      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
-    logger.atFine().log(
-        "listObjectNames(%s, %s, %s, %s)", bucketName, objectNamePrefix, delimiter, maxResults);
+    logger.atFine().log("listObjectNames(%s, %s, %s)", bucketName, objectNamePrefix, listOptions);
 
     // Helper will handle going through pages of list results and accumulating them.
     List<StorageObject> listedObjects = new ArrayList<>();
@@ -1409,9 +1407,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     listStorageObjectsAndPrefixes(
         bucketName,
         objectNamePrefix,
-        delimiter,
+        listOptions,
         /* includeTrailingDelimiter= */ false,
-        maxResults,
         listedObjects,
         listedPrefixes);
 
@@ -1425,26 +1422,19 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     return objectNames;
   }
 
-  /**
-   * See {@link GoogleCloudStorage#listObjectInfo(String, String, String)} for details about
-   * expected behavior.
-   */
+  /** @see GoogleCloudStorage#listObjectInfo(String, String) */
   @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter) throws IOException {
-    return listObjectInfo(bucketName, objectNamePrefix, delimiter, MAX_RESULTS_UNLIMITED);
+  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
+      throws IOException {
+    return listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
-  /**
-   * See {@link GoogleCloudStorage#listObjectInfo(String, String, String, long)} for details about
-   * expected behavior.
-   */
+  /** @see GoogleCloudStorage#listObjectInfo(String, String, ListObjectOptions) */
   @Override
   public List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
-    logger.atFine().log(
-        "listObjectInfo(%s, %s, %s, %s)", bucketName, objectNamePrefix, delimiter, maxResults);
+    logger.atFine().log("listObjectInfo(%s, %s, %s)", bucketName, objectNamePrefix, listOptions);
 
     // Helper will handle going through pages of list results and accumulating them.
     List<StorageObject> listedObjects = new ArrayList<>();
@@ -1452,9 +1442,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     listStorageObjectsAndPrefixes(
         bucketName,
         objectNamePrefix,
-        delimiter,
+        listOptions,
         /* includeTrailingDelimiter= */ true,
-        maxResults,
         listedObjects,
         listedPrefixes);
 
@@ -1475,20 +1464,26 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     return objectInfos;
   }
 
+  /** @see GoogleCloudStorage#listObjectInfoPage(String, String, ListObjectOptions, String) */
   @Override
   public ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
-      String bucketName, String objectNamePrefix, String delimiter, String pageToken)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions, String pageToken)
       throws IOException {
     logger.atFine().log(
-        "listObjectInfoPage(%s, %s, %s, %s)", bucketName, objectNamePrefix, delimiter, pageToken);
+        "listObjectInfoPage(%s, %s, %s, %s)", bucketName, objectNamePrefix, listOptions, pageToken);
+
+    checkArgument(
+        listOptions.getMaxResults() == MAX_RESULTS_UNLIMITED,
+        "maxResults should be unlimited for 'listObjectInfoPage' call, but was %s",
+        listOptions.getMaxResults());
 
     Storage.Objects.List listObject =
         createListRequest(
             bucketName,
             objectNamePrefix,
-            delimiter,
+            listOptions.getDelimiter(),
             /* includeTrailingDelimiter= */ true,
-            MAX_RESULTS_UNLIMITED);
+            listOptions.getMaxResults());
     if (pageToken != null) {
       logger.atFine().log("listObjectInfoPage: next page %s", pageToken);
       listObject.setPageToken(pageToken);
@@ -1498,9 +1493,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     List<StorageObject> listedObjects = new ArrayList<>();
     List<String> listedPrefixes = new ArrayList<>();
     String nextPageToken =
-        listStorageObjectsAndPrefixesPage(
-            listObject, MAX_RESULTS_UNLIMITED, listedObjects, listedPrefixes);
-
+        listStorageObjectsAndPrefixesPage(listObject, listOptions, listedObjects, listedPrefixes);
     // For the listedObjects, we simply parse each item into a GoogleCloudStorageItemInfo without
     // further work.
     List<GoogleCloudStorageItemInfo> objectInfos = new ArrayList<>(listedObjects.size());
@@ -1521,9 +1514,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       String bucketName, List<String> prefixes, List<GoogleCloudStorageItemInfo> objectInfos) {
     if (storageOptions.isInferImplicitDirectoriesEnabled()) {
       for (String prefix : prefixes) {
-        objectInfos.add(
-            GoogleCloudStorageItemInfo.createInferredDirectory(
-                new StorageResourceId(bucketName, prefix)));
+        objectInfos.add(createInferredDirectory(new StorageResourceId(bucketName, prefix)));
       }
     } else {
       logger.atInfo().log(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
@@ -32,7 +32,7 @@ public class GoogleCloudStorageItemInfo {
    * GoogleCloudStorageItemInfo for callers which may not know the concrete type of an object, but
    * want to check if the object happens to be an instance of this InfoProvider.
    */
-  public static interface Provider {
+  public interface Provider {
     GoogleCloudStorageItemInfo getItemInfo();
   }
 
@@ -123,7 +123,7 @@ public class GoogleCloudStorageItemInfo {
         storageClass,
         /* contentType= */ null,
         /* contentEncoding= */ null,
-        /* metadata= */ ImmutableMap.<String, byte[]>of(),
+        /* metadata= */ ImmutableMap.of(),
         /* contentGeneration= */ 0,
         /* metaGeneration= */ 0);
   }
@@ -314,10 +314,7 @@ public class GoogleCloudStorageItemInfo {
     return isRoot() && exists();
   }
 
-  /**
-   * Indicates whether {@code itemInfo} is a directory; static version of {@link #isDirectory()} to
-   * avoid having to create a FileInfo object just to use this logic.
-   */
+  /** Indicates whether {@code itemInfo} is a directory. */
   public boolean isDirectory() {
     return isGlobalRoot() || isBucket() || resourceId.isDirectory();
   }
@@ -384,11 +381,9 @@ public class GoogleCloudStorageItemInfo {
    */
   @Override
   public String toString() {
-    if (exists()) {
-      return String.format("%s: created on: %s", resourceId, new Date(creationTime));
-    } else {
-      return String.format("%s: exists: no", resourceId);
-    }
+    return exists()
+        ? String.format("%s: created on: %s", resourceId, new Date(creationTime))
+        : String.format("%s: exists: no", resourceId);
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ListObjectOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ListObjectOptions.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorage.MAX_RESULTS_UNLIMITED;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorage.PATH_DELIMITER;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+/** Options that can be specified when listing objects in the {@link GoogleCloudStorage}. */
+@AutoValue
+public abstract class ListObjectOptions {
+
+  /** List all objects in the directory. */
+  public static final ListObjectOptions DEFAULT = builder().build();
+
+  /** List all objects with the prefix. */
+  public static final ListObjectOptions DEFAULT_FLAT_LIST = builder().setDelimiter(null).build();
+
+  public static Builder builder() {
+    return new AutoValue_ListObjectOptions.Builder()
+        .setDelimiter(PATH_DELIMITER)
+        .setMaxResults(MAX_RESULTS_UNLIMITED);
+  }
+
+  public abstract Builder toBuilder();
+
+  /** Delimiter to use (typically {@code /}), otherwise {@code null}. */
+  @Nullable
+  public abstract String getDelimiter();
+
+  /** Maximum number of results to return, unlimited if negative or zero. */
+  public abstract long getMaxResults();
+
+  /** Builder for {@link ListObjectOptions} */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setDelimiter(String delimiter);
+
+    public abstract Builder setMaxResults(long maxResults);
+
+    public abstract ListObjectOptions build();
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.hadoop.gcsio;
 
-
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
@@ -107,22 +106,21 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
     return result;
   }
 
-  /** This function may return cached copies of GoogleCloudStorageItemInfo. */
+  /** This function may return cached copies of {@link GoogleCloudStorageItemInfo}. */
   @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter) throws IOException {
-    return this.listObjectInfo(
-        bucketName, objectNamePrefix, delimiter, GoogleCloudStorage.MAX_RESULTS_UNLIMITED);
+  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
+      throws IOException {
+    return this.listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
-  /** This function may return cached copies of GoogleCloudStorageItemInfo. */
+  /** This function may return cached copies of {@link GoogleCloudStorageItemInfo}. */
   @Override
   public List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix, String delimiter, long maxResults)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
     List<GoogleCloudStorageItemInfo> result;
 
-    result = super.listObjectInfo(bucketName, objectNamePrefix, delimiter, maxResults);
+    result = super.listObjectInfo(bucketName, objectNamePrefix, listOptions);
     for (GoogleCloudStorageItemInfo item : result) {
       cache.putItem(item);
     }
@@ -132,10 +130,10 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
 
   @Override
   public ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
-      String bucketName, String objectNamePrefix, String delimiter, String pageToken)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions, String pageToken)
       throws IOException {
     ListPage<GoogleCloudStorageItemInfo> result =
-        super.listObjectInfoPage(bucketName, objectNamePrefix, delimiter, pageToken);
+        super.listObjectInfoPage(bucketName, objectNamePrefix, listOptions, pageToken);
     for (GoogleCloudStorageItemInfo item : result.getItems()) {
       cache.putItem(item);
     }
@@ -157,7 +155,8 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
       String directoryName =
           lastSlashIndex >= 0 ? objectName.substring(0, lastSlashIndex + 1) : null;
       // make just 1 request to prefetch only 1 page of directory items
-      listObjectInfoPage(bucketName, directoryName, PATH_DELIMITER, /* pageToken= */ null);
+      listObjectInfoPage(
+          bucketName, directoryName, ListObjectOptions.DEFAULT, /* pageToken= */ null);
       item = cache.getItem(resourceId);
     }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ThrottledGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ThrottledGoogleCloudStorage.java
@@ -110,15 +110,15 @@ public class ThrottledGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public void create(String bucketName) throws IOException {
+  public void createBucket(String bucketName) throws IOException {
     throttle(StorageOperation.CREATE_BUCKET);
-    wrappedGcs.create(bucketName);
+    wrappedGcs.createBucket(bucketName);
   }
 
   @Override
-  public void create(String bucketName, CreateBucketOptions options) throws IOException {
+  public void createBucket(String bucketName, CreateBucketOptions options) throws IOException {
     throttle(StorageOperation.CREATE_BUCKET);
-    wrappedGcs.create(bucketName, options);
+    wrappedGcs.createBucket(bucketName, options);
   }
 
   @Override
@@ -199,45 +199,39 @@ public class ThrottledGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public List<String> listObjectNames(String bucketName,
-      String objectNamePrefix, String delimiter)
+  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
       throws IOException {
-    return listObjectNames(bucketName, objectNamePrefix, delimiter,
-        GoogleCloudStorage.MAX_RESULTS_UNLIMITED);
+    return listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
   @Override
-  public List<String> listObjectNames(String bucketName,
-      String objectNamePrefix, String delimiter, long maxResults)
+  public List<String> listObjectNames(
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
     throttle(StorageOperation.LIST_OBJECTS);
-    return wrappedGcs.listObjectNames(
-        bucketName, objectNamePrefix, delimiter, maxResults);
+    return wrappedGcs.listObjectNames(bucketName, objectNamePrefix, listOptions);
   }
 
   @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName,
-      String objectNamePrefix, String delimiter)
+  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
       throws IOException {
-    return listObjectInfo(bucketName, objectNamePrefix, delimiter,
-        GoogleCloudStorage.MAX_RESULTS_UNLIMITED);
+    return listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
   @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName,
-      String objectNamePrefix, String delimiter, long maxResults)
+  public List<GoogleCloudStorageItemInfo> listObjectInfo(
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
     throttle(StorageOperation.LIST_OBJECTS);
-    return wrappedGcs.listObjectInfo(
-        bucketName, objectNamePrefix, delimiter, maxResults);
+    return wrappedGcs.listObjectInfo(bucketName, objectNamePrefix, listOptions);
   }
 
   @Override
   public ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
-      String bucketName, String objectNamePrefix, String delimiter, String pageToken)
+      String bucketName, String objectNamePrefix, ListObjectOptions listOptions, String pageToken)
       throws IOException {
     throttle(StorageOperation.LIST_OBJECTS);
-    return wrappedGcs.listObjectInfoPage(bucketName, objectNamePrefix, delimiter, pageToken);
+    return wrappedGcs.listObjectInfoPage(bucketName, objectNamePrefix, listOptions, pageToken);
   }
 
   @Override

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
@@ -152,16 +152,16 @@ public class ForwardingGoogleCloudStorageTest {
 
   @Test
   public void testCreateWithBucket() throws IOException {
-    gcs.create(TEST_STRING);
+    gcs.createBucket(TEST_STRING);
 
-    verify(mockGcsDelegate).create(eq(TEST_STRING));
+    verify(mockGcsDelegate).createBucket(eq(TEST_STRING));
   }
 
   @Test
   public void testCreateWithBucketAndOptions() throws IOException {
-    gcs.create(TEST_STRING, TEST_BUCKET_OPTIONS);
+    gcs.createBucket(TEST_STRING, TEST_BUCKET_OPTIONS);
 
-    verify(mockGcsDelegate).create(eq(TEST_STRING), eq(TEST_BUCKET_OPTIONS));
+    verify(mockGcsDelegate).createBucket(eq(TEST_STRING), eq(TEST_BUCKET_OPTIONS));
   }
 
   @Test
@@ -202,32 +202,32 @@ public class ForwardingGoogleCloudStorageTest {
 
   @Test
   public void testListObjectNames() throws IOException {
-    gcs.listObjectNames(TEST_STRING, TEST_STRING, TEST_STRING);
+    gcs.listObjectNames(TEST_STRING, TEST_STRING);
 
-    verify(mockGcsDelegate).listObjectNames(eq(TEST_STRING), eq(TEST_STRING), eq(TEST_STRING));
+    verify(mockGcsDelegate).listObjectNames(eq(TEST_STRING), eq(TEST_STRING));
   }
 
   @Test
   public void testListObjectNamesWithMax() throws IOException {
-    gcs.listObjectNames(TEST_STRING, TEST_STRING, TEST_STRING, 1L);
+    gcs.listObjectNames(TEST_STRING, TEST_STRING, ListObjectOptions.DEFAULT);
 
     verify(mockGcsDelegate)
-        .listObjectNames(eq(TEST_STRING), eq(TEST_STRING), eq(TEST_STRING), eq(1L));
+        .listObjectNames(eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT));
   }
 
   @Test
   public void testListObjectInfo() throws IOException {
-    gcs.listObjectInfo(TEST_STRING, TEST_STRING, TEST_STRING);
+    gcs.listObjectInfo(TEST_STRING, TEST_STRING);
 
-    verify(mockGcsDelegate).listObjectInfo(eq(TEST_STRING), eq(TEST_STRING), eq(TEST_STRING));
+    verify(mockGcsDelegate).listObjectInfo(eq(TEST_STRING), eq(TEST_STRING));
   }
 
   @Test
   public void testListObjectInfoWithMax() throws IOException {
-    gcs.listObjectInfo(TEST_STRING, TEST_STRING, TEST_STRING, 1L);
+    gcs.listObjectInfo(TEST_STRING, TEST_STRING, ListObjectOptions.DEFAULT);
 
     verify(mockGcsDelegate)
-        .listObjectInfo(eq(TEST_STRING), eq(TEST_STRING), eq(TEST_STRING), eq(1L));
+        .listObjectInfo(eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT));
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptionsTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptionsTestBase.java
@@ -158,7 +158,7 @@ public abstract class GoogleCloudStorageFileSystemOptionsTestBase {
   private void createBucket(
       GoogleCloudStorage gcs, String bucketName)
       throws IOException {
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
   }
 
   private void createEmptyFile(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorage.PATH_DELIMITER;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.batchRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.composeRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.copyRequestString;
@@ -115,7 +114,8 @@ public class GoogleCloudStorageNewIntegrationTest {
     String testDir = createObjectsInTestDir(testBucket, "f1", "f2", "f3");
 
     List<String> listedObjects =
-        gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER, /* maxResults= */ 1);
+        gcs.listObjectNames(
+            testBucket, testDir, ListObjectOptions.DEFAULT.toBuilder().setMaxResults(1).build());
 
     assertThat(listedObjects).containsExactly(testDir + "f1");
     // Assert that only 1 GCS request was sent
@@ -136,7 +136,9 @@ public class GoogleCloudStorageNewIntegrationTest {
     String testBucket = gcsfsIHelper.sharedBucketName1;
     String testDir = createObjectsInTestDir(testBucket, "f1", "f2", "subdir1/f3", "subdir2/f4");
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER, 3);
+    List<String> listedObjects =
+        gcs.listObjectNames(
+            testBucket, testDir, ListObjectOptions.DEFAULT.toBuilder().setMaxResults(3).build());
 
     assertThat(listedObjects).containsExactly(testDir + "f1", testDir + "f2", testDir + "subdir1/");
     // Assert that 4 GCS requests were sent
@@ -160,7 +162,7 @@ public class GoogleCloudStorageNewIntegrationTest {
     String testBucket = gcsfsIHelper.sharedBucketName1;
     String testDir = createObjectsInTestDir(testBucket, "f1", "f2", "subdir/f3", "subdir/f4");
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER);
+    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir);
 
     assertThat(listedObjects).containsExactly(testDir + "f1", testDir + "f2", testDir + "subdir/");
     // Assert that 5 GCS requests were sent
@@ -183,7 +185,8 @@ public class GoogleCloudStorageNewIntegrationTest {
     String testDir = createObjectsInTestDir(testBucket, "f1", "f2", "f3");
 
     List<GoogleCloudStorageItemInfo> listedObjects =
-        gcs.listObjectInfo(testBucket, testDir, PATH_DELIMITER, /* maxResults= */ 1);
+        gcs.listObjectInfo(
+            testBucket, testDir, ListObjectOptions.DEFAULT.toBuilder().setMaxResults(1).build());
 
     assertThat(toObjectNames(listedObjects)).containsExactly(testDir + "f1");
     // Assert that only 1 GCS request was sent
@@ -206,7 +209,8 @@ public class GoogleCloudStorageNewIntegrationTest {
     String testDir = createObjectsInTestDir(testBucket, "f1", "f2", "f3", "f4");
 
     List<GoogleCloudStorageItemInfo> listedObjects =
-        gcs.listObjectInfo(testBucket, testDir, PATH_DELIMITER, /* maxResults= */ 2);
+        gcs.listObjectInfo(
+            testBucket, testDir, ListObjectOptions.DEFAULT.toBuilder().setMaxResults(2).build());
 
     assertThat(toObjectNames(listedObjects)).containsExactly(testDir + "f1", testDir + "f2");
     // Assert that 3 GCS requests were sent
@@ -230,8 +234,7 @@ public class GoogleCloudStorageNewIntegrationTest {
     String testBucket = gcsfsIHelper.sharedBucketName1;
     String testDir = createObjectsInTestDir(testBucket, "f1", "f2", "f3");
 
-    List<GoogleCloudStorageItemInfo> listedObjects =
-        gcs.listObjectInfo(testBucket, testDir, PATH_DELIMITER);
+    List<GoogleCloudStorageItemInfo> listedObjects = gcs.listObjectInfo(testBucket, testDir);
 
     assertThat(toObjectNames(listedObjects))
         .containsExactly(testDir + "f1", testDir + "f2", testDir + "f3");
@@ -436,7 +439,7 @@ public class GoogleCloudStorageNewIntegrationTest {
             copyRequestString(testBucket1, testDir + "f1", testBucket2, testDir + "f4", "copyTo"),
             copyRequestString(testBucket1, testDir + "f2", testBucket2, testDir + "f5", "copyTo"));
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket2, testDir, PATH_DELIMITER);
+    List<String> listedObjects = gcs.listObjectNames(testBucket2, testDir);
     assertThat(listedObjects).containsExactly(testDir + "f4", testDir + "f5");
   }
 
@@ -468,7 +471,7 @@ public class GoogleCloudStorageNewIntegrationTest {
             copyRequestString(
                 testBucket1, testDir + "f2", testBucket2, testDir + "f5", "rewriteTo"));
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket2, testDir, PATH_DELIMITER);
+    List<String> listedObjects = gcs.listObjectNames(testBucket2, testDir);
     assertThat(listedObjects).containsExactly(testDir + "f4", testDir + "f5");
   }
 
@@ -495,7 +498,7 @@ public class GoogleCloudStorageNewIntegrationTest {
             deleteRequestString(testBucket, testDir + "f1", /* generationId= */ 1),
             deleteRequestString(testBucket, testDir + "f2", /* generationId= */ 2));
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER);
+    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir);
     assertThat(listedObjects).containsExactly(testDir + "f3");
   }
 
@@ -522,7 +525,7 @@ public class GoogleCloudStorageNewIntegrationTest {
             getRequestString(testBucket, testDir + "f2"),
             deleteRequestString(testBucket, testDir + "f2", /* generationId= */ 2));
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER);
+    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir);
     assertThat(listedObjects).containsExactly(testDir + "f3");
   }
 
@@ -542,7 +545,7 @@ public class GoogleCloudStorageNewIntegrationTest {
             getRequestString(testBucket, testDir + "f3"),
             composeRequestString(testBucket, testDir + "f3", /* generationId= */ 1));
 
-    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER);
+    List<String> listedObjects = gcs.listObjectNames(testBucket, testDir);
     assertThat(listedObjects).containsExactly(testDir + "f1", testDir + "f2", testDir + "f3");
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/CsekEncryptionIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/CsekEncryptionIntegrationTest.java
@@ -52,7 +52,7 @@ public class CsekEncryptionIntegrationTest {
     String bucketName = BUCKET_HELPER.getUniqueBucketName("upload-and-get");
     StorageResourceId resourceId = new StorageResourceId(bucketName, "obj");
 
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
     gcs.createEmptyObject(
         resourceId, CreateObjectOptions.builder().setContentType("text/plain").build());
 
@@ -69,12 +69,13 @@ public class CsekEncryptionIntegrationTest {
                 .build());
 
     String srcBucketName = BUCKET_HELPER.getUniqueBucketName("rewrite-src");
-    gcs.create(srcBucketName);
+    gcs.createBucket(srcBucketName);
 
     String dstBucketName = BUCKET_HELPER.getUniqueBucketName("rewrite-dst");
     // Create destination bucket with different location and storage class,
     // because this is supported by rewrite but not copy requests
-    gcs.create(dstBucketName, CreateBucketOptions.builder().setStorageClass("coldline").build());
+    gcs.createBucket(
+        dstBucketName, CreateBucketOptions.builder().setStorageClass("coldline").build());
 
     StorageResourceId srcResourceId = new StorageResourceId(srcBucketName, "encryptedObject");
     int partitionsCount = 32;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -85,7 +85,7 @@ public class GoogleCloudStorageImplTest {
     GoogleCloudStorageImpl gcs = makeStorageWithBufferSize(1024 * 1024);
 
     String bucketName = BUCKET_HELPER.getUniqueBucketName("write-large-obj");
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
 
     StorageResourceId resourceId = new StorageResourceId(bucketName, "LargeObject");
     int partitionsCount = 64;
@@ -100,7 +100,7 @@ public class GoogleCloudStorageImplTest {
     GoogleCloudStorageImpl gcs = makeStorageWithBufferSize(3 * 1024 * 1024);
 
     String bucketName = BUCKET_HELPER.getUniqueBucketName("write-3m-buff-obj");
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
 
     StorageResourceId resourceId = new StorageResourceId(bucketName, "Object");
     int partitionsCount = 64;
@@ -118,7 +118,7 @@ public class GoogleCloudStorageImplTest {
     GoogleCloudStorageImpl gcs =
         makeStorage(GoogleCloudStorageTestHelper.getStandardOptionBuilder().build());
 
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
     byte[] bytesToWrite = new byte[1024];
     GoogleCloudStorageTestHelper.fillBytes(bytesToWrite);
     WritableByteChannel byteChannel1 =
@@ -143,13 +143,13 @@ public class GoogleCloudStorageImplTest {
 
     GoogleCloudStorageImpl gcs = makeStorageWithInferImplicit();
 
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
     gcs.createEmptyObject(resourceId);
 
     GoogleCloudStorageItemInfo itemInfo = gcs.getItemInfo(new StorageResourceId(bucketName, "d0/"));
     assertThat(itemInfo.exists()).isFalse();
 
-    List<GoogleCloudStorageItemInfo> d0ItemInfo = gcs.listObjectInfo(bucketName, "d0/", "/");
+    List<GoogleCloudStorageItemInfo> d0ItemInfo = gcs.listObjectInfo(bucketName, "d0/");
     assertWithMessage("d0 length").that(d0ItemInfo.size()).isEqualTo(1);
   }
 
@@ -164,7 +164,7 @@ public class GoogleCloudStorageImplTest {
     StorageResourceId resourceId2 = new StorageResourceId(bucketName, "obj2");
     StorageResourceId resourceId3 = new StorageResourceId(bucketName, "obj3");
 
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
     gcs.createEmptyObject(
         resourceId1, CreateObjectOptions.builder().setContentType("text/plain").build());
     gcs.create(resourceId2, CreateObjectOptions.builder().setContentType("image/png").build())
@@ -186,12 +186,13 @@ public class GoogleCloudStorageImplTest {
                 .build());
 
     String srcBucketName = BUCKET_HELPER.getUniqueBucketName("copy-with-rewrite-src");
-    gcs.create(srcBucketName);
+    gcs.createBucket(srcBucketName);
 
     String dstBucketName = BUCKET_HELPER.getUniqueBucketName("copy-with-rewrite-dst");
     // Create destination bucket with different location and storage class,
     // because this is supported by rewrite but not copy requests
-    gcs.create(dstBucketName, CreateBucketOptions.builder().setStorageClass("coldline").build());
+    gcs.createBucket(
+        dstBucketName, CreateBucketOptions.builder().setStorageClass("coldline").build());
 
     StorageResourceId resourceId =
         new StorageResourceId(srcBucketName, "testCopySingleItemWithRewrite_SourceObject");
@@ -214,7 +215,7 @@ public class GoogleCloudStorageImplTest {
         makeStorage(GoogleCloudStorageTestHelper.getStandardOptionBuilder().build());
 
     String bucketName = BUCKET_HELPER.getUniqueBucketName("metadata-equals");
-    gcs.create(bucketName);
+    gcs.createBucket(bucketName);
 
     StorageResourceId object = new StorageResourceId(bucketName, "testMetadataEquals_Object");
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -25,6 +25,7 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
+import com.google.cloud.hadoop.gcsio.ListObjectOptions;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import com.google.cloud.hadoop.util.CredentialFactory;
@@ -244,12 +245,16 @@ public class GoogleCloudStorageTestHelper {
       }
 
       List<GoogleCloudStorageItemInfo> objectsToDelete =
-          bucketsToDelete
-              .parallelStream()
+          bucketsToDelete.parallelStream()
               .flatMap(
                   bucket -> {
                     try {
-                      return storage.listObjectInfo(bucket, null, null).stream();
+                      return storage
+                          .listObjectInfo(
+                              bucket,
+                              /* objectNamePrefix= */ null,
+                              ListObjectOptions.DEFAULT_FLAT_LIST)
+                          .stream();
                     } catch (IOException e) {
                       throw new RuntimeException(e);
                     }


### PR DESCRIPTION
This PR also renames `create` method used to create buckets in `GoogleCloudStorage` class to `createBucket` - this reduces confusion with `create` methods overloaded for object creation.