### PR TITLE
Added exponential backoff retry for gRPC write

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -138,10 +138,6 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.github.rholder</groupId>
-      <artifactId>guava-retrying</artifactId>
-    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -138,6 +138,10 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -273,6 +277,7 @@
               <artifactSet>
                 <includes>
                   <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>com.github.rholder</include>
                   <include>com.google.api-client</include>
                   <include>com.google.api.grpc</include>
                   <include>com.google.apis</include>
@@ -300,6 +305,7 @@
                   <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.com</shadedPattern>
                   <includes>
                     <include>com.fasterxml.**</include>
+                    <include>com.github.rholder.retry.**</include>
                     <include>com.google.api.**</include>
                     <include>com.google.auth.**</include>
                     <include>com.google.cloud.audit.**</include>

--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -150,6 +150,10 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -265,6 +265,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
       }
 
       return responseObserver.getResponseOrThrow();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -177,7 +177,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
     private Hasher objectHasher;
     private String uploadId;
     private long writeOffset = 0;
-    InsertChunkResponseObserver responseObserver;
+    private InsertChunkResponseObserver responseObserver;
     // Holds list of most recent number of NUMBER_OF_REQUESTS_TO_RETAIN requests, so upload can be
     // rewound and re-sent upon transient errors.
     private final TreeMap<Long, ByteString> dataChunkMap = new TreeMap<>();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
@@ -357,7 +357,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setInsertObjectExceptions(
         ImmutableList.of(new StatusException(Status.DEADLINE_EXCEEDED)));
     fakeService.setQueryWriteStatusResponses(
-        ImmutableList.of(QueryWriteStatusResponse.newBuilder().setCommittedSize(0).build())
+        ImmutableList.of(QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build())
             .iterator());
     ByteString chunk = createTestData(chunkSize);
     List<InsertObjectRequest> expectedRequests =
@@ -380,7 +380,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     writeChannel.write(chunk.asReadOnlyByteBuffer());
     writeChannel.close();
 
-    verify(fakeService, times(2)).startResumableWrite(eq(START_REQUEST), any());
+    verify(fakeService, times(1)).startResumableWrite(eq(START_REQUEST), any());
     verify(fakeService, times(1)).queryWriteStatus(eq(WRITE_STATUS_REQUEST), any());
     verify(fakeService.insertRequestObserver, atLeast(1)).onNext(requestCaptor.capture());
     // TODO(hgong): Figure out a way to check the expected requests and actual reqeusts builder.
@@ -406,6 +406,37 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     writeChannel.initialize();
     writeChannel.write(chunk.asReadOnlyByteBuffer());
     assertThrows(IOException.class, writeChannel::close);
+  }
+
+  @Test
+  public void retryInsertOnIOException() throws Exception {
+    int chunkSize = GoogleCloudStorageGrpcWriteChannel.GCS_MINIMUM_CHUNK_SIZE;
+    AsyncWriteChannelOptions options =
+        AsyncWriteChannelOptions.builder().setUploadChunkSize(chunkSize).build();
+    ObjectWriteConditions writeConditions = ObjectWriteConditions.NONE;
+    GoogleCloudStorageGrpcWriteChannel writeChannel =
+        newWriteChannel(options, writeConditions, /* requesterPaysProject= */ null);
+    fakeService.setInsertObjectExceptions(
+        ImmutableList.of(
+            new StatusException(Status.DEADLINE_EXCEEDED),
+            new StatusException(Status.DEADLINE_EXCEEDED),
+            new StatusException(Status.DEADLINE_EXCEEDED),
+            new StatusException(Status.DEADLINE_EXCEEDED),
+            new StatusException(Status.DEADLINE_EXCEEDED)));
+    fakeService.setQueryWriteStatusResponses(
+        ImmutableList.of(
+                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build(),
+                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build(),
+                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build(),
+                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build())
+            .iterator());
+    ByteString chunk = createTestData(chunkSize);
+
+    writeChannel.initialize();
+    writeChannel.write(chunk.asReadOnlyByteBuffer());
+    assertThat(assertThrows(IOException.class, writeChannel::close).getCause().getCause())
+        .hasMessageThat()
+        .contains("after 5 attempts");
   }
 
   @Test
@@ -593,7 +624,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     public void queryWriteStatus(
         QueryWriteStatusRequest request,
         StreamObserver<QueryWriteStatusResponse> responseObserver) {
-      if (queryWriteStatusException != null) {
+      if (queryWriteStatusException != null && queryWriteStatusResponses.hasNext()) {
         responseObserver.onError(queryWriteStatusException);
       } else {
         QueryWriteStatusResponse response = queryWriteStatusResponses.next();

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
     <junit.version>4.13</junit.version>
     <mockito.version>3.4.0</mockito.version>
     <system-lambda.version>1.1.0</system-lambda.version>
+    <guava.retrying.version>2.0.0</guava.retrying.version>
   </properties>
 
   <modules>
@@ -466,6 +467,11 @@
         <artifactId>flogger-slf4j-backend</artifactId>
         <version>${google.flogger.version}</version>
         <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.github.rholder</groupId>
+        <artifactId>guava-retrying</artifactId>
+        <version>${guava.retrying.version}</version>
       </dependency>
 
       <!-- Test dependencies -->


### PR DESCRIPTION
This change does:
1. Updated current plain retry to exponential backoff retry.
2. Added exception propogation back and retry as well for two non-gRPC streaming APIs (Resolving [b/169692122](https://b.corp.google.com/issues/169692122)).