### PR TITLE
Cleanup GoogleCloudStorage interface implementation

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -50,22 +50,10 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public WritableByteChannel create(StorageResourceId resourceId) throws IOException {
-    logger.atFine().log("%s.create(%s)", delegateClassName, resourceId);
-    return delegate.create(resourceId);
-  }
-
-  @Override
   public WritableByteChannel create(StorageResourceId resourceId, CreateObjectOptions options)
       throws IOException {
     logger.atFine().log("%s.create(%s, %s)", delegateClassName, resourceId, options);
     return delegate.create(resourceId, options);
-  }
-
-  @Override
-  public void createBucket(String bucketName) throws IOException {
-    logger.atFine().log("%s.createBucket(%s)", delegateClassName, bucketName);
-    delegate.createBucket(bucketName);
   }
 
   @Override
@@ -98,12 +86,6 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
       throws IOException {
     logger.atFine().log("%s.createEmptyObjects(%s, %s)", delegateClassName, resourceIds, options);
     delegate.createEmptyObjects(resourceIds, options);
-  }
-
-  @Override
-  public SeekableByteChannel open(StorageResourceId resourceId) throws IOException {
-    logger.atFine().log("%s.open(%s)", delegateClassName, resourceId);
-    return delegate.open(resourceId);
   }
 
   @Override
@@ -151,14 +133,6 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
-      throws IOException {
-    logger.atFine().log(
-        "%s.listObjectNames(%s, %s)", delegateClassName, bucketName, objectNamePrefix);
-    return delegate.listObjectNames(bucketName, objectNamePrefix);
-  }
-
-  @Override
   public List<String> listObjectNames(
       String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
@@ -166,14 +140,6 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
         "%s.listObjectNames(%s, %s, %s)",
         delegateClassName, bucketName, objectNamePrefix, listOptions);
     return delegate.listObjectNames(bucketName, objectNamePrefix, listOptions);
-  }
-
-  @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
-      throws IOException {
-    logger.atFine().log(
-        "%s.listObjectInfo(%s, %s)", delegateClassName, bucketName, objectNamePrefix);
-    return delegate.listObjectInfo(bucketName, objectNamePrefix);
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -59,7 +59,9 @@ public interface GoogleCloudStorage {
    * @return a channel for writing to the given object
    * @throws IOException on IO error
    */
-  WritableByteChannel create(StorageResourceId resourceId) throws IOException;
+  default WritableByteChannel create(StorageResourceId resourceId) throws IOException {
+    return create(resourceId, CreateObjectOptions.DEFAULT_OVERWRITE);
+  }
 
   /**
    * Creates and opens an object for writing. The bucket must already exist. If {@code resourceId}
@@ -82,7 +84,9 @@ public interface GoogleCloudStorage {
    * @param bucketName name of the bucket to create
    * @throws IOException on IO error
    */
-  void createBucket(String bucketName) throws IOException;
+  default void createBucket(String bucketName) throws IOException {
+    createBucket(bucketName, CreateBucketOptions.DEFAULT);
+  }
 
   /**
    * Creates a bucket.
@@ -145,7 +149,9 @@ public interface GoogleCloudStorage {
    * @throws java.io.FileNotFoundException if the given object does not exist
    * @throws IOException if object exists but cannot be opened
    */
-  SeekableByteChannel open(StorageResourceId resourceId) throws IOException;
+  default SeekableByteChannel open(StorageResourceId resourceId) throws IOException {
+    return open(resourceId, GoogleCloudStorageReadOptions.DEFAULT);
+  }
 
   /**
    * Opens an object for reading.
@@ -235,7 +241,10 @@ public interface GoogleCloudStorage {
    * @return list of object names
    * @throws IOException on IO error
    */
-  List<String> listObjectNames(String bucketName, String objectNamePrefix) throws IOException;
+  default List<String> listObjectNames(String bucketName, String objectNamePrefix)
+      throws IOException {
+    return listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
+  }
 
   /**
    * Gets names of objects contained in the given bucket and whose names begin with the given
@@ -274,8 +283,10 @@ public interface GoogleCloudStorage {
    * @return list of object info
    * @throws IOException on IO error
    */
-  List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
-      throws IOException;
+  default List<GoogleCloudStorageItemInfo> listObjectInfo(
+      String bucketName, String objectNamePrefix) throws IOException {
+    return listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
+  }
 
   /**
    * Same name-matching semantics as {@link #listObjectNames} except this method retrieves the full
@@ -290,6 +301,21 @@ public interface GoogleCloudStorage {
   List<GoogleCloudStorageItemInfo> listObjectInfo(
       String bucketName, String objectNamePrefix, ListObjectOptions listOptions) throws IOException;
 
+  /**
+   * The same semantics as {@link #listObjectInfo}, but returns only result of single list request
+   * (1 page).
+   *
+   * @param bucketName bucket name
+   * @param objectNamePrefix object name prefix or null if all objects in the bucket are desired
+   * @param pageToken the page token
+   * @return {@link ListPage} object with listed {@link GoogleCloudStorageItemInfo}s and next page
+   *     token if any
+   * @throws IOException on IO error
+   */
+  default ListPage<GoogleCloudStorageItemInfo> listObjectInfoPage(
+      String bucketName, String objectNamePrefix, String pageToken) throws IOException {
+    return listObjectInfoPage(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT, pageToken);
+  }
   /**
    * The same semantics as {@link #listObjectInfo}, but returns only result of single list request
    * (1 page).

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -426,24 +426,6 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   }
 
   /**
-   * See {@link GoogleCloudStorage#create(StorageResourceId)} for details about expected behavior.
-   */
-  @Override
-  public WritableByteChannel create(StorageResourceId resourceId) throws IOException {
-    logger.atFine().log("create(%s)", resourceId);
-    Preconditions.checkArgument(
-        resourceId.isStorageObject(), "Expected full StorageObject id, got %s", resourceId);
-
-    return create(resourceId, CreateObjectOptions.DEFAULT_OVERWRITE);
-  }
-
-  /** See {@link GoogleCloudStorage#createBucket(String)} for details about expected behavior. */
-  @Override
-  public void createBucket(String bucketName) throws IOException {
-    createBucket(bucketName, CreateBucketOptions.DEFAULT);
-  }
-
-  /**
    * See {@link GoogleCloudStorage#createBucket(String, CreateBucketOptions)} for details about
    * expected behavior.
    */
@@ -615,15 +597,6 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   @Override
   public void createEmptyObjects(List<StorageResourceId> resourceIds) throws IOException {
     createEmptyObjects(resourceIds, EMPTY_OBJECT_CREATE_OPTIONS);
-  }
-
-  /**
-   * See {@link GoogleCloudStorage#open(StorageResourceId)} for details about expected behavior.
-   */
-  @Override
-  public SeekableByteChannel open(StorageResourceId resourceId)
-      throws IOException {
-    return open(resourceId, GoogleCloudStorageReadOptions.DEFAULT);
   }
 
   /** See {@link GoogleCloudStorage#open(StorageResourceId)} for details about expected behavior. */
@@ -1392,13 +1365,6 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     return maxResults - numResults;
   }
 
-  /** @see GoogleCloudStorage#listObjectNames(String, String) */
-  @Override
-  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
-      throws IOException {
-    return listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
-  }
-
   /** @see GoogleCloudStorage#listObjectNames(String, String, ListObjectOptions) */
   @Override
   public List<String> listObjectNames(
@@ -1442,13 +1408,6 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     objectNames.sort(String::compareTo);
 
     return objectNames;
-  }
-
-  /** @see GoogleCloudStorage#listObjectInfo(String, String) */
-  @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
-      throws IOException {
-    return listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
   /** @see GoogleCloudStorage#listObjectInfo(String, String, ListObjectOptions) */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -66,14 +66,15 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
   }
 
   @Override
-  public WritableByteChannel create(StorageResourceId resourceId) throws IOException {
+  public WritableByteChannel create(StorageResourceId resourceId, CreateObjectOptions options)
+      throws IOException {
     // If the item exists in cache upon creation, remove it from cache so that later getItemInfo
     // will pull the most updated item info.
     if (cache.getItem(resourceId) != null) {
       cache.removeItem(resourceId);
     }
 
-    return super.create(resourceId);
+    return super.create(resourceId, options);
   }
 
   @Override
@@ -110,26 +111,12 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
 
   /** This function may return names from cached copies of {@link GoogleCloudStorageItemInfo}. */
   @Override
-  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
-      throws IOException {
-    return this.listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
-  }
-
-  /** This function may return names from cached copies of {@link GoogleCloudStorageItemInfo}. */
-  @Override
   public List<String> listObjectNames(
       String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
     return this.listObjectInfo(bucketName, objectNamePrefix, listOptions).stream()
         .map(GoogleCloudStorageItemInfo::getObjectName)
         .collect(toImmutableList());
-  }
-
-  /** This function may return cached copies of {@link GoogleCloudStorageItemInfo}. */
-  @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
-      throws IOException {
-    return this.listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
   /** This function may return cached copies of {@link GoogleCloudStorageItemInfo}. */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ThrottledGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ThrottledGoogleCloudStorage.java
@@ -97,22 +97,10 @@ public class ThrottledGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public WritableByteChannel create(StorageResourceId resourceId) throws IOException {
-    throttle(StorageOperation.CREATE_OBJECT);
-    return wrappedGcs.create(resourceId);
-  }
-
-  @Override
   public WritableByteChannel create(StorageResourceId resourceId, CreateObjectOptions options)
       throws IOException {
     throttle(StorageOperation.CREATE_OBJECT);
     return wrappedGcs.create(resourceId, options);
-  }
-
-  @Override
-  public void createBucket(String bucketName) throws IOException {
-    throttle(StorageOperation.CREATE_BUCKET);
-    wrappedGcs.createBucket(bucketName);
   }
 
   @Override
@@ -150,15 +138,7 @@ public class ThrottledGoogleCloudStorage implements GoogleCloudStorage {
 
   @Override
   public SeekableByteChannel open(
-      StorageResourceId resourceId) throws IOException {
-    throttle(StorageOperation.OPEN_OBJECT);
-    return wrappedGcs.open(resourceId);
-  }
-
-  @Override
-  public SeekableByteChannel open(
-      StorageResourceId resourceId, GoogleCloudStorageReadOptions readOptions)
-      throws IOException {
+      StorageResourceId resourceId, GoogleCloudStorageReadOptions readOptions) throws IOException {
     throttle(StorageOperation.OPEN_OBJECT);
     return wrappedGcs.open(resourceId, readOptions);
   }
@@ -199,23 +179,11 @@ public class ThrottledGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public List<String> listObjectNames(String bucketName, String objectNamePrefix)
-      throws IOException {
-    return listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
-  }
-
-  @Override
   public List<String> listObjectNames(
       String bucketName, String objectNamePrefix, ListObjectOptions listOptions)
       throws IOException {
     throttle(StorageOperation.LIST_OBJECTS);
     return wrappedGcs.listObjectNames(bucketName, objectNamePrefix, listOptions);
-  }
-
-  @Override
-  public List<GoogleCloudStorageItemInfo> listObjectInfo(String bucketName, String objectNamePrefix)
-      throws IOException {
-    return listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -111,11 +111,6 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public synchronized WritableByteChannel create(StorageResourceId resourceId) throws IOException {
-    return create(resourceId, CreateObjectOptions.DEFAULT_OVERWRITE);
-  }
-
-  @Override
   public synchronized WritableByteChannel create(
       StorageResourceId resourceId, CreateObjectOptions options) throws IOException {
     if (!bucketLookup.containsKey(resourceId.getBucketName())) {
@@ -152,11 +147,6 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
             options.getMetadata());
     bucketLookup.get(resourceId.getBucketName()).add(entry);
     return entry.getWriteChannel();
-  }
-
-  @Override
-  public synchronized void createBucket(String bucketName) throws IOException {
-    createBucket(bucketName, CreateBucketOptions.DEFAULT);
   }
 
   @Override
@@ -202,12 +192,6 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
     for (StorageResourceId resourceId : resourceIds) {
       createEmptyObject(resourceId, options);
     }
-  }
-
-  @Override
-  public synchronized SeekableByteChannel open(StorageResourceId resourceId)
-      throws IOException {
-    return open(resourceId, GoogleCloudStorageReadOptions.DEFAULT);
   }
 
   @Override
@@ -373,11 +357,6 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
-  public synchronized List<String> listObjectNames(String bucketName, String objectNamePrefix) {
-    return listObjectNames(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
-  }
-
-  @Override
   public synchronized List<String> listObjectNames(
       String bucketName, String objectNamePrefix, ListObjectOptions listOptions) {
     InMemoryBucketEntry bucketEntry = bucketLookup.get(bucketName);
@@ -408,12 +387,6 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
     // TODO: implement pagination
     return new ListPage<>(
         listObjectInfo(bucketName, objectNamePrefix, listOptions), /* nextPageToken= */ null);
-  }
-
-  @Override
-  public synchronized List<GoogleCloudStorageItemInfo> listObjectInfo(
-      String bucketName, String objectNamePrefix) throws IOException {
-    return listObjectInfo(bucketName, objectNamePrefix, ListObjectOptions.DEFAULT);
   }
 
   @Override

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
@@ -96,7 +96,8 @@ public class ForwardingGoogleCloudStorageTest {
   public void testCreateWithResource() throws IOException {
     gcs.create(TEST_STORAGE_RESOURCE_ID);
 
-    verify(mockGcsDelegate).create(eq(TEST_STORAGE_RESOURCE_ID));
+    verify(mockGcsDelegate)
+        .create(eq(TEST_STORAGE_RESOURCE_ID), eq(CreateObjectOptions.DEFAULT_OVERWRITE));
   }
 
   @Test
@@ -140,7 +141,8 @@ public class ForwardingGoogleCloudStorageTest {
   public void testOpen() throws IOException {
     gcs.open(TEST_STORAGE_RESOURCE_ID);
 
-    verify(mockGcsDelegate).open(eq(TEST_STORAGE_RESOURCE_ID));
+    verify(mockGcsDelegate)
+        .open(eq(TEST_STORAGE_RESOURCE_ID), eq(GoogleCloudStorageReadOptions.DEFAULT));
   }
 
   @Test
@@ -154,7 +156,7 @@ public class ForwardingGoogleCloudStorageTest {
   public void testCreateWithBucket() throws IOException {
     gcs.createBucket(TEST_STRING);
 
-    verify(mockGcsDelegate).createBucket(eq(TEST_STRING));
+    verify(mockGcsDelegate).createBucket(eq(TEST_STRING), eq(CreateBucketOptions.DEFAULT));
   }
 
   @Test
@@ -204,7 +206,8 @@ public class ForwardingGoogleCloudStorageTest {
   public void testListObjectNames() throws IOException {
     gcs.listObjectNames(TEST_STRING, TEST_STRING);
 
-    verify(mockGcsDelegate).listObjectNames(eq(TEST_STRING), eq(TEST_STRING));
+    verify(mockGcsDelegate)
+        .listObjectNames(eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT));
   }
 
   @Test
@@ -219,7 +222,8 @@ public class ForwardingGoogleCloudStorageTest {
   public void testListObjectInfo() throws IOException {
     gcs.listObjectInfo(TEST_STRING, TEST_STRING);
 
-    verify(mockGcsDelegate).listObjectInfo(eq(TEST_STRING), eq(TEST_STRING));
+    verify(mockGcsDelegate)
+        .listObjectInfo(eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT));
   }
 
   @Test
@@ -228,6 +232,24 @@ public class ForwardingGoogleCloudStorageTest {
 
     verify(mockGcsDelegate)
         .listObjectInfo(eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT));
+  }
+
+  @Test
+  public void testListObjectInfoPage() throws IOException {
+    gcs.listObjectInfoPage(TEST_STRING, TEST_STRING, TEST_STRING);
+
+    verify(mockGcsDelegate)
+        .listObjectInfoPage(
+            eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT), eq(TEST_STRING));
+  }
+
+  @Test
+  public void testListObjectInfoPageWithMax() throws IOException {
+    gcs.listObjectInfoPage(TEST_STRING, TEST_STRING, ListObjectOptions.DEFAULT, TEST_STRING);
+
+    verify(mockGcsDelegate)
+        .listObjectInfoPage(
+            eq(TEST_STRING), eq(TEST_STRING), eq(ListObjectOptions.DEFAULT), eq(TEST_STRING));
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -2695,8 +2695,7 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs = mockedGcs(transport);
 
     ListPage<GoogleCloudStorageItemInfo> objectsPage =
-        gcs.listObjectInfoPage(
-            BUCKET_NAME, prefix, ListObjectOptions.DEFAULT, /* pageToken= */ null);
+        gcs.listObjectInfoPage(BUCKET_NAME, prefix, /* pageToken= */ null);
 
     // The item exactly matching the input prefix will be discarded.
     assertThat(objectsPage.getNextPageToken()).isNull();
@@ -2735,8 +2734,7 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs = mockedGcs(transport);
 
     ListPage<GoogleCloudStorageItemInfo> objectsPage =
-        gcs.listObjectInfoPage(
-            BUCKET_NAME, objectPrefix, ListObjectOptions.DEFAULT, /* pageToken= */ null);
+        gcs.listObjectInfoPage(BUCKET_NAME, objectPrefix, /* pageToken= */ null);
 
     trackingHttpRequestInitializer.getAllRequestStrings();
     assertThat(objectsPage.getNextPageToken()).isNull();
@@ -2770,8 +2768,7 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs = mockedGcs(transport);
 
     ListPage<GoogleCloudStorageItemInfo> objectsPage =
-        gcs.listObjectInfoPage(
-            BUCKET_NAME, prefix, ListObjectOptions.DEFAULT, /* pageToken= */ null);
+        gcs.listObjectInfoPage(BUCKET_NAME, prefix, /* pageToken= */ null);
 
     assertThat(objectsPage.getNextPageToken()).isNull();
     assertThat(objectsPage.getItems())
@@ -3107,8 +3104,7 @@ public class GoogleCloudStorageTest {
 
     // List the objects
     ListPage<GoogleCloudStorageItemInfo> objectInfos =
-        gcs.listObjectInfoPage(
-            BUCKET_NAME, objectPrefix, ListObjectOptions.DEFAULT, /* pageToken= */ null);
+        gcs.listObjectInfoPage(BUCKET_NAME, objectPrefix, /* pageToken= */ null);
 
     assertThat(objectInfos.getNextPageToken()).isNull();
     if (gcs.getOptions().isInferImplicitDirectoriesEnabled()) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
@@ -426,8 +426,7 @@ public class GoogleCloudStorageTest {
     writeObject(rawStorage, objectToCreate, /* objectSize= */ 512);
 
     ListPage<GoogleCloudStorageItemInfo> listedObjectsPage =
-        rawStorage.listObjectInfoPage(
-            bucketName, "listObjectInfoPage_test_", ListObjectOptions.DEFAULT, /* pageToken= */ "");
+        rawStorage.listObjectInfoPage(bucketName, "listObjectInfoPage_test_", /* pageToken= */ "");
 
     assertThat(listedObjectsPage.getNextPageToken()).isNull();
     assertThat(
@@ -1690,17 +1689,14 @@ public class GoogleCloudStorageTest {
     StorageResourceId resourceId = new StorageResourceId(bucketName, objectName);
 
     ListPage<GoogleCloudStorageItemInfo> itemInfosPage =
-        rawStorage.listObjectInfoPage(
-            bucketName, objectName, ListObjectOptions.DEFAULT, /* pageToken= */ null);
+        rawStorage.listObjectInfoPage(bucketName, objectName, /* pageToken= */ null);
 
     assertThat(itemInfosPage.getNextPageToken()).isNull();
     assertThat(itemInfosPage.getItems()).isEmpty();
 
     writeObject(rawStorage, resourceId, /* objectSize= */ 512);
 
-    itemInfosPage =
-        rawStorage.listObjectInfoPage(
-            bucketName, objectName, ListObjectOptions.DEFAULT, /* pageToken= */ null);
+    itemInfosPage = rawStorage.listObjectInfoPage(bucketName, objectName, /* pageToken= */ null);
 
     assertThat(itemInfosPage.getNextPageToken()).isNull();
     assertThat(itemInfosPage.getItems()).hasSize(1);


### PR DESCRIPTION
1. Use `default` method definitions in interface.
1. Add missing methods with default option instance.