### PR TITLE
Do not create parent directories for new objects

### DIFF
--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/GsonBigQueryInputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/GsonBigQueryInputFormatTest.java
@@ -217,6 +217,7 @@ public class GsonBigQueryInputFormatTest {
 
     // Write values to file.
     Path mockPath = new Path("gs://test_bucket/path/test");
+    ghfs.mkdirs(new Path("gs://test_bucket/"));
     GsonRecordReaderTest.writeFile(ghfs, mockPath, (value1 + "\n" + value2 + "\n").getBytes(UTF_8));
 
     // Create a new InputSplit containing the values.
@@ -299,6 +300,7 @@ public class GsonBigQueryInputFormatTest {
 
     // Write values to file.
     Path mockPath = new Path("gs://test_bucket/path/test");
+    ghfs.mkdirs(new Path("gs://test_bucket/"));
     GsonRecordReaderTest.writeFile(ghfs, mockPath, (value1 + "\n" + value2 + "\n").getBytes(UTF_8));
 
     // Run getSplits method.

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/GsonRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/GsonRecordReaderTest.java
@@ -180,6 +180,7 @@ public class GsonRecordReaderTest {
 
     // Write values to file.
     Path mockPath = new Path("gs://test_bucket/test-object");
+    ghfs.mkdirs(new Path("gs://test_bucket/"));
     writeFile(ghfs, mockPath, (value1 + "\n" + value2 + "\n").getBytes(UTF_8));
 
     // Create a new InputSplit containing the values.

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitterTest.java
@@ -162,6 +162,7 @@ public class FederatedBigQueryOutputCommitterTest {
 
   /** Helper method to create basic valid output based. */
   private void generateSampleFiles() throws IOException {
+    ghfs.mkdirs(outputSampleFilePath.getParent());
     ghfs.createNewFile(outputSampleFilePath);
     assertThat(ghfs.exists(outputPath)).isTrue();
     assertThat(ghfs.exists(outputSampleFilePath)).isTrue();

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/ForwardingBigQueryFileOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/ForwardingBigQueryFileOutputCommitterTest.java
@@ -160,6 +160,7 @@ public class ForwardingBigQueryFileOutputCommitterTest {
 
   /** Helper method to create basic valid output based. */
   private void generateSampleFiles() throws IOException {
+    ghfs.mkdirs(outputSampleFilePath.getParent());
     ghfs.createNewFile(outputSampleFilePath);
 
     // Verify the files were created.

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
@@ -189,6 +189,7 @@ public class IndirectBigQueryOutputCommitterTest {
 
   /** Helper method to create basic valid output based. */
   private void generateSampleFiles() throws IOException {
+    ghfs.mkdirs(outputSampleFilePath.getParent());
     ghfs.createNewFile(outputSampleFilePath);
     assertThat(ghfs.exists(outputPath)).isTrue();
     assertThat(ghfs.exists(outputSampleFilePath)).isTrue();

--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -132,6 +132,9 @@
     fs.gs.glob.algorithm (default: CONCURRENT)
     ```
 
+1.  Do not create the parent directory objects when writing a file, instead rely
+    on the implicit directory inference.
+
 ### 2.1.1 - 2020-03-11
 
 1.  Add upload cache to support high-level retries of failed uploads. Cache size

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopSyncableOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopSyncableOutputStream.java
@@ -82,7 +82,6 @@ public class GoogleHadoopSyncableOutputStream extends OutputStream implements Sy
   private static final CreateFileOptions TEMPFILE_CREATE_OPTIONS =
       CreateFileOptions.DEFAULT_NO_OVERWRITE.toBuilder()
           .setEnsureNoDirectoryConflict(false)
-          .setEnsureParentDirectoriesExist(false)
           .setOverwriteGenerationId(0)
           .build();
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSIntegrationTest.java
@@ -112,7 +112,7 @@ public class GoogleHadoopFSIntegrationTest {
     }
 
     FileStatus parentStatus = ghfs.getFileStatus(filePath.getParent());
-    assertThat(parentStatus.getModificationTime()).isGreaterThan(0L);
+    assertThat(parentStatus.getModificationTime()).isEqualTo(0L);
   }
 
   @Test
@@ -141,7 +141,7 @@ public class GoogleHadoopFSIntegrationTest {
 
     // GoogleHadoopFS ignores 'createParent' flag and always creates parent
     FileStatus parentStatus = ghfs.getFileStatus(filePath.getParent().getParent());
-    assertThat(parentStatus.getModificationTime()).isGreaterThan(0L);
+    assertThat(parentStatus.getModificationTime()).isEqualTo(0);
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -664,7 +664,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
 
   @Test
   public void testGlobStatusPathExpansionAndFilter() throws IOException {
-    Path testRoot = new Path("/testGlobStatusPathExpansionAndFilter");
+    Path testRoot = new Path(ghfs.getWorkingDirectory(), "testGlobStatusPathExpansionAndFilter");
 
     byte[] data = "testGlobStatusPathExpansionAndFilter_data".getBytes(UTF_8);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/CreateFileOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/CreateFileOptions.java
@@ -38,7 +38,6 @@ public abstract class CreateFileOptions {
         .setAttributes(ImmutableMap.of())
         .setContentType(CreateObjectOptions.CONTENT_TYPE_DEFAULT)
         .setEnsureNoDirectoryConflict(true)
-        .setEnsureParentDirectoriesExist(true)
         .setOverwriteExisting(false)
         .setOverwriteGenerationId(StorageResourceId.UNKNOWN_GENERATION_ID);
   }
@@ -58,14 +57,6 @@ public abstract class CreateFileOptions {
    * already sure no such directory exists, then this is safe to set for improved performance.
    */
   public abstract boolean isEnsureNoDirectoryConflict();
-
-  /**
-   * If true, ensures parent directories exist, creating them on-demand if they don't. If false, you
-   * run the risk of creating objects without parent directories, which may degrade or break the
-   * behavior of some filesystem functionality. If already sure parent directories exist, then this
-   * is safe to set for improved performance.
-   */
-  public abstract boolean isEnsureParentDirectoriesExist();
 
   /** Whether to overwrite an existing file with the same name. */
   public abstract boolean isOverwriteExisting();
@@ -88,8 +79,6 @@ public abstract class CreateFileOptions {
     public abstract Builder setContentType(String contentType);
 
     public abstract Builder setEnsureNoDirectoryConflict(boolean ensureNoDirectoryConflict);
-
-    public abstract Builder setEnsureParentDirectoriesExist(boolean ensureParentDirectoriesExist);
 
     public abstract Builder setOverwriteGenerationId(long overwriteGenerationId);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -235,14 +235,6 @@ public class GoogleCloudStorageFileSystem {
       throw new FileAlreadyExistsException("A directory with that name exists: " + path);
     }
 
-    // Ensure that parent directories exist.
-    if (options.isEnsureParentDirectoriesExist()) {
-      URI parentPath = UriPaths.getParentPath(path);
-      if (parentPath != null) {
-        mkdirs(parentPath);
-      }
-    }
-
     if (options.getOverwriteGenerationId() != StorageResourceId.UNKNOWN_GENERATION_ID) {
       resourceId =
           new StorageResourceId(
@@ -423,7 +415,7 @@ public class GoogleCloudStorageFileSystem {
     logger.atFine().log("mkdirs(path: %s)", path);
     Preconditions.checkNotNull(path, "path should not be null");
 
-    mkdirsInternal(StorageResourceId.fromUriPath(path, true));
+    mkdirsInternal(StorageResourceId.fromUriPath(path, /* allowEmptyObjectName= */ true));
   }
 
   public void mkdirsInternal(StorageResourceId resourceId) throws IOException {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -460,7 +460,7 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
     URI bucketUri = new URI("gs://" + bucketName + "/");
     String dirObject = getTestResource();
 
-    gcsfsIHelper.create(bucketUri.resolve(dirObject + "/subdir/file"));
+    gcsfsIHelper.createObjects(bucketName, dirObject + "/subdir/file");
 
     List<FileInfo> fileInfos = gcsFs.listFileInfo(bucketUri.resolve(dirObject));
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
@@ -410,29 +410,17 @@ public class GoogleCloudStorageFileSystemTest
   public void testCreateNoParentDirectories()
       throws URISyntaxException, IOException {
     String bucketName = sharedBucketName1;
-    gcsfs
-        .create(
-            new URI("gs://" + bucketName + "/no/parent/dirs/exist/a.txt"),
-            CreateFileOptions.builder().setEnsureParentDirectoriesExist(false).build())
-        .close();
+    String testDir = "no/parent/dirs";
+
+    gcsfs.create(new URI(String.format("gs://%s/%s/exist/a.txt", bucketName, testDir))).close();
+
+    GoogleCloudStorage gcs = gcsfs.getGcs();
     assertThat(
-            gcsfs
-                .getGcs()
-                .getItemInfo(new StorageResourceId(bucketName, "no/parent/dirs/exist/a.txt"))
-                .exists())
+            gcs.getItemInfo(new StorageResourceId(bucketName, testDir + "/exist/a.txt")).exists())
         .isTrue();
-    assertThat(
-            gcsfs
-                .getGcs()
-                .getItemInfo(new StorageResourceId(bucketName, "no/parent/dirs/exist/"))
-                .exists())
+    assertThat(gcs.getItemInfo(new StorageResourceId(bucketName, testDir + "/exist/")).exists())
         .isFalse();
-    assertThat(
-            gcsfs
-                .getGcs()
-                .getItemInfo(new StorageResourceId(bucketName, "no/parent/dirs/"))
-                .exists())
-        .isFalse();
+    assertThat(gcs.getItemInfo(new StorageResourceId(bucketName, testDir)).exists()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Explicit parent directories objects are not necessary because they will be inferred automatically if object exists.

Partially fixes #356