### PR TITLE
Revert "Add interceptor to inject remote address to non-ok status dis…

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -145,10 +145,8 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   private static IOException convertError(
       StatusRuntimeException error, String bucketName, String objectName) {
     Status.Code statusCode = Status.fromThrowable(error).getCode();
-    Status status = error.getStatus();
     String msg =
-        String.format("Error reading '%s', got status: %s",
-            StringPaths.fromComponents(bucketName, objectName), status);
+        String.format("Error reading '%s'", StringPaths.fromComponents(bucketName, objectName));
     if (statusCode == Status.Code.NOT_FOUND) {
       return GoogleCloudStorageExceptions.createFileNotFoundException(
           bucketName, objectName, new IOException(msg, error));

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -390,6 +390,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
       @Override
       public void onError(Throwable t) {
         Status s = Status.fromThrowable(t);
+        String statusDesc = s == null ? "" : s.getDescription();
 
         if (t.getClass() == StatusException.class || t.getClass() == StatusRuntimeException.class) {
           Code code =
@@ -406,7 +407,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
                   String.format(
                       "Caught exception for '%s', while uploading to uploadId %s at writeOffset %d."
                           + " Status: %s",
-                      resourceId, uploadId, writeOffset, s),
+                      resourceId, uploadId, writeOffset, statusDesc),
                   t);
         }
         done.countDown();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -17,13 +17,11 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Context;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
-import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.alts.GoogleDefaultChannelBuilder;
-import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -117,32 +115,6 @@ public class StorageStubProvider {
     }
   }
 
-  // TODO(weiranf): Temporarily added for debugging, will be removed once GCS/DirectPath is stable.
-  final class RemoteAddressDebuggingInterceptor implements ClientInterceptor {
-
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
-        CallOptions callOptions, Channel next) {
-      final ClientCall<ReqT, RespT> newCall = next.newCall(method, callOptions);
-      return new SimpleForwardingClientCall<ReqT, RespT>(newCall) {
-        @Override
-        public void start(Listener<RespT> responseListener, Metadata headers) {
-          super.start(new SimpleForwardingClientCallListener<RespT>(responseListener) {
-            @Override
-            public void onClose(Status status, Metadata trailers) {
-              if (!status.isOk()) {
-                SocketAddress remoteAddr =
-                    newCall.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
-                status = status.augmentDescription("Remote Address: " + remoteAddr.toString());
-              }
-              super.onClose(status, trailers);
-            }
-          }, headers);
-        }
-      };
-    }
-  }
-
   class ChannelAndRequestCounter {
     private final ManagedChannel channel;
     private final ActiveRequestCounter counter;
@@ -174,9 +146,6 @@ public class StorageStubProvider {
             .enableRetry()
             .defaultServiceConfig(getGrpcServiceConfig())
             .intercept(counter)
-            // TODO(weiranf): Temporarily added for debugging,
-            //                will be removed once GCS/DirectPath is stable.
-            .intercept(new RemoteAddressDebuggingInterceptor())
             .build();
     return new ChannelAndRequestCounter(channel, counter);
   }


### PR DESCRIPTION
…cription (#441)"

This reverts commit 815e773927c1e1247380d9d86b859e4b7d132a27.

The remote_addr is now included in the server log so the redundant logging is not needed. Plus this appears to be the culprit that causes the TestDFSIO jobs to be hanging.