### PR TITLE
Do not create parent directory objects and bucket for new directories

### DIFF
--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReaderTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/DynamicFileListRecordReaderTest.java
@@ -99,6 +99,7 @@ public class DynamicFileListRecordReaderTest {
     estimatedNumRecords = 2;
 
     fileSystem = basePath.getFileSystem(config);
+    fileSystem.mkdirs(basePath);
     fileSystem.mkdirs(shardPath.getParent());
 
     // Instead of actually blocking, make our mockSleeper throw an exception that we can catch

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/FederatedBigQueryOutputCommitterTest.java
@@ -84,8 +84,10 @@ public class FederatedBigQueryOutputCommitterTest {
   private static final TaskAttemptID TEST_TASK_ATTEMPT_ID =
       new TaskAttemptID(new TaskID("sample_task", 100, false, 200), 1);
 
+  private static final String TEST_BUCKET_STRING = "gs://test_bucket";
+
   /** Sample raw output path for data. */
-  private static final String TEST_OUTPUT_PATH_STRING = "gs://test_bucket/test_directory/";
+  private static final String TEST_OUTPUT_PATH_STRING = TEST_BUCKET_STRING + "/test_directory/";
 
   /** Sample output file. */
   private static final String TEST_OUTPUT_FILE_STRING = TEST_OUTPUT_PATH_STRING + "test_file";
@@ -124,6 +126,7 @@ public class FederatedBigQueryOutputCommitterTest {
 
     // Create the file system.
     ghfs = new InMemoryGoogleHadoopFileSystem();
+    ghfs.mkdirs(new Path(TEST_BUCKET_STRING));
 
     // Setup the configuration.
     job = Job.getInstance(InMemoryGoogleHadoopFileSystem.getSampleConfiguration());

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/ForwardingBigQueryFileOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/ForwardingBigQueryFileOutputCommitterTest.java
@@ -90,8 +90,10 @@ public class ForwardingBigQueryFileOutputCommitterTest {
   private static final TaskAttemptID TEST_TASK_ATTEMPT_ID =
       new TaskAttemptID(new TaskID("sample_task", 100, false, 200), 1);
 
+  private static final String TEST_BUCKET_STRING = "gs://test_bucket";
+
   /** Sample raw output path for data. */
-  private static final String TEST_OUTPUT_PATH_STRING = "gs://test_bucket/test_directory/";
+  private static final String TEST_OUTPUT_PATH_STRING = TEST_BUCKET_STRING + "/test_directory/";
 
   /** Sample output file. */
   private static final String TEST_OUTPUT_FILE_STRING = TEST_OUTPUT_PATH_STRING + "test_file";
@@ -125,6 +127,7 @@ public class ForwardingBigQueryFileOutputCommitterTest {
 
     // Create the file system.
     ghfs = new InMemoryGoogleHadoopFileSystem();
+    ghfs.mkdirs(new Path(TEST_BUCKET_STRING));
 
     // Setup the configuration.
     job = Job.getInstance(InMemoryGoogleHadoopFileSystem.getSampleConfiguration());

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/ForwardingBigQueryFileOutputFormatTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/ForwardingBigQueryFileOutputFormatTest.java
@@ -67,8 +67,10 @@ public class ForwardingBigQueryFileOutputFormatTest {
   @SuppressWarnings("rawtypes")
   private static final Class<? extends FileOutputFormat> TEST_OUTPUT_CLASS = TextOutputFormat.class;
 
+  private static final String TEST_BUCKET_STRING = "gs://test_bucket";
+
   /** Sample raw output path for data. */
-  private static final String TEST_OUTPUT_PATH_STRING = "gs://test_bucket/test_directory/";
+  private static final String TEST_OUTPUT_PATH_STRING = TEST_BUCKET_STRING + "/test_directory/";
 
   /** Sample output path for data. */
   private static final Path TEST_OUTPUT_PATH = new Path(TEST_OUTPUT_PATH_STRING);
@@ -104,6 +106,7 @@ public class ForwardingBigQueryFileOutputFormatTest {
 
     // Create the file system.
     ghfs = new InMemoryGoogleHadoopFileSystem();
+    ghfs.mkdirs(new Path(TEST_BUCKET_STRING));
 
     // Create the configuration, but setup in the tests.
     job = Job.getInstance(InMemoryGoogleHadoopFileSystem.getSampleConfiguration());

--- a/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
+++ b/bigquery/src/test/java/com/google/cloud/hadoop/io/bigquery/output/IndirectBigQueryOutputCommitterTest.java
@@ -107,8 +107,10 @@ public class IndirectBigQueryOutputCommitterTest {
   private static final TaskAttemptID TEST_TASK_ATTEMPT_ID =
       new TaskAttemptID(new TaskID("sample_task", 100, false, 200), 1);
 
+  private static final String TEST_BUCKET_STRING = "gs://test_bucket";
+
   /** Sample raw output path for data. */
-  private static final String TEST_OUTPUT_PATH_STRING = "gs://test_bucket/test_directory/";
+  private static final String TEST_OUTPUT_PATH_STRING = TEST_BUCKET_STRING + "/test_directory/";
 
   /** Sample output file. */
   private static final String TEST_OUTPUT_FILE_STRING = TEST_OUTPUT_PATH_STRING + "test_file";
@@ -147,6 +149,7 @@ public class IndirectBigQueryOutputCommitterTest {
 
     // Create the file system.
     ghfs = new InMemoryGoogleHadoopFileSystem();
+    ghfs.mkdirs(new Path(TEST_BUCKET_STRING));
 
     // Setup the configuration.
     job = Job.getInstance(InMemoryGoogleHadoopFileSystem.getSampleConfiguration());

--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -132,8 +132,9 @@
     fs.gs.glob.algorithm (default: CONCURRENT)
     ```
 
-1.  Do not create the parent directory objects when writing a file, instead rely
-    on the implicit directory inference.
+1.  Do not create the parent directory objects (this includes buckets) when
+    creating a new file or a directory, instead rely on the implicit directory
+    inference.
 
 1.  Use default logging backend for Google Flogger instead of Slf4j.
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
@@ -145,16 +145,19 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
   }
 
   /**
-   * Validates that we cannot open a non-existent object.
-   * Note: WebHDFS throws IOException (Internal Server Error (error code=500))
+   * Validates that we cannot open a non-existent object. Note: WebHDFS throws IOException (Internal
+   * Server Error (error code=500))
    */
-  @Test @Override
-  public void testOpenNonExistent()
-      throws IOException {
-    String bucketName = ghfsHelper.getUniqueBucketName("open-non-existent");
+  @Test
+  @Override
+  public void testOpenNonExistentObject() throws IOException {
+    String bucketName = ghfsHelper.sharedBucketName1;
     IOException e =
         assertThrows(
-            IOException.class, () -> ghfsHelper.readTextFile(bucketName, objectName, 0, 100, true));
+            IOException.class,
+            () ->
+                ghfsHelper.readTextFile(
+                    bucketName, objectName + "_open-non-existent", 0, 100, true));
     assertThat(e).hasMessageThat().contains("Internal Server Error (error code=500)");
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
@@ -170,7 +170,7 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
   @Test
   @Override
   public void testOpenInNonExistentBucket() throws IOException {
-    String bucketName = ghfsHelper.sharedBucketName1 + "_open-non-existent";
+    String bucketName = ghfsHelper.getUniqueBucketName("open-non-existent");
     IOException e =
         assertThrows(
             IOException.class, () -> ghfsHelper.readTextFile(bucketName, objectName, 0, 100, true));

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
@@ -145,8 +145,9 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
   }
 
   /**
-   * Validates that we cannot open a non-existent object. Note: WebHDFS throws IOException (Internal
-   * Server Error (error code=500))
+   * Validates that we cannot open a non-existent object.
+   *
+   * <p>Note: WebHDFS throws IOException (Internal Server Error (error code=500))
    */
   @Test
   @Override
@@ -158,6 +159,21 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
             () ->
                 ghfsHelper.readTextFile(
                     bucketName, objectName + "_open-non-existent", 0, 100, true));
+    assertThat(e).hasMessageThat().contains("Internal Server Error (error code=500)");
+  }
+
+  /**
+   * Validates that we cannot open an object in non-existent bucket.
+   *
+   * <p>Note: WebHDFS throws IOException (Internal Server Error (error code=500))
+   */
+  @Test
+  @Override
+  public void testOpenInNonExistentBucket() throws IOException {
+    String bucketName = ghfsHelper.sharedBucketName1 + "_open-non-existent";
+    IOException e =
+        assertThrows(
+            IOException.class, () -> ghfsHelper.readTextFile(bucketName, objectName, 0, 100, true));
     assertThat(e).hasMessageThat().contains("Internal Server Error (error code=500)");
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/GoogleContract.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/contract/GoogleContract.java
@@ -22,7 +22,10 @@ import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.SERVICE
 
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
+import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractBondedFSContract;
 
 /** Contract of GoogleHadoopFileSystem via scheme "gs". */
@@ -49,6 +52,13 @@ public class GoogleContract extends AbstractBondedFSContract {
           GCS_CONFIG_PREFIX + SERVICE_ACCOUNT_KEYFILE_SUFFIX.getKey(),
           testConf.getPrivateKeyFile());
     }
+  }
+
+  @Override
+  public void init() throws IOException {
+    super.init();
+    FileSystem testFs = getTestFileSystem();
+    testFs.mkdirs(new Path(testFs.getUri()));
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -447,7 +447,8 @@ public class GoogleCloudStorageFileSystem {
       try {
         gcs.createBucket(resourceId.getBucketName());
       } catch (IOException e) {
-        if (ApiErrorExtractor.INSTANCE.itemAlreadyExists(e)) {
+        if (e instanceof FileAlreadyExistsException
+            || ApiErrorExtractor.INSTANCE.itemAlreadyExists(e)) {
           // This means that bucket already exist and we do not need to do anything.
           logger.atFine().withCause(e).log(
               "mkdirs: %s already exists, ignoring creation failure", resourceId);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -233,7 +233,7 @@ public class GoogleCloudStorageFileSystem {
               "Cannot create a file whose name looks like a directory: '%s'", resourceId));
     }
 
-    // Before creating a top-level directory we need to check if there are no conflicting files
+    // Before creating a leaf directory we need to check if there are no conflicting files
     // with the same name as any subdirectory
     if (options.isEnsureNoConflictingItems()) {
       // Asynchronously check if a directory with the same name exists.
@@ -446,29 +446,24 @@ public class GoogleCloudStorageFileSystem {
     if (resourceId.isBucket()) {
       try {
         gcs.createBucket(resourceId.getBucketName());
-      } catch (IOException e) {
-        if (e instanceof FileAlreadyExistsException
-            || ApiErrorExtractor.INSTANCE.itemAlreadyExists(e)) {
-          // This means that bucket already exist and we do not need to do anything.
-          logger.atFine().withCause(e).log(
-              "mkdirs: %s already exists, ignoring creation failure", resourceId);
-        } else {
-          throw e;
-        }
+      } catch (FileAlreadyExistsException e) {
+        // This means that bucket already exist and we do not need to do anything.
+        logger.atFine().withCause(e).log(
+            "mkdirs: %s already exists, ignoring creation failure", resourceId);
       }
       return;
     }
 
     resourceId = resourceId.toDirectoryId();
 
-    // Before creating a top-level directory we need to check if there are no conflicting files
+    // Before creating a leaf directory we need to check if there are no conflicting files
     // with the same name as any subdirectory
     if (options.isEnsureNoConflictingItems()) {
       checkNoFilesConflictingWithDirs(resourceId);
     }
 
-    // Create only a top-level directory because subdirectories will be inferred
-    // if top-level directory exists
+    // Create only a leaf directory because subdirectories will be inferred
+    // if leaf directory exists
     try {
       gcs.createEmptyObject(resourceId);
     } catch (IOException e) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -31,7 +31,6 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage.ListPage;
 import com.google.cloud.hadoop.gcsio.cooplock.CoopLockOperationDelete;
 import com.google.cloud.hadoop.gcsio.cooplock.CoopLockOperationRename;
-import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.LazyExecutorService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -466,13 +465,10 @@ public class GoogleCloudStorageFileSystem {
     // if leaf directory exists
     try {
       gcs.createEmptyObject(resourceId);
-    } catch (IOException e) {
-      if (ApiErrorExtractor.INSTANCE.itemAlreadyExists(e)) {
-        logger.atFine().withCause(e).log(
-            "mkdirs: %s already exists, ignoring creation failure", resourceId);
-      } else {
-        throw e;
-      }
+    } catch (FileAlreadyExistsException e) {
+      // This means that directory object already exist and we do not need to do anything.
+      logger.atFine().withCause(e).log(
+          "mkdirs: %s already exists, ignoring creation failure", resourceId);
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
@@ -29,7 +29,7 @@ public abstract class GoogleCloudStorageFileSystemOptions {
         .setCloudStorageOptions(GoogleCloudStorageOptions.DEFAULT)
         .setBucketDeleteEnabled(false)
         .setMarkerFilePattern((String) null)
-        .setStatusParallelEnabled(false)
+        .setStatusParallelEnabled(true)
         .setCooperativeLockingEnabled(false);
   }
 
@@ -49,6 +49,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
   public abstract boolean isStatusParallelEnabled();
 
   public abstract boolean isCooperativeLockingEnabled();
+
+  public abstract boolean isEnsureNoConflictingItems();
 
   public void throwIfNotValid() {
     getCloudStorageOptions().throwIfNotValid();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
@@ -30,7 +30,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
         .setBucketDeleteEnabled(false)
         .setMarkerFilePattern((String) null)
         .setStatusParallelEnabled(true)
-        .setCooperativeLockingEnabled(false);
+        .setCooperativeLockingEnabled(false)
+        .setEnsureNoConflictingItems(true);
   }
 
   public abstract Builder toBuilder();
@@ -83,6 +84,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
     public abstract Builder setStatusParallelEnabled(boolean statusParallelEnabled);
 
     public abstract Builder setCooperativeLockingEnabled(boolean cooperativeLockingEnabled);
+
+    public abstract Builder setEnsureNoConflictingItems(boolean ensureNoConflictingItems);
 
     public abstract GoogleCloudStorageFileSystemOptions build();
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static java.lang.Math.toIntExact;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback;
@@ -442,15 +443,11 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
             .setLocation(options.getLocation())
             .setStorageClass(options.getStorageClass());
     if (options.getTtl() != null) {
-      bucket.setLifecycle(
-          new Lifecycle()
-              .setRule(
-                  ImmutableList.of(
-                      new Rule()
-                          .setAction(new Action().setType("Delete"))
-                          .setCondition(
-                              new Condition()
-                                  .setAge(Math.toIntExact(options.getTtl().toDays()))))));
+      Rule lifecycleRule =
+          new Rule()
+              .setAction(new Action().setType("Delete"))
+              .setCondition(new Condition().setAge(toIntExact(options.getTtl().toDays())));
+      bucket.setLifecycle(new Lifecycle().setRule(ImmutableList.of(lifecycleRule)));
     }
 
     Storage.Buckets.Insert insertBucket =

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -155,14 +155,13 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
     if (!validateBucketName(bucketName)) {
       throw new IOException("Error creating bucket. Invalid name: " + bucketName);
     }
-    if (!bucketLookup.containsKey(bucketName)) {
-      bucketLookup.put(
-          bucketName,
-          new InMemoryBucketEntry(
-              bucketName, clock.currentTimeMillis(), clock.currentTimeMillis(), options));
-    } else {
-      throw new IOException("Bucket '" + bucketName + "'already exists");
+    if (bucketLookup.containsKey(bucketName)) {
+      throw new FileAlreadyExistsException("Bucket '" + bucketName + "' already exists");
     }
+    bucketLookup.put(
+        bucketName,
+        new InMemoryBucketEntry(
+            bucketName, clock.currentTimeMillis(), clock.currentTimeMillis(), options));
   }
 
   @Override

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -1622,7 +1622,7 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
   private List<URI> getSubDirPaths(URI path) {
     StorageResourceId resourceId = StorageResourceId.fromUriPath(path, true);
 
-    List<String> subdirs = GoogleCloudStorageFileSystem.getSubDirs(resourceId.getObjectName());
+    List<String> subdirs = GoogleCloudStorageFileSystem.getDirs(resourceId.getObjectName());
     List<URI> subDirPaths = new ArrayList<>(subdirs.size());
     for (String subdir : subdirs) {
       subDirPaths.add(gcsiHelper.getPath(resourceId.getBucketName(), subdir));

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -596,6 +596,15 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
         () -> gcsiHelper.readTextFile(bucketName, objectName + "_open-non-existent", 0, 100, true));
   }
 
+  /** Validates that we cannot open an object in non-existent bucket. */
+  @Test
+  public void testOpenInNonExistentBucket() throws IOException {
+    String bucketName = sharedBucketName1 + "_open-non-existent";
+    assertThrows(
+        FileNotFoundException.class,
+        () -> gcsiHelper.readTextFile(bucketName, objectName, 0, 100, true));
+  }
+
   /** Validates delete(). */
   public void deleteHelper(DeletionBehavior behavior) throws Exception {
     String bucketName = sharedBucketName1;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -599,7 +599,7 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
   /** Validates that we cannot open an object in non-existent bucket. */
   @Test
   public void testOpenInNonExistentBucket() throws IOException {
-    String bucketName = sharedBucketName1 + "_open-non-existent";
+    String bucketName = gcsiHelper.getUniqueBucketName("open-non-existent");
     assertThrows(
         FileNotFoundException.class,
         () -> gcsiHelper.readTextFile(bucketName, objectName, 0, 100, true));


### PR DESCRIPTION
1. Instead of creating parent directory objects rely on implicit directory inference.
2. Do not create bucket if it does not exist - this will require that buckets to be created explicitly.

Fixes #135