### PR TITLE
Cancel the request context when no more data available

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -333,7 +333,12 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
           .call(
               () -> {
                 try {
-                  return resIterator.hasNext();
+                  boolean moreDataAvailable = resIterator.hasNext();
+                  if (!moreDataAvailable) {
+                    cancelCurrentRequest();
+                  }
+
+                  return moreDataAvailable;
                 } catch (StatusRuntimeException e) {
                   throw convertError(e, bucketName, objectName);
                 }


### PR DESCRIPTION
Bring back https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/379 regarding `moreServerContent()` method. This PR fixed a regression that was introduced back by the refactoring PR - https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/463.

Not canceling the request context after no more data available will pile up streams over the time and it will work fine with small load tests but will hang for large load.