### PR TITLE
Enable reading from public buckets (without credentials)

### DIFF
--- a/bigquery/CHANGES.md
+++ b/bigquery/CHANGES.md
@@ -8,6 +8,8 @@
 
 1.  Removed unused `mapred.bq.output.buffer.size` configuration property.
 
+1.  Fix unauthenticated access support (`mapred.bq.auth.null.enable=true`).
+
 ### 1.1.1 - 2020-03-11
 
 1.  Fix shaded jar - add back missing relocated dependencies.

--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -135,6 +135,8 @@
 1.  Remove obsolete `fs.gs.inputstream.buffer.size` property and related
     functionality.
 
+1.  Fix unauthenticated access support (`fs.gs.auth.null.enable=true`).
+
 ### 2.1.1 - 2020-03-11
 
 1.  Add upload cache to support high-level retries of failed uploads. Cache size

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -1142,4 +1142,34 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
     assertThrows(
         IllegalArgumentException.class, () -> myghfs.getGcsPath(new Path("gs://buck^et/object")));
   }
+
+  @Test
+  public void unauthenticatedAccessToPublicBuckets_fsGsProperties() throws Exception {
+    String publicBucket = "gs://gcp-public-data-landsat";
+
+    Configuration config = new Configuration();
+    config.setBoolean("fs.gs.auth.service.account.enable", false);
+    config.setBoolean("fs.gs.auth.null.enable", true);
+
+    FileSystem fs = FileSystem.get(new URI(publicBucket), config);
+
+    FileStatus[] fileStatuses = fs.listStatus(new Path(publicBucket));
+
+    assertThat(fileStatuses).isNotEmpty();
+  }
+
+  @Test
+  public void unauthenticatedAccessToPublicBuckets_googleCloudProperties() throws Exception {
+    String publicBucket = "gs://gcp-public-data-landsat";
+
+    Configuration config = new Configuration();
+    config.setBoolean("google.cloud.auth.service.account.enable", false);
+    config.setBoolean("google.cloud.auth.null.enable", true);
+
+    FileSystem fs = FileSystem.get(new URI(publicBucket), config);
+
+    FileStatus[] fileStatuses = fs.listStatus(new Path(publicBucket));
+
+    assertThat(fileStatuses).isNotEmpty();
+  }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -144,8 +144,6 @@ public class GoogleCloudStorageFileSystem {
       Credential credential, GoogleCloudStorageFileSystemOptions options) throws IOException {
     logger.atFine().log("GoogleCloudStorageFileSystem(options: %s)", options);
 
-    checkNotNull(credential, "credential must not be null");
-
     this.options = checkNotNull(options, "options must not be null");
     this.options.throwIfNotValid();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -243,7 +243,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     this(
         options,
         new RetryHttpInitializer(
-            checkNotNull(credential, "credential must not be null"),
+            credential,
             options.toRetryHttpInitializerOptions()));
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -240,11 +240,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
    */
   public GoogleCloudStorageImpl(GoogleCloudStorageOptions options, Credential credential)
       throws IOException {
-    this(
-        options,
-        new RetryHttpInitializer(
-            credential,
-            options.toRetryHttpInitializerOptions()));
+    this(options, new RetryHttpInitializer(credential, options.toRetryHttpInitializerOptions()));
   }
 
   @VisibleForTesting

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
@@ -134,10 +134,8 @@ public class GoogleCloudStorageFileSystemTest
     optionsBuilder.setCloudStorageOptions(
         options.getCloudStorageOptions().toBuilder().setAppName("appName").build());
 
-    // Verify that credential == null throws IllegalArgumentException.
-    assertThrows(
-        NullPointerException.class,
-        () -> new GoogleCloudStorageFileSystem((Credential) null, optionsBuilder.build()));
+    // Verify that credential == null works - this is required for unauthenticated access.
+    new GoogleCloudStorageFileSystem((Credential) null, optionsBuilder.build());
 
     // Verify that fake projectId/appName and empty cred does not throw.
     setDefaultValidOptions(optionsBuilder);

--- a/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.hadoop.util;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.concurrent.TimeUnit.SECONDS;
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
@@ -161,7 +161,7 @@ public class RetryHttpInitializer implements HttpRequestInitializer {
     @Override
     public boolean handleResponse(HttpRequest request, HttpResponse response, boolean supportsRetry)
         throws IOException {
-      if (credential.handleResponse(request, response, supportsRetry)) {
+      if (credential != null && credential.handleResponse(request, response, supportsRetry)) {
         // If credential decides it can handle it, the return code or message indicated something
         // specific to authentication, and no backoff is desired.
         return true;
@@ -215,7 +215,7 @@ public class RetryHttpInitializer implements HttpRequestInitializer {
    * @param options An options that configure {@link RetryHttpInitializer} instance behaviour.
    */
   public RetryHttpInitializer(Credential credential, RetryHttpInitializerOptions options) {
-    this.credential = checkNotNull(credential, "A valid Credential is required");
+    this.credential = credential;
     this.options = options;
     this.sleeperOverride = null;
   }

--- a/util/src/test/java/com/google/cloud/hadoop/util/RetryHttpInitializerTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/RetryHttpInitializerTest.java
@@ -15,7 +15,6 @@
 package com.google.cloud.hadoop.util;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -101,8 +100,7 @@ public class RetryHttpInitializerTest {
 
   @Test
   public void testConstructorNullCredential() {
-    assertThrows(
-        NullPointerException.class, () -> new RetryHttpInitializer(null, "foo-user-agent"));
+    new RetryHttpInitializer(/* credential= */ null, "foo-user-agent");
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/459

Without this fix getting below error on v2.0.0, with `google.cloud.auth.null.enable=true` and `google.cloud.auth.service.account.enable=false`, when run from my local laptop (i.e. not within GCP) against public bucket like `gs://dartlang-api-docs/`:
```
java.lang.IllegalArgumentException: credential must not be null
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem.<init>(GoogleCloudStorageFileSystem.java:148)
	at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.createGcsFs(GoogleHadoopFileSystemBase.java:1604)
	at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.configure(GoogleHadoopFileSystemBase.java:1554)
	at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.initialize(GoogleHadoopFileSystemBase.java:553)
	at com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.initialize(GoogleHadoopFileSystemBase.java:506)
	at org.apache.hadoop.fs.PrestoFileSystemCache.createFileSystem(PrestoFileSystemCache.java:125)
	at org.apache.hadoop.fs.PrestoFileSystemCache.getInternal(PrestoFileSystemCache.java:92)
	at org.apache.hadoop.fs.PrestoFileSystemCache.get(PrestoFileSystemCache.java:65)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:479)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:361)
```