### PR TITLE
List only object fields that are used in Hadoop FileStatus

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -331,8 +331,8 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
           .isTrue();
     } else {
       assertWithMessage("Expected to have requested ID: %s", path)
-          .that(gcsfs.getFileInfo(path).getItemInfo().getResourceId())
-          .isEqualTo(StorageResourceId.fromUriPath(path, /* allowEmptyObjectName= */ true));
+          .that(gcsfs.getFileInfo(path).getPath())
+          .isEqualTo(path);
     }
   }
 

--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -161,6 +161,10 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
     </dependency>

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import com.google.common.base.Objects;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
@@ -132,6 +133,11 @@ public class FileInfo {
     return verificationAttributes == null ? null : verificationAttributes.getMd5hash();
   }
 
+  /** Gets information about the underlying item. */
+  GoogleCloudStorageItemInfo getItemInfo() {
+    return itemInfo;
+  }
+
   /**
    * Gets string representation of this instance.
    */
@@ -139,11 +145,21 @@ public class FileInfo {
     return getPath() + (exists() ? ": created on: " + new Date(getCreationTime()) : ": exists: no");
   }
 
-  /**
-   * Gets information about the underlying item.
-   */
-  public GoogleCloudStorageItemInfo getItemInfo() {
-    return itemInfo;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof FileInfo)) {
+      return false;
+    }
+    FileInfo fileInfo = (FileInfo) o;
+    return Objects.equal(path, fileInfo.path) && Objects.equal(itemInfo, fileInfo.itemInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(path, itemInfo);
   }
 
   /**

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -16,12 +16,12 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import com.google.common.base.Objects;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Contains information about a file or a directory.
@@ -154,12 +154,12 @@ public class FileInfo {
       return false;
     }
     FileInfo fileInfo = (FileInfo) o;
-    return Objects.equal(path, fileInfo.path) && Objects.equal(itemInfo, fileInfo.itemInfo);
+    return Objects.equals(path, fileInfo.path) && Objects.equals(itemInfo, fileInfo.itemInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(path, itemInfo);
+    return Objects.hash(path, itemInfo);
   }
 
   /**

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
@@ -43,9 +42,6 @@ public class FileInfo {
   // Information about the underlying GCS item.
   private final GoogleCloudStorageItemInfo itemInfo;
 
-  // Custom file attributes, including those used for storing custom modification times, etc
-  private final Map<String, byte[]> attributes;
-
   /**
    * Constructs an instance of FileInfo.
    *
@@ -56,9 +52,6 @@ public class FileInfo {
 
     // Construct the path once.
     this.path = path;
-    Preconditions.checkArgument(itemInfo.getMetadata() != null);
-
-    this.attributes = itemInfo.getMetadata();
   }
 
   /**
@@ -86,7 +79,7 @@ public class FileInfo {
   /**
    * Gets creation time of this item.
    *
-   * Time is expressed as milliseconds since January 1, 1970 UTC.
+   * <p>Time is expressed as milliseconds since January 1, 1970 UTC.
    */
   public long getCreationTime() {
     return itemInfo.getCreationTime();
@@ -95,19 +88,18 @@ public class FileInfo {
   /**
    * Gets the size of this file or directory.
    *
-   * For files, size is in number of bytes.
-   * For directories size is 0.
-   * For items that do not exist, size is -1.
+   * <p>For files, size is in number of bytes. For directories size is 0. For items that do not
+   * exist, size is -1.
    */
   public long getSize() {
     return itemInfo.getSize();
   }
 
   /**
-   * Gets the modification time of this file if one is set, otherwise the value of
-   * {@link #getCreationTime()} is returned.
+   * Gets the modification time of this file if one is set, otherwise the value of {@link
+   * #getCreationTime()} is returned.
    *
-   * Time is expressed as milliseconds since January 1, 1970 UTC.
+   * <p>Time is expressed as milliseconds since January 1, 1970 UTC.
    */
   public long getModificationTime() {
     return itemInfo.getModificationTime();
@@ -118,7 +110,7 @@ public class FileInfo {
    * @return A map of file attributes
    */
   public Map<String, byte[]> getAttributes() {
-    return attributes;
+    return itemInfo.getMetadata();
   }
 
   /**
@@ -126,6 +118,18 @@ public class FileInfo {
    */
   public boolean exists() {
     return itemInfo.exists();
+  }
+
+  /** Returns CRC32C checksum of the file or {@code null}. */
+  public byte[] getCrc32cChecksum() {
+    VerificationAttributes verificationAttributes = itemInfo.getVerificationAttributes();
+    return verificationAttributes == null ? null : verificationAttributes.getCrc32c();
+  }
+
+  /** Returns MD5 checksum of the file or {@code null}. */
+  public byte[] getMd5Checksum() {
+    VerificationAttributes verificationAttributes = itemInfo.getVerificationAttributes();
+    return verificationAttributes == null ? null : verificationAttributes.getMd5hash();
   }
 
   /**

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -96,6 +96,9 @@ public class GoogleCloudStorageFileSystem {
   private static final ListObjectOptions LIST_FILE_INFO_LIST_OPTIONS =
       ListObjectOptions.DEFAULT.toBuilder().setIncludePrefix(true).build();
 
+  public static final ListFileOptions DELETE_RENAME_LIST_OPTIONS =
+      ListFileOptions.DEFAULT.toBuilder().setFields("bucket,name,generation").build();
+
   // GCS access instance.
   private GoogleCloudStorage gcs;
 
@@ -339,8 +342,8 @@ public class GoogleCloudStorageFileSystem {
     if (fileInfo.isDirectory()) {
       itemsToDelete =
           recursive
-              ? listAllFileInfoForPrefix(fileInfo.getPath())
-              : listFileInfo(fileInfo.getPath());
+              ? listFileInfoForPrefix(fileInfo.getPath(), DELETE_RENAME_LIST_OPTIONS)
+              : listFileInfo(fileInfo.getPath(), DELETE_RENAME_LIST_OPTIONS);
       if (!itemsToDelete.isEmpty() && !recursive) {
         throw new DirectoryNotEmptyException("Cannot delete a non-empty directory.");
       }
@@ -733,7 +736,7 @@ public class GoogleCloudStorageFileSystem {
 
     // List of individual paths to rename;
     // we will try to carry out the copies in this list's order.
-    List<FileInfo> srcItemInfos = listAllFileInfoForPrefix(src);
+    List<FileInfo> srcItemInfos = listFileInfoForPrefix(src, DELETE_RENAME_LIST_OPTIONS);
 
     // Create a list of sub-items to copy.
     Pattern markerFilePattern = options.getMarkerFilePattern();
@@ -866,28 +869,53 @@ public class GoogleCloudStorageFileSystem {
    *
    * @param prefix the prefix to use to list all matching objects.
    */
-  public List<FileInfo> listAllFileInfoForPrefix(URI prefix) throws IOException {
-    logger.atFiner().log("listAllFileInfoForPrefixPage(prefix: %s)", prefix);
+  public List<FileInfo> listFileInfoForPrefix(URI prefix) throws IOException {
+    return listFileInfoForPrefix(prefix, ListFileOptions.DEFAULT);
+  }
+
+  /**
+   * Equivalent to a recursive listing of {@code prefix}, except that {@code prefix} doesn't have to
+   * represent an actual object but can just be a partial prefix string. The 'authority' component
+   * of the {@code prefix} <b>must</b> be the complete authority, however; we can only list prefixes
+   * of <b>objects</b>, not buckets.
+   *
+   * @param prefix the prefix to use to list all matching objects.
+   */
+  public List<FileInfo> listFileInfoForPrefix(URI prefix, ListFileOptions listOptions)
+      throws IOException {
+    logger.atFiner().log("listAllFileInfoForPrefix(prefix: %s)", prefix);
     StorageResourceId prefixId = getPrefixId(prefix);
     List<GoogleCloudStorageItemInfo> itemInfos =
         gcs.listObjectInfo(
             prefixId.getBucketName(),
             prefixId.getObjectName(),
-            ListObjectOptions.DEFAULT_FLAT_LIST);
+            updateListFileOptions(listOptions, ListObjectOptions.DEFAULT_FLAT_LIST));
     List<FileInfo> fileInfos = FileInfo.fromItemInfos(itemInfos);
     fileInfos.sort(FILE_INFO_PATH_COMPARATOR);
     return fileInfos;
   }
 
   /**
-   * Equivalent to {@link #listAllFileInfoForPrefix} but returns {@link FileInfo}s listed by single
+   * Equivalent to {@link #listFileInfoForPrefix} but returns {@link FileInfo}s listed by single
    * request (1 page).
    *
    * @param prefix the prefix to use to list all matching objects.
    * @param pageToken the page token to list
    */
-  public ListPage<FileInfo> listAllFileInfoForPrefixPage(URI prefix, String pageToken)
+  public ListPage<FileInfo> listFileInfoForPrefixPage(URI prefix, String pageToken)
       throws IOException {
+    return listFileInfoForPrefixPage(prefix, ListFileOptions.DEFAULT, pageToken);
+  }
+
+  /**
+   * Equivalent to {@link #listFileInfoForPrefix} but returns {@link FileInfo}s listed by single
+   * request (1 page).
+   *
+   * @param prefix the prefix to use to list all matching objects.
+   * @param pageToken the page token to list
+   */
+  public ListPage<FileInfo> listFileInfoForPrefixPage(
+      URI prefix, ListFileOptions listOptions, String pageToken) throws IOException {
     logger.atFinest().log(
         "listAllFileInfoForPrefixPage(prefix: %s, pageToken:%s)", prefix, pageToken);
     StorageResourceId prefixId = getPrefixId(prefix);
@@ -895,7 +923,7 @@ public class GoogleCloudStorageFileSystem {
         gcs.listObjectInfoPage(
             prefixId.getBucketName(),
             prefixId.getObjectName(),
-            ListObjectOptions.DEFAULT_FLAT_LIST,
+            updateListFileOptions(listOptions, ListObjectOptions.DEFAULT_FLAT_LIST),
             pageToken);
     List<FileInfo> fileInfosPage = FileInfo.fromItemInfos(itemInfosPage.getItems());
     fileInfosPage.sort(FILE_INFO_PATH_COMPARATOR);
@@ -912,6 +940,10 @@ public class GoogleCloudStorageFileSystem {
     return prefixId;
   }
 
+  public List<FileInfo> listFileInfo(URI path) throws IOException {
+    return listFileInfo(path, ListFileOptions.DEFAULT);
+  }
+
   /**
    * If the given path points to a directory then the information about its children is returned,
    * otherwise information about the given file is returned.
@@ -920,7 +952,7 @@ public class GoogleCloudStorageFileSystem {
    * @return Information about a file or children of a directory.
    * @throws FileNotFoundException if the given path does not exist.
    */
-  public List<FileInfo> listFileInfo(URI path) throws IOException {
+  public List<FileInfo> listFileInfo(URI path, ListFileOptions listOptions) throws IOException {
     Preconditions.checkNotNull(path, "path can not be null");
     logger.atFinest().log("listFileInfo(path: %s)", path);
 
@@ -943,7 +975,9 @@ public class GoogleCloudStorageFileSystem {
         dirId.isRoot()
             ? gcs.listBucketInfo()
             : gcs.listObjectInfo(
-                dirId.getBucketName(), dirId.getObjectName(), LIST_FILE_INFO_LIST_OPTIONS);
+                dirId.getBucketName(),
+                dirId.getObjectName(),
+                updateListFileOptions(listOptions, LIST_FILE_INFO_LIST_OPTIONS));
     if (pathId.isStorageObject() && dirItemInfos.isEmpty()) {
       throw new FileNotFoundException("Item not found: " + path);
     }
@@ -1186,6 +1220,11 @@ public class GoogleCloudStorageFileSystem {
             ? objectName.lastIndexOf(PATH_DELIMITER, objectName.length() - 2)
             : objectName.lastIndexOf(PATH_DELIMITER);
     return index < 0 ? objectName : objectName.substring(index + 1);
+  }
+
+  private static ListObjectOptions updateListFileOptions(
+      ListFileOptions listFileOptions, ListObjectOptions listObjectOptions) {
+    return listObjectOptions.toBuilder().setFields(listFileOptions.getFields()).build();
   }
 
   /** Retrieve our internal gcs. */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -889,7 +889,7 @@ public class GoogleCloudStorageFileSystem {
         gcs.listObjectInfo(
             prefixId.getBucketName(),
             prefixId.getObjectName(),
-            updateListFileOptions(listOptions, ListObjectOptions.DEFAULT_FLAT_LIST));
+            updateListObjectOptions(ListObjectOptions.DEFAULT_FLAT_LIST, listOptions));
     List<FileInfo> fileInfos = FileInfo.fromItemInfos(itemInfos);
     fileInfos.sort(FILE_INFO_PATH_COMPARATOR);
     return fileInfos;
@@ -923,7 +923,7 @@ public class GoogleCloudStorageFileSystem {
         gcs.listObjectInfoPage(
             prefixId.getBucketName(),
             prefixId.getObjectName(),
-            updateListFileOptions(listOptions, ListObjectOptions.DEFAULT_FLAT_LIST),
+            updateListObjectOptions(ListObjectOptions.DEFAULT_FLAT_LIST, listOptions),
             pageToken);
     List<FileInfo> fileInfosPage = FileInfo.fromItemInfos(itemInfosPage.getItems());
     fileInfosPage.sort(FILE_INFO_PATH_COMPARATOR);
@@ -940,6 +940,14 @@ public class GoogleCloudStorageFileSystem {
     return prefixId;
   }
 
+  /**
+   * If the given path points to a directory then the information about its children is returned,
+   * otherwise information about the given file is returned.
+   *
+   * @param path Given path.
+   * @return Information about a file or children of a directory.
+   * @throws FileNotFoundException if the given path does not exist.
+   */
   public List<FileInfo> listFileInfo(URI path) throws IOException {
     return listFileInfo(path, ListFileOptions.DEFAULT);
   }
@@ -977,7 +985,7 @@ public class GoogleCloudStorageFileSystem {
             : gcs.listObjectInfo(
                 dirId.getBucketName(),
                 dirId.getObjectName(),
-                updateListFileOptions(listOptions, LIST_FILE_INFO_LIST_OPTIONS));
+                updateListObjectOptions(LIST_FILE_INFO_LIST_OPTIONS, listOptions));
     if (pathId.isStorageObject() && dirItemInfos.isEmpty()) {
       throw new FileNotFoundException("Item not found: " + path);
     }
@@ -1222,8 +1230,8 @@ public class GoogleCloudStorageFileSystem {
     return index < 0 ? objectName : objectName.substring(index + 1);
   }
 
-  private static ListObjectOptions updateListFileOptions(
-      ListFileOptions listFileOptions, ListObjectOptions listObjectOptions) {
+  private static ListObjectOptions updateListObjectOptions(
+      ListObjectOptions listObjectOptions, ListFileOptions listFileOptions) {
     return listObjectOptions.toBuilder().setFields(listFileOptions.getFields()).build();
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
@@ -68,7 +68,6 @@ public class GoogleCloudStorageItemInfo {
       long modificationTime,
       String location,
       String storageClass) {
-    checkNotNull(resourceId, "resourceId must not be null.");
     checkArgument(resourceId.isBucket(), "expected bucket but got '%s'", resourceId);
     return new GoogleCloudStorageItemInfo(
         resourceId,
@@ -104,7 +103,6 @@ public class GoogleCloudStorageItemInfo {
       long contentGeneration,
       long metaGeneration,
       VerificationAttributes verificationAttributes) {
-    checkNotNull(resourceId, "resourceId must not be null.");
     checkArgument(!resourceId.isRoot(), "expected object or directory but got '%s'", resourceId);
     checkArgument(!resourceId.isBucket(), "expected object or directory but got '%s'", resourceId);
     return new GoogleCloudStorageItemInfo(
@@ -128,7 +126,6 @@ public class GoogleCloudStorageItemInfo {
    * @param resourceId Resource ID that identifies an inferred directory
    */
   public static GoogleCloudStorageItemInfo createInferredDirectory(StorageResourceId resourceId) {
-    checkNotNull(resourceId, "resourceId must not be null");
     return new GoogleCloudStorageItemInfo(
         resourceId,
         /* creationTime= */ 0,
@@ -150,7 +147,6 @@ public class GoogleCloudStorageItemInfo {
    * @param resourceId Resource ID that identifies an inferred directory
    */
   public static GoogleCloudStorageItemInfo createNotFound(StorageResourceId resourceId) {
-    checkNotNull(resourceId, "resourceId must not be null.");
     return new GoogleCloudStorageItemInfo(
         resourceId,
         /* creationTime= */ 0,
@@ -214,8 +210,7 @@ public class GoogleCloudStorageItemInfo {
       long contentGeneration,
       long metaGeneration,
       VerificationAttributes verificationAttributes) {
-    checkNotNull(resourceId, "resourceId must not be null.");
-    this.resourceId = resourceId;
+    this.resourceId = checkNotNull(resourceId, "resourceId must not be null.");
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
     this.size = size;
@@ -229,16 +224,12 @@ public class GoogleCloudStorageItemInfo {
     this.verificationAttributes = verificationAttributes;
   }
 
-  /**
-   * Gets bucket name of this item.
-   */
+  /** Gets bucket name of this item. */
   public String getBucketName() {
     return resourceId.getBucketName();
   }
 
-  /**
-   * Gets object name of this item.
-   */
+  /** Gets object name of this item. */
   public String getObjectName() {
     return resourceId.getObjectName();
   }
@@ -253,7 +244,7 @@ public class GoogleCloudStorageItemInfo {
   /**
    * Gets creation time of this item.
    *
-   * Time is expressed as milliseconds since January 1, 1970 UTC.
+   * <p>Time is expressed as milliseconds since January 1, 1970 UTC.
    */
   public long getCreationTime() {
     return creationTime;
@@ -268,10 +259,7 @@ public class GoogleCloudStorageItemInfo {
     return modificationTime;
   }
 
-  /**
-   * Gets size of this item (number of bytes). Returns -1 if the object
-   * does not exist.
-   */
+  /** Gets size of this item (number of bytes). Returns -1 if the object does not exist. */
   public long getSize() {
     return size;
   }
@@ -279,7 +267,7 @@ public class GoogleCloudStorageItemInfo {
   /**
    * Gets location of this item.
    *
-   * Note: Location is only supported for buckets. The value is always null for objects.
+   * <p>Note: Location is only supported for buckets. The value is always null for objects.
    */
   public String getLocation() {
     return location;
@@ -288,7 +276,7 @@ public class GoogleCloudStorageItemInfo {
   /**
    * Gets storage class of this item.
    *
-   * Note: Storage-class is only supported for buckets. The value is always null for objects.
+   * <p>Note: Storage-class is only supported for buckets. The value is always null for objects.
    */
   public String getStorageClass() {
     return storageClass;
@@ -315,7 +303,7 @@ public class GoogleCloudStorageItemInfo {
   /**
    * Gets user-supplied metadata for this item.
    *
-   * Note: metadata is only supported for objects. This value is always an empty map for buckets.
+   * <p>Note: metadata is only supported for objects. This value is always an empty map for buckets.
    */
   public Map<String, byte[]> getMetadata() {
     return metadata;
@@ -328,9 +316,7 @@ public class GoogleCloudStorageItemInfo {
     return resourceId.isBucket();
   }
 
-  /**
-   * Indicates whether this item refers to the GCS root (gs://).
-   */
+  /** Indicates whether this item refers to the GCS root (gs://). */
   public boolean isRoot() {
     return resourceId.isRoot();
   }
@@ -348,32 +334,24 @@ public class GoogleCloudStorageItemInfo {
     return isGlobalRoot() || isBucket() || resourceId.isDirectory();
   }
 
-  /**
-   * Indicates whether this item exists.
-   */
-  public boolean exists() {
-    return size >= 0;
-  }
-
-  /**
-   * Get the content generation of the object.
-   */
+  /** Get the content generation of the object. */
   public long getContentGeneration() {
     return contentGeneration;
   }
 
-  /**
-   * Get the meta generation of the object.
-   */
+  /** Get the meta generation of the object. */
   public long getMetaGeneration() {
     return metaGeneration;
   }
 
-  /**
-   * Get object validation attributes.
-   */
+  /** Get object validation attributes. */
   public VerificationAttributes getVerificationAttributes() {
     return verificationAttributes;
+  }
+
+  /** Indicates whether this item exists. */
+  public boolean exists() {
+    return size >= 0;
   }
 
   /**
@@ -405,9 +383,7 @@ public class GoogleCloudStorageItemInfo {
     return true;
   }
 
-  /**
-   * Gets string representation of this instance.
-   */
+  /** Gets string representation of this instance. */
   @Override
   public String toString() {
     return exists()
@@ -421,6 +397,7 @@ public class GoogleCloudStorageItemInfo {
       GoogleCloudStorageItemInfo other = (GoogleCloudStorageItemInfo) obj;
       return resourceId.equals(other.resourceId)
           && creationTime == other.creationTime
+          && modificationTime == other.modificationTime
           && size == other.size
           && Objects.equals(location, other.location)
           && Objects.equals(storageClass, other.storageClass)
@@ -438,6 +415,7 @@ public class GoogleCloudStorageItemInfo {
     int result = 1;
     result = prime * result + resourceId.hashCode();
     result = prime * result + (int) creationTime;
+    result = prime * result + (int) modificationTime;
     result = prime * result + (int) size;
     result = prime * result + Objects.hashCode(location);
     result = prime * result + Objects.hashCode(storageClass);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
@@ -19,6 +19,7 @@ package com.google.cloud.hadoop.gcsio;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Date;
@@ -68,6 +69,7 @@ public class GoogleCloudStorageItemInfo {
       long modificationTime,
       String location,
       String storageClass) {
+    checkNotNull(resourceId, "resourceId must not be null");
     checkArgument(resourceId.isBucket(), "expected bucket but got '%s'", resourceId);
     return new GoogleCloudStorageItemInfo(
         resourceId,
@@ -103,6 +105,7 @@ public class GoogleCloudStorageItemInfo {
       long contentGeneration,
       long metaGeneration,
       VerificationAttributes verificationAttributes) {
+    checkNotNull(resourceId, "resourceId must not be null");
     checkArgument(!resourceId.isRoot(), "expected object or directory but got '%s'", resourceId);
     checkArgument(!resourceId.isBucket(), "expected object or directory but got '%s'", resourceId);
     return new GoogleCloudStorageItemInfo(
@@ -210,7 +213,7 @@ public class GoogleCloudStorageItemInfo {
       long contentGeneration,
       long metaGeneration,
       VerificationAttributes verificationAttributes) {
-    this.resourceId = checkNotNull(resourceId, "resourceId must not be null.");
+    this.resourceId = checkNotNull(resourceId, "resourceId must not be null");
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
     this.size = size;
@@ -359,6 +362,7 @@ public class GoogleCloudStorageItemInfo {
    * this.metadata and otherMetadata, and then using Arrays.equals to compare contents of
    * corresponding byte arrays.
    */
+  @VisibleForTesting
   public boolean metadataEquals(Map<String, byte[]> otherMetadata) {
     if (metadata == otherMetadata) {
       // Fast-path for common cases where the same actual default metadata instance may be used in
@@ -422,7 +426,11 @@ public class GoogleCloudStorageItemInfo {
     result = prime * result + Objects.hashCode(verificationAttributes);
     result = prime * result + (int) metaGeneration;
     result = prime * result + (int) contentGeneration;
-    result = prime * result + metadata.hashCode();
+    result =
+        prime * result
+            + metadata.entrySet().stream()
+                .mapToInt(e -> Objects.hash(e.getKey()) + Arrays.hashCode(e.getValue()))
+                .sum();
     return result;
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ListFileOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ListFileOptions.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.OBJECT_FIELDS;
+
+import com.google.auto.value.AutoValue;
+
+/** Options that can be specified when listing files in the {@link GoogleCloudStorageFileSystem}. */
+@AutoValue
+public abstract class ListFileOptions {
+
+  /** List all files in the directory. */
+  public static final ListFileOptions DEFAULT = builder().build();
+
+  public static Builder builder() {
+    return new AutoValue_ListFileOptions.Builder().setFields(OBJECT_FIELDS);
+  }
+
+  public abstract Builder toBuilder();
+
+  /**
+   * Comma separated list of object fields to include in the list response.
+   *
+   * <p>See <a
+   * href="https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations">
+   * object resource</a> for reference.
+   */
+  public abstract String getFields();
+
+  /** Builder for {@link ListFileOptions} */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setFields(String delimiter);
+
+    public abstract ListFileOptions build();
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ListObjectOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ListObjectOptions.java
@@ -16,6 +16,7 @@ package com.google.cloud.hadoop.gcsio;
 
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorage.MAX_RESULTS_UNLIMITED;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorage.PATH_DELIMITER;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.OBJECT_FIELDS;
 
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
@@ -34,7 +35,8 @@ public abstract class ListObjectOptions {
     return new AutoValue_ListObjectOptions.Builder()
         .setDelimiter(PATH_DELIMITER)
         .setIncludePrefix(false)
-        .setMaxResults(MAX_RESULTS_UNLIMITED);
+        .setMaxResults(MAX_RESULTS_UNLIMITED)
+        .setFields(OBJECT_FIELDS);
   }
 
   public abstract Builder toBuilder();
@@ -49,6 +51,16 @@ public abstract class ListObjectOptions {
   /** Maximum number of results to return, unlimited if negative or zero. */
   public abstract long getMaxResults();
 
+  /**
+   * Comma separated list of object fields to include in the list response.
+   *
+   * <p>See <a
+   * href="https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations">
+   * object resource</a> for reference.
+   */
+  @Nullable
+  public abstract String getFields();
+
   /** Builder for {@link ListObjectOptions} */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -57,6 +69,8 @@ public abstract class ListObjectOptions {
     public abstract Builder setIncludePrefix(boolean includePrefix);
 
     public abstract Builder setMaxResults(long maxResults);
+
+    public abstract Builder setFields(String fields);
 
     public abstract ListObjectOptions build();
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/VerificationAttributes.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/VerificationAttributes.java
@@ -49,7 +49,6 @@ public class VerificationAttributes {
     if (!(o instanceof VerificationAttributes)) {
       return false;
     }
-
     VerificationAttributes that = (VerificationAttributes) o;
     return Arrays.equals(md5hash, that.md5hash) && Arrays.equals(crc32c, that.crc32c);
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationDao.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/cooplock/CoopLockOperationDao.java
@@ -119,7 +119,7 @@ public class CoopLockOperationDao {
                         .setResource(resourceId.toString()))));
     List<String> logRecords =
         Streams.concat(itemsToDelete.stream(), bucketsToDelete.stream())
-            .map(i -> i.getItemInfo().getResourceId().toString())
+            .map(i -> i.getPath().toString())
             .collect(toImmutableList());
     writeOperationFile(
         resourceId.getBucketName(),
@@ -362,7 +362,7 @@ public class CoopLockOperationDao {
   private static RenameOperationLogRecord toRenameOperationLogRecord(
       Map.Entry<FileInfo, URI> record) {
     return new RenameOperationLogRecord()
-        .setSrc(record.getKey().getItemInfo().getResourceId().toString())
+        .setSrc(record.getKey().getPath().toString())
         .setDst(record.getValue().toString());
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FileInfoTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FileInfoTest.java
@@ -14,9 +14,11 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo.ROOT_INFO;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
 import com.google.common.truth.Correspondence;
 import java.net.URI;
 import java.util.Arrays;
@@ -52,5 +54,51 @@ public class FileInfoTest {
         .<byte[], byte[]>comparingValuesUsing(Correspondence.from(Arrays::equals, "Arrays.equals"))
         .containsExactly("foo-meta", new byte[] {5, 66, 56});
     assertThat(fileInfo.getItemInfo()).isEqualTo(itemInfo);
+  }
+
+  @Test
+  public void testEquals() {
+    StorageResourceId testObject = StorageResourceId.fromStringPath("gs://test-bucket/dir/object");
+    new EqualsTester()
+        .addEqualityGroup(FileInfo.fromItemInfo(ROOT_INFO), FileInfo.fromItemInfo(ROOT_INFO))
+        .addEqualityGroup(
+            FileInfo.fromItemInfo(
+                GoogleCloudStorageItemInfo.createObject(
+                    testObject,
+                    /* creationTime= */ 100,
+                    /* modificationTime= */ 1000,
+                    /* size= */ 324,
+                    /* contentType= */ "text",
+                    /* contentEncoding */ "gzip",
+                    /* metadata */ ImmutableMap.of("mkey", new byte[] {1, 6}),
+                    /* contentGeneration= */ 122,
+                    /* metaGeneration= */ 3,
+                    /* verificationAttributes= */ null)))
+        .addEqualityGroup(
+            FileInfo.fromItemInfo(
+                GoogleCloudStorageItemInfo.createObject(
+                    testObject,
+                    /* creationTime= */ 100,
+                    /* modificationTime= */ 1000,
+                    /* size= */ 324,
+                    /* contentType= */ "text",
+                    /* contentEncoding */ "gzip",
+                    /* metadata */ ImmutableMap.of("mky", new byte[] {1, 6}),
+                    /* contentGeneration= */ 122,
+                    /* metaGeneration= */ 3,
+                    /* verificationAttributes= */ null)),
+            FileInfo.fromItemInfo(
+                GoogleCloudStorageItemInfo.createObject(
+                    testObject,
+                    /* creationTime= */ 100,
+                    /* modificationTime= */ 1000,
+                    /* size= */ 324,
+                    /* contentType= */ "text",
+                    /* contentEncoding */ "gzip",
+                    /* metadata */ ImmutableMap.of("mky", new byte[] {1, 6}),
+                    /* contentGeneration= */ 122,
+                    /* metaGeneration= */ 3,
+                    /* verificationAttributes= */ null)))
+        .testEquals();
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfoTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfoTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link GoogleCloudStorageItemInfo} class */
+@RunWith(JUnit4.class)
+public class GoogleCloudStorageItemInfoTest {
+
+  @Test
+  public void testEquals() throws Exception {
+    StorageResourceId testBucket = StorageResourceId.fromStringPath("gs://test-bucket");
+    StorageResourceId testObject = StorageResourceId.fromStringPath("gs://test-bucket/dir/object");
+    StorageResourceId testDirectory =
+        StorageResourceId.fromStringPath("gs://test-bucket/dir/subdir/");
+
+    new EqualsTester()
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.ROOT_INFO, GoogleCloudStorageItemInfo.ROOT_INFO)
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createBucket(
+                testBucket,
+                /* creationTime= */ 1000,
+                /* modificationTime= */ 1200,
+                /* location= */ "US",
+                /* storageClass= */ "standard"),
+            GoogleCloudStorageItemInfo.createBucket(
+                testBucket,
+                /* creationTime= */ 1000,
+                /* modificationTime= */ 1200,
+                /* location= */ "US",
+                /* storageClass= */ "standard"))
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createBucket(
+                testBucket,
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1200,
+                /* location= */ "US",
+                /* storageClass= */ "standard"))
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createBucket(
+                StorageResourceId.fromStringPath("gs://test-bucket-other"),
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1200,
+                /* location= */ "US",
+                /* storageClass= */ "standard"))
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createObject(
+                testObject,
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1000,
+                /* size= */ 324,
+                /* contentType= */ "text",
+                /* contentEncoding */ "gzip",
+                /* metadata */ ImmutableMap.of("mkey", new byte[] {1, 6}),
+                /* contentGeneration= */ 122,
+                /* metaGeneration= */ 3,
+                /* verificationAttributes= */ null))
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createObject(
+                testObject,
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1000,
+                /* size= */ 324,
+                /* contentType= */ "text",
+                /* contentEncoding */ "gzip",
+                /* metadata */ ImmutableMap.of("mkey", new byte[] {1, 6}),
+                /* contentGeneration= */ 122,
+                /* metaGeneration= */ 3,
+                new VerificationAttributes(/* md5hash= */ null, /* crc32c= */ null)))
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createObject(
+                testObject,
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1000,
+                /* size= */ 324,
+                /* contentType= */ "text",
+                /* contentEncoding */ "gzip",
+                /* metadata */ ImmutableMap.of("mkey", new byte[] {1, 6}),
+                /* contentGeneration= */ 122,
+                /* metaGeneration= */ 3,
+                new VerificationAttributes(
+                    /* md5hash= */ new byte[] {1, 6}, /* crc32c= */ new byte[] {10})))
+        .addEqualityGroup(
+            GoogleCloudStorageItemInfo.createObject(
+                testObject,
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1000,
+                /* size= */ 324,
+                /* contentType= */ "text",
+                /* contentEncoding */ "gzip",
+                /* metadata */ ImmutableMap.of("mkey", new byte[] {1, 6}, "akey", new byte[] {9}),
+                /* contentGeneration= */ 122,
+                /* metaGeneration= */ 3,
+                new VerificationAttributes(
+                    /* md5hash= */ new byte[] {1, 6}, /* crc32c= */ new byte[] {11})),
+            GoogleCloudStorageItemInfo.createObject(
+                testObject,
+                /* creationTime= */ 100,
+                /* modificationTime= */ 1000,
+                /* size= */ 324,
+                /* contentType= */ "text",
+                /* contentEncoding */ "gzip",
+                /* metadata */ ImmutableMap.of("akey", new byte[] {9}, "mkey", new byte[] {1, 6}),
+                /* contentGeneration= */ 122,
+                /* metaGeneration= */ 3,
+                new VerificationAttributes(
+                    /* md5hash= */ new byte[] {1, 6}, /* crc32c= */ new byte[] {11})))
+        .addEqualityGroup(GoogleCloudStorageItemInfo.createInferredDirectory(testDirectory))
+        .addEqualityGroup(GoogleCloudStorageItemInfo.createNotFound(testBucket))
+        .addEqualityGroup(GoogleCloudStorageItemInfo.createNotFound(testObject))
+        .addEqualityGroup(GoogleCloudStorageItemInfo.createNotFound(testDirectory))
+        .testEquals();
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -18,8 +18,10 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class GoogleCloudStorageGrpcIntegrationTest {
 
   // Prefix this name with the prefix used in other gcs io integrate tests once it's whitelisted by

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -18,10 +18,8 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class GoogleCloudStorageGrpcIntegrationTest {
 
   // Prefix this name with the prefix used in other gcs io integrate tests once it's whitelisted by

--- a/pom.xml
+++ b/pom.xml
@@ -472,6 +472,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>${google.guava.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
         <version>${google.truth.version}</version>


### PR DESCRIPTION
This PR also fixes `equals` and `hashCode` methods in the `FileInfo` and `GoogleCloudStorageItemInfo` classes and improves their test coverage.