### PR TITLE
Remove obsolete fs.gs.inputstream.buffer.size property

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -132,6 +132,9 @@
 
 1.  Add `FsBenchmark` tool for benchmarking HCFS.
 
+1.  Remove obsolete `fs.gs.inputstream.buffer.size` property and related
+    functionality.
+
 ### 2.1.1 - 2020-03-11
 
 1.  Add upload cache to support high-level retries of failed uploads. Cache size

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -296,10 +296,6 @@ permissions (not authorized) to execute these requests.
 
 ### IO configuration
 
-*   `fs.gs.inputstream.buffer.size` (default: `0`)
-
-    The number of bytes in read buffers.
-
 *   `fs.gs.inputstream.fast.fail.on.not.found.enable` (default: `true`)
 
     If `true`, on opening a file connector will proactively send a Cloud Storage

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -625,9 +625,6 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
   /**
    * Opens the given file for reading.
    *
-   * <p>Note: This function overrides the given bufferSize value with a higher number unless further
-   * overridden using configuration parameter {@code fs.gs.inputstream.buffer.size}.
-   *
    * @param hadoopPath File to open.
    * @param bufferSize Size of buffer to use for IO.
    * @return A readable stream.

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -295,10 +295,6 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Integer> GCS_OUTPUT_STREAM_SYNC_MIN_INTERVAL_MS =
       new HadoopConfigurationProperty<>("fs.gs.outputstream.sync.min.interval.ms", 0);
 
-  /** Configuration key for setting read buffer size. */
-  public static final HadoopConfigurationProperty<Integer> GCS_INPUT_STREAM_BUFFER_SIZE =
-      new HadoopConfigurationProperty<>("fs.gs.inputstream.buffer.size", 0, "fs.gs.io.buffersize");
-
   /**
    * If true, on opening a file we will proactively perform a metadata GET to check whether the
    * object exists, even though the underlying channel will not open a data stream until read() is
@@ -491,7 +487,6 @@ public class GoogleHadoopFileSystemConfiguration {
         .setSupportGzipEncoding(
             GCS_INPUT_STREAM_SUPPORT_GZIP_ENCODING_ENABLE.get(config, config::getBoolean))
         .setInplaceSeekLimit(GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.get(config, config::getLong))
-        .setBufferSize(GCS_INPUT_STREAM_BUFFER_SIZE.get(config, config::getInt))
         .setFadvise(GCS_INPUT_STREAM_FADVISE.get(config, config::getEnum))
         .setMinRangeRequestSize(GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.get(config, config::getInt))
         .setGrpcChecksumsEnabled(GCS_GRPC_CHECKSUMS_ENABLE.get(config, config::getBoolean))

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -80,8 +80,6 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.list.max.items.per.call", 1024L);
           put("fs.gs.max.wait.for.empty.object.creation.ms", 3_000);
           put("fs.gs.marker.file.pattern", null);
-          put("fs.gs.inputstream.buffer.size", 0);
-          put("fs.gs.io.buffersize", 0);
           put("fs.gs.inputstream.fast.fail.on.not.found.enable", true);
           put("fs.gs.inputstream.support.gzip.encoding.enable", false);
           put("fs.gs.outputstream.buffer.size", 8 * 1024 * 1024);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemDelegationTokensTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemDelegationTokensTest.java
@@ -128,7 +128,6 @@ public class GoogleHadoopFileSystemDelegationTokensTest {
     Configuration config = new Configuration();
 
     config.set(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(), "test_project");
-    config.setInt(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getKey(), 512);
     config.setLong(GoogleHadoopFileSystemConfiguration.BLOCK_SIZE.getKey(), 1024);
 
     // Token binding config

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -447,9 +447,6 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
     Configuration config = loadConfig();
 
     // Set up remaining settings to known test values.
-    int bufferSize = 512;
-    config.setInt(
-        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getKey(), bufferSize);
     long blockSize = 1024;
     config.setLong(GoogleHadoopFileSystemConfiguration.BLOCK_SIZE.getKey(), blockSize);
     String rootBucketName = ghfsHelper.getUniqueBucketName("initialize-root");
@@ -461,7 +458,6 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
         fs.getGcsFs().getOptions().getCloudStorageOptions();
 
     // Verify that config settings were set correctly.
-    assertThat(cloudStorageOptions.getReadChannelOptions().getBufferSize()).isEqualTo(bufferSize);
     assertThat(fs.getDefaultBlockSize()).isEqualTo(blockSize);
     assertThat(fs.initUri).isEqualTo(initUri);
     assertThat(fs.getRootBucketName()).isEqualTo(rootBucketName);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -154,8 +154,9 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     GoogleCloudStorageOptions cloudStorageOptions =
         myghfs.getGcsFs().getOptions().getCloudStorageOptions();
 
-    assertThat(cloudStorageOptions.getReadChannelOptions().getBufferSize())
-        .isEqualTo(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getDefault());
+    assertThat(cloudStorageOptions.getReadChannelOptions().getInplaceSeekLimit())
+        .isEqualTo(
+            GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getDefault());
     assertThat(myghfs.getDefaultBlockSize())
         .isEqualTo(GoogleHadoopFileSystemConfiguration.BLOCK_SIZE.getDefault());
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationHelper.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationHelper.java
@@ -196,10 +196,7 @@ public class HadoopFileSystemIntegrationHelper
     StringBuilder returnBuffer = new StringBuilder();
 
     try {
-      readStream =
-          ghfs.open(
-              hadoopPath,
-              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getDefault());
+      readStream = ghfs.open(hadoopPath);
       int numBytesRead = readStream.read(readBuffer);
       while (numBytesRead > 0) {
         returnBuffer.append(new String(readBuffer, 0, numBytesRead, StandardCharsets.UTF_8));
@@ -249,10 +246,7 @@ public class HadoopFileSystemIntegrationHelper
       int bufferSize = len;
       bufferSize += checkOverflow ? 1 : 0;
       byte[] readBuffer = new byte[bufferSize];
-      readStream =
-          ghfs.open(
-              hadoopPath,
-              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getDefault());
+      readStream = ghfs.open(hadoopPath);
       int numBytesRead;
       if (offset > 0) {
         numBytesRead = readStream.read(offset, readBuffer, 0, bufferSize);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
@@ -281,10 +281,7 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
     URI path = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
     Path hadoopPath = ghfsHelper.castAsHadoopPath(path);
     ghfsHelper.writeFile(hadoopPath, "file text", 1, /* overwrite= */ true);
-    FSDataInputStream readStream =
-        ghfs.open(
-            hadoopPath,
-            GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getDefault());
+    FSDataInputStream readStream = ghfs.open(hadoopPath);
     byte[] buffer = new byte[1];
 
     // Verify that normal read works.
@@ -465,10 +462,7 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
     int numBytesWritten = ghfsHelper.writeFile(hadoopPath, text, 1, /* overwrite= */ false);
 
     // Verify that position is at 0 for a newly opened stream.
-    try (FSDataInputStream readStream =
-        ghfs.open(
-            hadoopPath,
-            GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_BUFFER_SIZE.getDefault())) {
+    try (FSDataInputStream readStream = ghfs.open(hadoopPath)) {
       assertThat(readStream.getPos()).isEqualTo(0);
 
       // Verify that position advances by 2 after reading 2 bytes.

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -42,7 +42,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.flogger.GoogleLogger;
-import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -1013,21 +1012,9 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
 
     try {
       InputStream contentStream = response.getContent();
-      if (readOptions.getBufferSize() > 0) {
-        int bufferSize = readOptions.getBufferSize();
-        // limit buffer size to the channel end
-        bufferSize =
-            Math.toIntExact(Math.min(bufferSize, contentChannelEnd - contentChannelPosition));
-        logger.atFine().log(
-            "Opened stream from %d position with %s range, %d bytesToRead"
-                + " and %d bytes buffer for '%s'",
-            currentPosition, rangeHeader, bytesToRead, bufferSize, resourceId);
-        contentStream = new BufferedInputStream(contentStream, bufferSize);
-      } else {
-        logger.atFine().log(
-            "Opened stream from %d position with %s range and %d bytesToRead for '%s'",
-            currentPosition, rangeHeader, bytesToRead, resourceId);
-      }
+      logger.atFine().log(
+          "Opened stream from %d position with %s range and %d bytesToRead for '%s'",
+          currentPosition, rangeHeader, bytesToRead, resourceId);
 
       if (contentChannelPosition < currentPosition) {
         long bytesToSkip = currentPosition - contentChannelPosition;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -42,8 +42,7 @@ public abstract class GoogleCloudStorageReadOptions {
   public static final int DEFAULT_BACKOFF_MAX_ELAPSED_TIME_MILLIS = 2 * 60 * 1000;
   public static final boolean DEFAULT_FAST_FAIL_ON_NOT_FOUND = true;
   public static final boolean DEFAULT_SUPPORT_GZIP_ENCODING = true;
-  public static final int DEFAULT_BUFFER_SIZE = 0;
-  public static final long DEFAULT_INPLACE_SEEK_LIMIT = 0L;
+  public static final long DEFAULT_INPLACE_SEEK_LIMIT = 8 * 1024 * 1024;
   public static final Fadvise DEFAULT_FADVISE = Fadvise.SEQUENTIAL;
   public static final int DEFAULT_MIN_RANGE_REQUEST_SIZE = 512 * 1024;
   public static final boolean GRPC_CHECKSUMS_ENABLED_DEFAULT = false;
@@ -61,7 +60,6 @@ public abstract class GoogleCloudStorageReadOptions {
         .setBackoffMaxElapsedTimeMillis(DEFAULT_BACKOFF_MAX_ELAPSED_TIME_MILLIS)
         .setFastFailOnNotFound(DEFAULT_FAST_FAIL_ON_NOT_FOUND)
         .setSupportGzipEncoding(DEFAULT_SUPPORT_GZIP_ENCODING)
-        .setBufferSize(DEFAULT_BUFFER_SIZE)
         .setInplaceSeekLimit(DEFAULT_INPLACE_SEEK_LIMIT)
         .setFadvise(DEFAULT_FADVISE)
         .setMinRangeRequestSize(DEFAULT_MIN_RANGE_REQUEST_SIZE)
@@ -90,9 +88,6 @@ public abstract class GoogleCloudStorageReadOptions {
 
   /** See {@link Builder#setSupportGzipEncoding}. */
   public abstract boolean getSupportGzipEncoding();
-
-  /** See {@link Builder#setBufferSize}. */
-  public abstract int getBufferSize();
 
   /** See {@link Builder#setInplaceSeekLimit}. */
   public abstract long getInplaceSeekLimit();
@@ -163,14 +158,6 @@ public abstract class GoogleCloudStorageReadOptions {
     public abstract Builder setSupportGzipEncoding(boolean supportGzipEncoding);
 
     /**
-     * If set to a positive value, low-level streams will be wrapped inside a BufferedInputStream of
-     * this size. Otherwise no buffer will be created to wrap the low-level streams. Note that the
-     * low-level streams may or may not have their own additional buffering layers independent of
-     * this setting.
-     */
-    public abstract Builder setBufferSize(int bufferSize);
-
-    /**
      * If seeking to a new position which is within this number of bytes in front of the current
      * position, then we will skip forward by reading and discarding the necessary amount of bytes
      * rather than trying to open a brand-new underlying stream.
@@ -186,7 +173,7 @@ public abstract class GoogleCloudStorageReadOptions {
      *   <li>{@code AUTO} - automatically switches to {@code RANDOM} mode if backward read or
      *       forward read for more than {@link #setInplaceSeekLimit} bytes is detected.
      *   <li>{@code RANDOM} - sends HTTP requests with {@code Range} header set to greater of
-     *       provided reade buffer by user or {@link #setBufferSize}.
+     *       provided reade buffer by user.
      *   <li>{@code SEQUENTIAL} - sends HTTP requests with unbounded {@code Range} header.
      * </ul>
      */

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -168,6 +168,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
         GoogleCloudStorageReadOptions.builder()
             .setFadvise(Fadvise.RANDOM)
             .setGrpcChecksumsEnabled(true)
+            .setInplaceSeekLimit(5)
             .build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
 
@@ -195,6 +196,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
         GoogleCloudStorageReadOptions.builder()
             .setFadvise(Fadvise.RANDOM)
             .setGrpcChecksumsEnabled(true)
+            .setInplaceSeekLimit(5)
             .build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
 
@@ -236,6 +238,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
         GoogleCloudStorageReadOptions.builder()
             .setFadvise(Fadvise.RANDOM)
             .setGrpcChecksumsEnabled(true)
+            .setInplaceSeekLimit(5)
             .build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
 
@@ -292,7 +295,9 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   @Test
   public void readSucceedsAfterSeek() throws Exception {
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(100).build());
-    GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
+    GoogleCloudStorageReadOptions options =
+        GoogleCloudStorageReadOptions.builder().setInplaceSeekLimit(10).build();
+    GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
 
     ByteBuffer buffer = ByteBuffer.allocate(10);
     readChannel.position(50);
@@ -688,13 +693,13 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     assertFalse(readChannel.isOpen());
   }
 
+  private GoogleCloudStorageGrpcReadChannel newReadChannel() throws IOException {
+    return newReadChannel(GoogleCloudStorageReadOptions.DEFAULT);
+  }
+
   private GoogleCloudStorageGrpcReadChannel newReadChannel(GoogleCloudStorageReadOptions options)
       throws IOException {
     return GoogleCloudStorageGrpcReadChannel.open(stub, BUCKET_NAME, OBJECT_NAME, options);
-  }
-
-  private GoogleCloudStorageGrpcReadChannel newReadChannel() throws IOException {
-    return newReadChannel(GoogleCloudStorageReadOptions.DEFAULT);
   }
 
   private static class FakeService extends StorageImplBase {


### PR DESCRIPTION
This PR sets in-place seek limit in GCSIO to the same value as in GCS connector (8 MiB)