### PR TITLE
Remove obsolete counters

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -32,9 +32,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  // Instance of GoogleHadoopFileSystemBase.
-  private GoogleHadoopFileSystemBase ghfs;
-
   // All store IO access goes through this.
   private final SeekableByteChannel channel;
 
@@ -47,9 +44,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
   // Statistics tracker provided by the parent GoogleHadoopFileSystemBase for recording
   // numbers of bytes read.
   private final FileSystem.Statistics statistics;
-
-  // Time of initialization
-  private long initTime;
 
   // Used for single-byte reads.
   private final byte[] singleReadBuf = new byte[1];
@@ -70,10 +64,8 @@ class GoogleHadoopFSInputStream extends FSInputStream {
       throws IOException {
     logger.atFine().log(
         "GoogleHadoopFSInputStream(gcsPath: %s, readOptions: %s)", gcsPath, readOptions);
-    this.ghfs = ghfs;
     this.gcsPath = gcsPath;
     this.statistics = statistics;
-    this.initTime = System.nanoTime();
     this.totalBytesRead = 0;
     this.channel = ghfs.getGcsFs().open(gcsPath, readOptions);
   }
@@ -86,8 +78,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
    */
   @Override
   public synchronized int read() throws IOException {
-    long startTime = System.nanoTime();
-
     // TODO(user): Wrap this in a while-loop if we ever introduce a non-blocking mode for the
     // underlying channel.
     int numRead = channel.read(ByteBuffer.wrap(singleReadBuf));
@@ -105,9 +95,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
     totalBytesRead++;
     statistics.incrementBytesRead(1);
     statistics.incrementReadOps(1);
-    long duration = System.nanoTime() - startTime;
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ1);
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ1_TIME, duration);
     return (b & 0xff);
   }
 
@@ -123,7 +110,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
    */
   @Override
   public synchronized int read(byte[] buf, int offset, int length) throws IOException {
-    long startTime = System.nanoTime();
     Preconditions.checkNotNull(buf, "buf must not be null");
     if (offset < 0 || length < 0 || length > buf.length - offset) {
       throw new IndexOutOfBoundsException();
@@ -138,9 +124,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
       totalBytesRead += numRead;
     }
 
-    long duration = System.nanoTime() - startTime;
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ);
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ_TIME, duration);
     return numRead;
   }
 
@@ -159,7 +142,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
   @Override
   public synchronized int read(long position, byte[] buf, int offset, int length)
       throws IOException {
-    long startTime = System.nanoTime();
     int result = super.read(position, buf, offset, length);
 
     if (result > 0) {
@@ -167,10 +149,6 @@ class GoogleHadoopFSInputStream extends FSInputStream {
       statistics.incrementBytesRead(result);
       totalBytesRead += result;
     }
-
-    long duration = System.nanoTime() - startTime;
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ_POS);
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ_POS_TIME, duration);
     return result;
   }
 
@@ -195,16 +173,12 @@ class GoogleHadoopFSInputStream extends FSInputStream {
    */
   @Override
   public synchronized void seek(long pos) throws IOException {
-    long startTime = System.nanoTime();
     logger.atFine().log("seek(%d)", pos);
     try {
       channel.position(pos);
     } catch (IllegalArgumentException e) {
       throw new IOException(e);
     }
-    long duration = System.nanoTime() - startTime;
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.SEEK);
-    ghfs.increment(GoogleHadoopFileSystemBase.Counter.SEEK_TIME, duration);
   }
 
   /**
@@ -226,15 +200,8 @@ class GoogleHadoopFSInputStream extends FSInputStream {
   public synchronized void close() throws IOException {
     logger.atFinest().log("close(): %s", gcsPath);
     if (channel != null) {
-      long startTime = System.nanoTime();
       logger.atFine().log("Closing '%s' file with %d total bytes read", gcsPath, totalBytesRead);
       channel.close();
-      long duration = System.nanoTime() - startTime;
-      ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ_CLOSE);
-      ghfs.increment(GoogleHadoopFileSystemBase.Counter.READ_CLOSE_TIME, duration);
-      long streamDuration = System.nanoTime() - initTime;
-      ghfs.increment(GoogleHadoopFileSystemBase.Counter.INPUT_STREAM);
-      ghfs.increment(GoogleHadoopFileSystemBase.Counter.INPUT_STREAM_TIME, streamDuration);
     }
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -91,12 +91,6 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
         /** Perform clean-up once after all tests are turn. */
         @Override
         public void after() {
-          if (ghfs != null) {
-            // For GHFS tests, print the counter values to stdout.
-            // We cannot use ghfs.logCounters() because we disable logging for tests.
-            String countersStr = ((GoogleHadoopFileSystemBase) ghfs).countersToString();
-            System.out.println(countersStr);
-          }
           HadoopFileSystemTestBase.storageResource.after();
         }
       };

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -138,9 +138,7 @@ public class FileInfo {
     return itemInfo;
   }
 
-  /**
-   * Gets string representation of this instance.
-   */
+  /** Gets string representation of this instance. */
   public String toString() {
     return getPath() + (exists() ? ": created on: " + new Date(getCreationTime()) : ": exists: no");
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -244,8 +244,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
         requestStreamObserver.onNext(insertRequest);
         objectFinalized = insertRequest.getFinishWrite();
 
-        if (responseObserver.hasTransientError()
-            || responseObserver.hasNonTransientError()) {
+        if (responseObserver.hasTransientError() || responseObserver.hasNonTransientError()) {
           requestStreamObserver.onError(
               responseObserver.hasTransientError()
                   ? responseObserver.transientError
@@ -365,7 +364,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
           throw new IOException(
               String.format("Resumable upload failed for '%s'", getResourceString()),
               nonTransientError);
-      }
+        }
         return checkNotNull(response, "Response not present for '%s'", resourceId);
       }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1226,7 +1226,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
         listedPrefixes != null && listedPrefixes.isEmpty(),
         "Must provide a non-null empty container for listedPrefixes.");
 
-    // List +1 object if prefix is not included in the result, because GCS always includes prefix object
+    // List +1 object if prefix is not included in the result,
+    // because GCS always includes prefix object
     // in the result if it exists and we filter it out.
     //
     // Example:
@@ -1237,9 +1238,9 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     //   gs://bucket/a/c
     //
     // In response to `gs://bucket/a/` list request with max results set to `1` GCS will return only
-    // `gs://bucket/a/` object. But this object will be filterred out from response if `isIncludePrefix`
-    // is set to `false`.
-    // 
+    // `gs://bucket/a/` object. But this object will be filterred out from response if
+    // `isIncludePrefix` is set to `false`.
+    //
     // To prevent this situation we increment max results by 1, which will allow to list
     // `gs://bucket/a/b` in the above case.
     long maxResults =

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ObjectWriteConditions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ObjectWriteConditions.java
@@ -21,8 +21,8 @@ import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
 /**
- * Conditions on which a object write should be allowed to continue. Corresponds to setting
- * {@code IfGenerationMatch} and {@code IfMetaGenerationMatch} in API requests.
+ * Conditions on which a object write should be allowed to continue. Corresponds to setting {@code
+ * IfGenerationMatch} and {@code IfMetaGenerationMatch} in API requests.
  */
 @AutoValue
 public abstract class ObjectWriteConditions {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -13,8 +13,6 @@
  */
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -34,8 +34,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -161,9 +161,7 @@ public class GoogleCloudStorageGrpcIntegrationTest {
         assertThat(bytesRead).isEqualTo(segmentSize);
         byte[] expectedSegment =
             Arrays.copyOfRange(
-                data,
-                /* from= */ i * segmentSize,
-                /* to= */ i * segmentSize + segmentSize);
+                data, /* from= */ i * segmentSize, /* to= */ i * segmentSize + segmentSize);
         assertWithMessage("Unexpected segment data read.")
             .that(readSegments[i])
             .isEqualTo(expectedSegment);


### PR DESCRIPTION
These counters are not used now and we should use new Hadoop [StorageStatistics](https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/fs/StorageStatistics.html) instead if necessary.

This PR has minor misc #cleanup changes too.