### PR TITLE
Add Hadoop Service lifecycle support for delegation token binding integrations

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -121,6 +121,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.service.ServiceStateException;
 import org.apache.hadoop.util.Progressable;
 
 /**
@@ -482,6 +483,7 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
     dts.bindToFileSystem(this, service);
     try {
       dts.init(config);
+      dts.start();
       delegationTokens = dts;
       if (delegationTokens.isBoundToDT()) {
         logger.atFine().log(
@@ -489,8 +491,18 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
                 + " using existing delegation token",
             config, path);
       }
-    } catch (IllegalStateException e) {
+    } catch (ServiceStateException | IllegalStateException e) {
       logger.atFiner().withCause(e).log("Failed to initialize delegation token support");
+    }
+  }
+
+  private void stopDelegationTokens() {
+    if (delegationTokens != null) {
+      try {
+        delegationTokens.close();
+      } catch (IOException e) {
+        logger.atSevere().withCause(e).log("Failed to stop delegation tokens support");
+      }
     }
   }
 
@@ -1580,6 +1592,8 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
       }
       gcsFsSupplier = null;
     }
+
+    stopDelegationTokens();
   }
 
   @Override

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -491,7 +491,7 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
                 + " using existing delegation token",
             config, path);
       }
-    } catch (ServiceStateException | IllegalStateException e) {
+    } catch (IllegalStateException | ServiceStateException e) {
       logger.atFiner().withCause(e).log("Failed to initialize delegation token support");
     }
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/AbstractDelegationTokenBinding.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/AbstractDelegationTokenBinding.java
@@ -27,11 +27,14 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
+import org.apache.hadoop.service.AbstractService;
 
 /** Binds file system with service and access token provider */
-public abstract class AbstractDelegationTokenBinding {
+public abstract class AbstractDelegationTokenBinding extends AbstractService {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private static final String SERVICE_NAME = "DelegationTokenBinding";
 
   private final Text kind;
 
@@ -45,6 +48,11 @@ public abstract class AbstractDelegationTokenBinding {
   private GoogleHadoopFileSystemBase fileSystem;
 
   protected AbstractDelegationTokenBinding(Text kind) {
+    this(SERVICE_NAME, kind);
+  }
+
+  protected AbstractDelegationTokenBinding(String name, Text kind) {
+    super(name);
     this.kind = kind;
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GcsDelegationTokens.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GcsDelegationTokens.java
@@ -31,9 +31,11 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.delegation.web.DelegationTokenIdentifier;
+import org.apache.hadoop.service.AbstractService;
+import org.apache.hadoop.service.ServiceOperations;
 
 /** Manages delegation tokens for files system */
-public class GcsDelegationTokens {
+public class GcsDelegationTokens extends AbstractService {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
@@ -56,10 +58,11 @@ public class GcsDelegationTokens {
   private Token<DelegationTokenIdentifier> boundDT = null;
 
   public GcsDelegationTokens() throws IOException {
+    super("GCSDelegationTokens");
     user = UserGroupInformation.getCurrentUser();
   }
 
-  public void init(Configuration conf) {
+  public void serviceInit(final Configuration conf) throws Exception {
     String tokenBindingImpl = conf.get(DELEGATION_TOKEN_BINDING_CLASS.getKey());
 
     checkState(tokenBindingImpl != null, "Delegation Tokens are not configured");
@@ -69,13 +72,33 @@ public class GcsDelegationTokens {
       AbstractDelegationTokenBinding binding =
           (AbstractDelegationTokenBinding) bindingClass.getDeclaredConstructor().newInstance();
       binding.bindToFileSystem(fileSystem, getService());
+      binding.init(conf);
       tokenBinding = binding;
       logger.atFine().log(
           "Filesystem %s is using delegation tokens of kind %s",
           getService(), tokenBinding.getKind());
-      bindToAnyDelegationToken();
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void serviceStart() throws Exception {
+    super.serviceStart();
+    tokenBinding.start();
+    bindToAnyDelegationToken();
+    logger.atFine().log("GCS Delegation support token %s with %s",
+                        (isBoundToDT() ? getBoundDT().decodeIdentifier().toString() : "none"),
+                        tokenBinding.getService().toString());
+  }
+
+  @Override
+  protected void serviceStop() throws Exception {
+    logger.atFine().log("Stopping GCS delegation tokens");
+    try {
+      super.serviceStop();
+    } finally {
+      ServiceOperations.stopQuietly(tokenBinding);
     }
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GcsDelegationTokens.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/auth/GcsDelegationTokens.java
@@ -62,7 +62,8 @@ public class GcsDelegationTokens extends AbstractService {
     user = UserGroupInformation.getCurrentUser();
   }
 
-  public void serviceInit(final Configuration conf) throws Exception {
+  @Override
+  public void serviceInit(Configuration conf) throws Exception {
     String tokenBindingImpl = conf.get(DELEGATION_TOKEN_BINDING_CLASS.getKey());
 
     checkState(tokenBindingImpl != null, "Delegation Tokens are not configured");
@@ -87,9 +88,9 @@ public class GcsDelegationTokens extends AbstractService {
     super.serviceStart();
     tokenBinding.start();
     bindToAnyDelegationToken();
-    logger.atFine().log("GCS Delegation support token %s with %s",
-                        (isBoundToDT() ? getBoundDT().decodeIdentifier().toString() : "none"),
-                        tokenBinding.getService().toString());
+    logger.atFine().log(
+        "GCS Delegation support token %s with %s",
+        isBoundToDT() ? getBoundDT().decodeIdentifier() : "none", tokenBinding.getService());
   }
 
   @Override

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -201,10 +201,10 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
 
     // Token binding config
     config.set(
-            DELEGATION_TOKEN_BINDING_CLASS.getKey(), TestDelegationTokenBindingImpl.class.getName());
+        DELEGATION_TOKEN_BINDING_CLASS.getKey(), TestDelegationTokenBindingImpl.class.getName());
     config.set(
-            TestDelegationTokenBindingImpl.TestAccessTokenProviderImpl.TOKEN_CONFIG_PROPERTY_NAME,
-            "qWDAWFA3WWFAWFAWFAW3FAWF3AWF3WFAF33GR5G5"); // Bogus auth token
+        TestDelegationTokenBindingImpl.TestAccessTokenProviderImpl.TOKEN_CONFIG_PROPERTY_NAME,
+        "qWDAWFA3WWFAWFAWFAW3FAWF3AWF3WFAF33GR5G5"); // Bogus auth token
 
     GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem();
     fs.initialize(fs.getUri(), config);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.service.Service;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -192,6 +193,25 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
             IllegalArgumentException.class,
             () -> myGhfs.initialize(incorrectUri, new Configuration()));
     assertThat(exception).hasMessageThat().startsWith("scheme of path must not be null");
+  }
+
+  @Test
+  public void initialize_delegationTokensServiceLifecycle() throws Exception {
+    Configuration config = new Configuration();
+
+    // Token binding config
+    config.set(
+            DELEGATION_TOKEN_BINDING_CLASS.getKey(), TestDelegationTokenBindingImpl.class.getName());
+    config.set(
+            TestDelegationTokenBindingImpl.TestAccessTokenProviderImpl.TOKEN_CONFIG_PROPERTY_NAME,
+            "qWDAWFA3WWFAWFAWFAW3FAWF3AWF3WFAF33GR5G5"); // Bogus auth token
+
+    GoogleHadoopFileSystem fs = new GoogleHadoopFileSystem();
+    fs.initialize(fs.getUri(), config);
+    assertThat(Service.STATE.STARTED).isEqualTo(fs.delegationTokens.getServiceState());
+
+    fs.close();
+    assertThat(Service.STATE.STOPPED).isEqualTo(fs.delegationTokens.getServiceState());
   }
 
   @Test


### PR DESCRIPTION
This change adds Hadoop Service lifecycle support for delegation token bindings integrations, such that these integrations can respond to lifecycle events from the FileSystem implementations.

This is especially helpful for allowing delegation token binding implementations the opportunity to clean up any resources they've allocated when the associated FileSystem instance is closed.

This change also aligns the GoogleHadoopFileSystem more closely with the corresponding Hadoop FileSystem implementations for S3 and ABFS, which already support this Service lifecycle facility.