### PR TITLE
Do not initialize perf cache with list request during get call

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest.java
@@ -92,12 +92,6 @@ public class GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest {
             getRequestString(TEST_BUCKET, file),
             getRequestString(TEST_BUCKET, file),
             listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
                 TEST_BUCKET, file + "/", /* maxResults= */ 1, /* pageToken= */ null),
             listRequestWithTrailingDelimiter(
                 TEST_BUCKET, file + "/", /* maxResults= */ 1, /* pageToken= */ null),
@@ -130,12 +124,6 @@ public class GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest {
             getRequestString(TEST_BUCKET, file),
             getRequestString(TEST_BUCKET, file),
             getRequestString(TEST_BUCKET, file),
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
             listRequestWithTrailingDelimiter(
                 TEST_BUCKET, file + "/", /* maxResults= */ 1, /* pageToken= */ null),
             listRequestWithTrailingDelimiter(
@@ -170,8 +158,6 @@ public class GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest {
             getRequestString(TEST_BUCKET, file),
             getRequestString(TEST_BUCKET, file),
             listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
                 TEST_BUCKET, file + "/", /* maxResults= */ 1, /* pageToken= */ null),
             listRequestWithTrailingDelimiter(
                 TEST_BUCKET, file + "/", /* maxResults= */ 1, /* pageToken= */ null),
@@ -203,8 +189,7 @@ public class GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest {
 
     assertThat(trackingGcsfs.requestsTracker.getAllRequestStrings())
         .containsExactly(
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
+            getRequestString(TEST_BUCKET, file),
             listRequestWithTrailingDelimiter(
                 TEST_BUCKET, file + "/", /* maxResults= */ 1, /* pageToken= */ null));
   }
@@ -274,8 +259,7 @@ public class GoogleCloudStorageFileSystemPerformanceCacheIntegrationTest {
 
     assertThat(trackingGcsfs.requestsTracker.getAllRequestStrings())
         .containsExactly(
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDir + "/", /* maxResults= */ 1024, /* pageToken= */ null),
+            getRequestString(TEST_BUCKET, dir),
             listRequestWithTrailingDelimiter(
                 TEST_BUCKET, dir + "/", /* maxResults= */ 1, /* pageToken= */ null));
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageIntegrationTest.java
@@ -14,7 +14,7 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestWithTrailingDelimiter;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getStandardOptionBuilder;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -64,9 +64,9 @@ public class PerformanceCachingGoogleCloudStorageIntegrationTest {
   }
 
   @Test
-  public void getItemInfo_multipleCalls_oneGcsListRequest() throws Exception {
-    String parentDirName = name.getMethodName();
-    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, parentDirName + "/object");
+  public void getItemInfo_multipleCalls_oneGcsGetRequest() throws Exception {
+    String objectName = name.getMethodName() + "/object";
+    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, objectName);
 
     TrackingStorageWrapper<PerformanceCachingGoogleCloudStorage> trackingGcs =
         newTrackingGoogleCloudStorage(GCS_OPTIONS);
@@ -82,9 +82,7 @@ public class PerformanceCachingGoogleCloudStorageIntegrationTest {
     assertThat(object1).isSameInstanceAs(object3);
 
     assertThat(trackingGcs.requestsTracker.getAllRequestStrings())
-        .containsExactly(
-            listRequestWithTrailingDelimiter(
-                TEST_BUCKET, parentDirName + "/", /* maxResults= */ 1024, /* pageToken= */ null));
+        .containsExactly(getRequestString(TEST_BUCKET, objectName));
   }
 
   private static TrackingStorageWrapper<PerformanceCachingGoogleCloudStorage>


### PR DESCRIPTION
This could be too costly in some cases and does not provide additional cache hits.