### PR TITLE
Remove redundant delete calls for inferred directories

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -70,13 +70,6 @@ public class FileInfo {
   }
 
   /**
-   * Indicates whether this item is an inferred directory.
-   */
-  public boolean isInferredDirectory() {
-    return itemInfo.isInferredDirectory();
-  }
-
-  /**
    * Indicates whether this instance has information about the unique, shared root of the
    * underlying storage system.
    */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -69,9 +69,7 @@ public class FileInfo {
     return itemInfo.isDirectory();
   }
 
-  /**
-   * Indicates whether this item is an inferred directory.
-   */
+  /** Indicates whether this item is an inferred directory. */
   public boolean isInferredDirectory() {
     return itemInfo.isInferredDirectory();
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileInfo.java
@@ -70,6 +70,13 @@ public class FileInfo {
   }
 
   /**
+   * Indicates whether this item is an inferred directory.
+   */
+  public boolean isInferredDirectory() {
+    return itemInfo.isInferredDirectory();
+  }
+
+  /**
    * Indicates whether this instance has information about the unique, shared root of the
    * underlying storage system.
    */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -395,13 +395,11 @@ public class GoogleCloudStorageFileSystem {
       List<StorageResourceId> objectsToDelete = new ArrayList<>(itemsToDelete.size());
       for (FileInfo fileInfo : itemsToDelete) {
         // TODO(b/110833109): populate generation ID in StorageResourceId when listing infos?
-        if (!fileInfo.isInferredDirectory()) {
-          objectsToDelete.add(
-              new StorageResourceId(
-                  fileInfo.getItemInfo().getBucketName(),
-                  fileInfo.getItemInfo().getObjectName(),
-                  fileInfo.getItemInfo().getContentGeneration()));
-        }
+        objectsToDelete.add(
+            new StorageResourceId(
+                fileInfo.getItemInfo().getBucketName(),
+                fileInfo.getItemInfo().getObjectName(),
+                fileInfo.getItemInfo().getContentGeneration()));
       }
       gcs.deleteObjects(objectsToDelete);
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -395,11 +395,13 @@ public class GoogleCloudStorageFileSystem {
       List<StorageResourceId> objectsToDelete = new ArrayList<>(itemsToDelete.size());
       for (FileInfo fileInfo : itemsToDelete) {
         // TODO(b/110833109): populate generation ID in StorageResourceId when listing infos?
-        objectsToDelete.add(
-            new StorageResourceId(
-                fileInfo.getItemInfo().getBucketName(),
-                fileInfo.getItemInfo().getObjectName(),
-                fileInfo.getItemInfo().getContentGeneration()));
+        if (!fileInfo.isInferredDirectory()) {
+          objectsToDelete.add(
+              new StorageResourceId(
+                  fileInfo.getItemInfo().getBucketName(),
+                  fileInfo.getItemInfo().getObjectName(),
+                  fileInfo.getItemInfo().getContentGeneration()));
+        }
       }
       gcs.deleteObjects(objectsToDelete);
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
@@ -337,15 +337,13 @@ public class GoogleCloudStorageItemInfo {
     return isGlobalRoot() || isBucket() || resourceId.isDirectory();
   }
 
-  /**
-   *  Indicates whether {@code itemInfo} is an inferred directory
-   */
+  /** Indicates whether {@code itemInfo} is an inferred directory */
   public boolean isInferredDirectory() {
-    return creationTime == 0 &&
-        modificationTime == 0 &&
-        size == 0 &&
-        contentGeneration == 0 &&
-        metaGeneration == 0;
+    return creationTime == 0
+        && modificationTime == 0
+        && size == 0
+        && contentGeneration == 0
+        && metaGeneration == 0;
   }
 
   /** Get the content generation of the object. */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
@@ -337,6 +337,17 @@ public class GoogleCloudStorageItemInfo {
     return isGlobalRoot() || isBucket() || resourceId.isDirectory();
   }
 
+  /**
+   *  Indicates whether {@code itemInfo} is an inferred directory
+   */
+  public boolean isInferredDirectory() {
+    return creationTime == 0 &&
+        modificationTime == 0 &&
+        size == 0 &&
+        contentGeneration == 0 &&
+        metaGeneration == 0;
+  }
+
   /** Get the content generation of the object. */
   public long getContentGeneration() {
     return contentGeneration;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageItemInfo.java
@@ -337,17 +337,6 @@ public class GoogleCloudStorageItemInfo {
     return isGlobalRoot() || isBucket() || resourceId.isDirectory();
   }
 
-  /**
-   *  Indicates whether {@code itemInfo} is an inferred directory
-   */
-  public boolean isInferredDirectory() {
-    return creationTime == 0 &&
-        modificationTime == 0 &&
-        size == 0 &&
-        contentGeneration == 0 &&
-        metaGeneration == 0;
-  }
-
   /** Get the content generation of the object. */
   public long getContentGeneration() {
     return contentGeneration;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -712,7 +712,7 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
   }
 
   @Test
-  public void delete_inferred_directory() throws Exception {
+  public void delete_inferredDirectory() throws Exception {
     GoogleCloudStorageFileSystemOptions gcsFsOptions =
         newGcsFsOptions().setStatusParallelEnabled(false).build();
 
@@ -724,7 +724,8 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
     URI bucketUri = new URI("gs://" + bucketName + "/");
     String dirObject = getTestResource();
 
-    gcsfsIHelper.createObjects(bucketName, dirObject + "/d1/d2");
+    gcsfsIHelper.createObjects(bucketName, dirObject + "/");
+    gcsfsIHelper.createObjects(bucketName, dirObject + "/d1/f1");
 
     gcsFs.delete(bucketUri.resolve(dirObject + "/d1/"), /* recursive= */ true);
 
@@ -740,11 +741,10 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
                 "bucket,name,generation",
                 /* maxResults= */ 1024,
                 /* pageToken= */ null),
-            deleteRequestString(bucketName, dirObject + "/d1/d2", /* generationId= */ 1),
-            getRequestString(bucketName, dirObject + "/"),
-            uploadRequestString(bucketName, dirObject + "/", /* generationId= */ null));
+            deleteRequestString(bucketName, dirObject + "/d1/f1", /* generationId= */ 1),
+            getRequestString(bucketName, dirObject + "/"));
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/"))).isFalse();
-    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/d2"))).isFalse();
+    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/f1"))).isFalse();
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
-import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -748,43 +748,6 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
   }
 
   @Test
-  public void delete_inferred_directory_with_parent() throws Exception {
-    GoogleCloudStorageFileSystemOptions gcsFsOptions =
-        newGcsFsOptions().setStatusParallelEnabled(false).build();
-
-    TrackingHttpRequestInitializer gcsRequestsTracker =
-        new TrackingHttpRequestInitializer(httpRequestsInitializer);
-    GoogleCloudStorageFileSystem gcsFs = newGcsFs(gcsFsOptions, gcsRequestsTracker);
-
-    String bucketName = gcsfsIHelper.sharedBucketName1;
-    URI bucketUri = new URI("gs://" + bucketName + "/");
-    String dirObject = getTestResource();
-
-    gcsfsIHelper.createObjects(bucketName, dirObject + "/d1/d2/d3");
-
-    gcsFs.delete(bucketUri.resolve(dirObject + "/d1/d2/"), /* recursive= */ true);
-
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/d1/d2/", /* maxResults= */ 1, /* pageToken= */ null),
-            listRequestString(
-                bucketName,
-                /* flatList= */ true,
-                /* includeTrailingDelimiter= */ null,
-                dirObject + "/d1/d2/",
-                "bucket,name,generation",
-                /* maxResults= */ 1024,
-                /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/d1/"),
-            uploadRequestString(bucketName, dirObject + "/d1/", /* generationId= */ null),
-            deleteRequestString(bucketName, dirObject + "/d1/d2/d3", /* generationId= */ 1));
-    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/"))).isTrue();
-    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/d2/"))).isFalse();
-    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/d2/d3/"))).isFalse();
-  }
-
-  @Test
   public void rename_file_sequential() throws Exception {
     GoogleCloudStorageFileSystemOptions gcsFsOptions =
         newGcsFsOptions().setStatusParallelEnabled(false).build();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
-import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;
@@ -676,83 +675,6 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
   @Test
   public void delete_directory_parallel() throws Exception {
     delete_directory(/* parallelStatus= */ true);
-  }
-
-  @Test
-  public void delete_inferred_directory() throws Exception {
-    GoogleCloudStorageOptions gcsOptions = GoogleCloudStorageOptions.builder()
-        .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
-        .setAutoRepairImplicitDirectoriesEnabled(false)
-        .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId())).build();
-
-    GoogleCloudStorageFileSystemOptions gcsFsOptions =
-        GoogleCloudStorageFileSystemOptions.builder().setCloudStorageOptions(gcsOptions)
-            .setStatusParallelEnabled(false).build();
-
-    TrackingHttpRequestInitializer gcsRequestsTracker =
-        new TrackingHttpRequestInitializer(httpRequestsInitializer);
-    GoogleCloudStorageFileSystem gcsFs = newGcsFs(gcsFsOptions, gcsRequestsTracker);
-
-    String bucketName = gcsfsIHelper.sharedBucketName1;
-    URI bucketUri = new URI("gs://" + bucketName + "/");
-    String dirObject = getTestResource();
-
-    gcsfsIHelper.createObjects(bucketName, dirObject + "/d1/d2");
-
-    gcsFs.delete(bucketUri.resolve(dirObject + "/d1/"), /* recursive= */ true);
-
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/d1/", /* maxResults= */ 1, /* pageToken= */ null),
-            listRequestString(
-                bucketName,
-                /* flatList= */ true,
-                /* includeTrailingDelimiter= */ null,
-                dirObject + "/d1/",
-                "bucket,name,generation",
-                /* maxResults= */ 1024,
-                /* pageToken= */ null),
-            deleteRequestString(bucketName, dirObject + "/d1/d2", /* generationId= */ 1));
-  }
-
-  @Test
-  public void delete_inferred_directory_with_parent() throws Exception {
-    GoogleCloudStorageFileSystemOptions gcsFsOptions =
-        newGcsFsOptions().setStatusParallelEnabled(false).build();
-
-    TrackingHttpRequestInitializer gcsRequestsTracker =
-        new TrackingHttpRequestInitializer(httpRequestsInitializer);
-    GoogleCloudStorageFileSystem gcsFs = newGcsFs(gcsFsOptions, gcsRequestsTracker);
-
-    String bucketName = gcsfsIHelper.sharedBucketName1;
-    URI bucketUri = new URI("gs://" + bucketName + "/");
-    String dirObject = getTestResource();
-
-    gcsfsIHelper.createObjects(bucketName, dirObject + "/d1/d2/d3");
-
-    gcsFs.delete(bucketUri.resolve(dirObject + "/d1/d2"), /* recursive= */ true);
-
-    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/"))).isTrue();
-
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getRequestString(bucketName, dirObject + "/d1/d2"),
-            getRequestString(bucketName, dirObject + "/d1/"),
-            uploadRequestString(bucketName, dirObject + "/d1/", /* generationId= */ null),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/d1/d2/", /* maxResults= */ 1, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/d1/", /* maxResults= */ 1, /* pageToken= */ null),
-            listRequestString(
-                bucketName,
-                /* flatList= */ true,
-                /* includeTrailingDelimiter= */ null,
-                dirObject + "/d1/d2/",
-                "bucket,name,generation",
-                /* maxResults= */ 1024,
-                /* pageToken= */ null),
-            deleteRequestString(bucketName, dirObject + "/d1/d2/d3", /* generationId= */ 1));
   }
 
   private void delete_directory(boolean parallelStatus) throws Exception {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -743,6 +743,7 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
                 /* pageToken= */ null),
             deleteRequestString(bucketName, dirObject + "/d1/f1", /* generationId= */ 1),
             getRequestString(bucketName, dirObject + "/"));
+
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/d1/f1"))).isFalse();
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -762,11 +762,10 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
 
     gcsfsIHelper.createObjects(bucketName, dirObject + "/d1/d2/d3");
 
-    gcsFs.delete(bucketUri.resolve(dirObject + "/d1/d2"), /* recursive= */ true);
+    gcsFs.delete(bucketUri.resolve(dirObject + "/d1/d2/"), /* recursive= */ true);
 
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
-            getRequestString(bucketName, dirObject + "/d1/d2"),
             listRequestWithTrailingDelimiter(
                 bucketName, dirObject + "/d1/d2/", /* maxResults= */ 1, /* pageToken= */ null),
             listRequestString(


### PR DESCRIPTION

# Description of changes

Removes redundant delete calls to GCS for inferred directories. 

# Testing 

* Added additional tests to cover the new code paths

