### PR TITLE
Add credentials support to StorageStubProvider

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -35,15 +35,12 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.InputStreamContent;
-import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.BackOff;
 import com.google.api.client.util.Data;
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.Sleeper;
-import com.google.api.services.storage.Storage;
-import com.google.api.services.storage.Storage.Objects.Insert;
-import com.google.api.services.storage.StorageRequest;
 import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.Bucket.Lifecycle;
 import com.google.api.services.storage.model.Bucket.Lifecycle.Rule;
@@ -54,6 +51,9 @@ import com.google.api.services.storage.model.ComposeRequest;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.RewriteResponse;
 import com.google.api.services.storage.model.StorageObject;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.Storage.Objects.Insert;
+import com.google.api.services.storage.StorageRequest;
 import com.google.cloud.hadoop.gcsio.authorization.StorageRequestAuthorizer;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.BaseAbstractGoogleAsyncWriteChannel;
@@ -85,19 +85,19 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentHashMap.KeySetView;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentHashMap.KeySetView;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -276,11 +276,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
           httpRequestInitializer instanceof RetryHttpInitializer,
           "request initializer must be an instance of the RetryHttpInitializer class"
               + " when gRPC API enabled");
-      this.storageStubProvider =
-          new StorageStubProvider(
-              this.storageOptions,
-              this.backgroundTasksThreadPool,
-              ((RetryHttpInitializer) httpRequestInitializer).getCredential());
+      Credential credential = ((RetryHttpInitializer) httpRequestInitializer).getCredential();
+      this.storageStubProvider = StorageStubProvider.newInstance(this.storageOptions, this.backgroundTasksThreadPool, credential);
     }
 
     this.storageRequestAuthorizer = initializeStorageRequestAuthorizer(storageOptions);


### PR DESCRIPTION
This PR does
 - Changed the signature of StorageStubProvider's constructor to have 
   - `Credentials` instead of `Credential` to be aligned with the gRPC-Java supporting only `Credentials` and the Beam SDK using `Credentials` 
   - Explicit `useDirectpath` because it's incomplete to infer this from the given `Credential`.
 -  Added `ComputeGoogleCredential` to the check-code to decide `useDirectpath` 

Note that it needs a future PR to support Beam SDK with directpath because it passes `HttpRequestInitializer` rather than `Credential` when creating `GoogleCloudStorageImpl`. Beam references:

 - How to create `GoogleCloudStorageImpl`: [code](https://github.com/apache/beam/blob/fe1116d1d8285084955d41f61d8039ebf5d9cf55/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java#L201)
 - How to create `GcsUtil`: [code](https://github.com/apache/beam/blob/fe1116d1d8285084955d41f61d8039ebf5d9cf55/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java#L105)
 - How to create `HttpRequestInitializer`: [code](https://github.com/apache/beam/blob/fe1116d1d8285084955d41f61d8039ebf5d9cf55/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java#L97)