### PR TITLE
Added credentials to the ctor of GoogleCloudStorageImpl 

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -38,6 +38,9 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for enabling use of GCS gRPC API. */
   public static final boolean ENABLE_GRPC_DEFAULT = false;
 
+  /** Default setting to prefer DirectPath for gRPC. */
+  public static final boolean DIRECT_PATH_PREFFERED_DEFAULT = true;
+
   /** Default root URL for Cloud Storage API endpoint. */
   public static final String STORAGE_ROOT_URL_DEFAULT = Storage.DEFAULT_ROOT_URL;
 
@@ -93,6 +96,7 @@ public abstract class GoogleCloudStorageOptions {
   public static Builder builder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
         .setGrpcEnabled(ENABLE_GRPC_DEFAULT)
+        .setDirectPathPreffered(DIRECT_PATH_PREFFERED_DEFAULT)
         .setStorageRootUrl(STORAGE_ROOT_URL_DEFAULT)
         .setStorageServicePath(STORAGE_SERVICE_PATH_DEFAULT)
         .setAutoRepairImplicitDirectoriesEnabled(AUTO_REPAIR_IMPLICIT_DIRECTORIES_DEFAULT)
@@ -118,6 +122,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract Builder toBuilder();
 
   public abstract boolean isGrpcEnabled();
+
+  public abstract boolean isDirectPathPreffered();
 
   public abstract String getStorageRootUrl();
 
@@ -203,6 +209,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract static class Builder {
 
     public abstract Builder setGrpcEnabled(boolean grpcEnabled);
+
+    public abstract Builder setDirectPathPreffered(boolean directPathPreffered);
 
     public abstract Builder setStorageRootUrl(String rootUrl);
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.cloud.hadoop.util.HttpTransportFactory;
+import com.google.cloud.hadoop.util.RetryHttpInitializer;
+import com.google.cloud.hadoop.gcsio.StorageStubProvider;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.Test;
+
+/** Tests that require a particular configuration of GoogleCloudStorageImpl. */
+@RunWith(JUnit4.class)
+public class GoogleCloudStorageImplCreateTest {
+  private Storage createStorage() throws IOException {
+    return new Storage.Builder(
+        HttpTransportFactory.createHttpTransport(HttpTransportFactory.HttpTransportType.JAVA_NET),
+        JacksonFactory.getDefaultInstance(), new RetryHttpInitializer(null, "foo-user-agent")).build();
+  }
+
+  @Test
+  public void create_grpcAndVmComputeEngineCredentials_useDirectpath() throws IOException {
+    GoogleCloudStorageImpl gcs = new GoogleCloudStorageImpl(
+        GoogleCloudStorageOptions.builder().setAppName("app").setGrpcEnabled(true).build(), createStorage(),
+        ComputeEngineCredentials.newBuilder().build());
+    assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
+        .isInstanceOf(StorageStubProvider.DirectPathGrpcDecorator.class);
+  }
+
+  @Test
+  public void create_grpcAndDisableDirectPathAndVmComputeEngineCredentials_useCloudpath() throws IOException {
+    GoogleCloudStorageImpl gcs = new GoogleCloudStorageImpl(GoogleCloudStorageOptions.builder().setAppName("app")
+        .setGrpcEnabled(true).setDirectPathPreffered(false).build(), createStorage(),
+        ComputeEngineCredentials.newBuilder().build());
+    assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
+        .isInstanceOf(StorageStubProvider.CloudPathGrpcDecorator.class);
+  }
+
+  @Test
+  public void create_grpcAndNonComputeEngineCredentials_useCloudpath() throws IOException {
+    GoogleCloudStorageImpl gcs = new GoogleCloudStorageImpl(
+        GoogleCloudStorageOptions.builder().setAppName("app").setGrpcEnabled(true).build(), createStorage());
+    assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
+        .isInstanceOf(StorageStubProvider.CloudPathGrpcDecorator.class);
+  }
+}


### PR DESCRIPTION
Added credentials to ctor of `GoogleCloudStorageImpl` so that `com.google.auth.Credentials` can be brought to StorageStub which is going to determine whether it will use directpath depending on the type of `Credentials`. Currently `Credentials` object is buried deep in `httpRequestInitializer` so it's not feasible to get the object from it. To address this, explicit field is added to the option. This PR is created with the Beam SDK's [usage](https://github.com/apache/beam/blob/e37bedea7955d2fc13ae44f72a96cc3b763b63e3/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java#L201) in mind.

In addition to this, `isDirectPathPreffered` is aded to `GoogleCloudStorageOptions` to disable Directpath particularly for the test.