### PR TITLE
Add a zero-copy deserializer to gRPC Read

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -466,6 +466,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
         invalidateBufferedContent();
         bufferedContent = content;
         bufferedContentReadOffset = bytesToWrite;
+        // This is to keep the stream alive for the message backed by this.
         streamForBufferedContent = stream;
       } else {
         if (stream != null) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -35,7 +35,6 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.common.hash.Hashing;
 import com.google.google.storage.v1.GetObjectMediaRequest;
 import com.google.google.storage.v1.GetObjectMediaResponse;
-import com.google.google.storage.v1.GetObjectRequest;
 import com.google.google.storage.v1.StorageGrpc;
 import com.google.google.storage.v1.StorageGrpc.StorageBlockingStub;
 import com.google.protobuf.ByteString;
@@ -45,8 +44,8 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.EOFException;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
@@ -61,12 +60,12 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   // ZeroCopy version of GetObjectMedia Method
   private static final ZeroCopyMessageMarshaller getObjectMediaResponseMarshaller =
-    new ZeroCopyMessageMarshaller(GetObjectMediaResponse.getDefaultInstance());
-  private static final MethodDescriptor<GetObjectMediaRequest, GetObjectMediaResponse> getObjectMediaMethod =
-    StorageGrpc.getGetObjectMediaMethod()
-      .toBuilder()
-      .setResponseMarshaller(getObjectMediaResponseMarshaller)
-      .build();
+      new ZeroCopyMessageMarshaller(GetObjectMediaResponse.getDefaultInstance());
+  private static final MethodDescriptor<GetObjectMediaRequest, GetObjectMediaResponse>
+      getObjectMediaMethod =
+          StorageGrpc.getGetObjectMediaMethod().toBuilder()
+              .setResponseMarshaller(getObjectMediaResponseMarshaller)
+              .build();
   private static final boolean useZeroCopyMarshaller = ZeroCopyReadinessChecker.isReady();
 
   private volatile StorageBlockingStub stub;
@@ -98,7 +97,8 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private int bufferedContentReadOffset = 0;
 
-  // InputStream that backs bufferedContent. This needs to be closed when bufferedContent is no longer needed.
+  // InputStream that backs bufferedContent. This needs to be closed when bufferedContent is no
+  // longer needed.
   @Nullable private InputStream streamForBufferedContent = null;
 
   // The streaming read operation. If null, there is not an in-flight read in progress.
@@ -541,11 +541,16 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
             try {
               requestContext = Context.current().withCancellation();
               Context toReattach = requestContext.attach();
-              StorageBlockingStub blockingStub = stub.withDeadlineAfter(readOptions.getGrpcReadTimeoutMillis(), MILLISECONDS);
+              StorageBlockingStub blockingStub =
+                  stub.withDeadlineAfter(readOptions.getGrpcReadTimeoutMillis(), MILLISECONDS);
               try {
                 if (useZeroCopyMarshaller) {
-                  resIterator = io.grpc.stub.ClientCalls.blockingServerStreamingCall(
-                    blockingStub.getChannel(), getObjectMediaMethod, blockingStub.getCallOptions(), request);
+                  resIterator =
+                      io.grpc.stub.ClientCalls.blockingServerStreamingCall(
+                          blockingStub.getChannel(),
+                          getObjectMediaMethod,
+                          blockingStub.getCallOptions(),
+                          request);
                 } else {
                   resIterator = blockingStub.getObjectMedia(request);
                 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -35,13 +35,17 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.common.hash.Hashing;
 import com.google.google.storage.v1.GetObjectMediaRequest;
 import com.google.google.storage.v1.GetObjectMediaResponse;
+import com.google.google.storage.v1.GetObjectRequest;
+import com.google.google.storage.v1.StorageGrpc;
 import com.google.google.storage.v1.StorageGrpc.StorageBlockingStub;
 import com.google.protobuf.ByteString;
 import io.grpc.Context;
 import io.grpc.Context.CancellableContext;
+import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.io.EOFException;
+import java.io.InputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -54,6 +58,15 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   protected static final String METADATA_FIELDS = "contentEncoding,generation,size";
+
+  // ZeroCopy version of GetObjectMedia Method
+  private static final ZeroCopyMessageMarshaller getObjectMediaResponseMarshaller =
+    new ZeroCopyMessageMarshaller(GetObjectMediaResponse.getDefaultInstance());
+  private static final MethodDescriptor<GetObjectMediaRequest, GetObjectMediaResponse> getObjectMediaMethod =
+    StorageGrpc.getGetObjectMediaMethod()
+      .toBuilder().setResponseMarshaller(getObjectMediaResponseMarshaller)
+      .build();
+  private static final boolean useZeroCopyMarshaller = ZeroCopyReadinessChecker.isReady();
 
   private volatile StorageBlockingStub stub;
 
@@ -83,6 +96,9 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   @Nullable private ByteString bufferedContent = null;
 
   private int bufferedContentReadOffset = 0;
+
+  // InputStream that backs bufferedContent. This needs to be closed when bufferedContent is no longer needed.
+  @Nullable private InputStream streamForBufferedContent = null;
 
   // The streaming read operation. If null, there is not an in-flight read in progress.
   @Nullable private Iterator<GetObjectMediaResponse> resIterator = null;
@@ -331,8 +347,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     if (remainingBufferedContentLargerThanByteBuffer) {
       bufferedContentReadOffset += bytesToWrite;
     } else {
-      bufferedContent = null;
-      bufferedContentReadOffset = 0;
+      invalidateBufferedContent();
     }
 
     return bytesToWrite;
@@ -417,7 +432,10 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     int bytesRead = 0;
     while (moreServerContent() && byteBuffer.hasRemaining()) {
       GetObjectMediaResponse res = resIterator.next();
-
+      // When zero-copy mashaller is used, the stream that backs GetObjectMediaResponse
+      // should be closed when the mssage is no longed needed so that all buffers in the
+      // stream can be reclaimed. If zero-copy is not used, stream will be null.
+      InputStream stream = getObjectMediaResponseMarshaller.popStream(res);
       ByteString content = res.getChecksummedData().getContent();
       if (bytesToSkipBeforeReading >= 0 && bytesToSkipBeforeReading < content.size()) {
         content = res.getChecksummedData().getContent().substring((int) bytesToSkipBeforeReading);
@@ -426,6 +444,9 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       } else if (bytesToSkipBeforeReading >= content.size()) {
         positionInGrpcStream += content.size();
         bytesToSkipBeforeReading -= content.size();
+        if (stream != null) {
+          stream.close();
+        }
         continue;
       }
 
@@ -441,8 +462,14 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       positionInGrpcStream += bytesToWrite;
 
       if (responseSizeLargerThanRemainingBuffer) {
+        invalidateBufferedContent();
         bufferedContent = content;
         bufferedContentReadOffset = bytesToWrite;
+        streamForBufferedContent = stream;
+      } else {
+        if (stream != null) {
+          stream.close();
+        }
       }
     }
     return bytesRead;
@@ -513,10 +540,14 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
             try {
               requestContext = Context.current().withCancellation();
               Context toReattach = requestContext.attach();
+              StorageBlockingStub blockingStub = stub.withDeadlineAfter(readOptions.getGrpcReadTimeoutMillis(), MILLISECONDS);
               try {
-                resIterator =
-                    stub.withDeadlineAfter(readOptions.getGrpcReadTimeoutMillis(), MILLISECONDS)
-                        .getObjectMedia(request);
+                if (useZeroCopyMarshaller) {
+                  resIterator = io.grpc.stub.ClientCalls.blockingServerStreamingCall(
+                    blockingStub.getChannel(), getObjectMediaMethod, blockingStub.getCallOptions(), request);
+                } else {
+                  resIterator = blockingStub.getObjectMedia(request);
+                }
               } finally {
                 requestContext.detach(toReattach);
               }
@@ -631,9 +662,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
     // Reset any ongoing read operations or local data caches.
     cancelCurrentRequest();
-    bufferedContent = null;
-    bufferedContentReadOffset = 0;
-    bytesToSkipBeforeReading = 0;
+    invalidateBufferedContent();
 
     positionInGrpcStream = newPosition;
     return this;
@@ -660,6 +689,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   @Override
   public void close() {
     cancelCurrentRequest();
+    invalidateBufferedContent();
     channelIsOpen = false;
   }
 
@@ -669,5 +699,18 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
         .add("resourceId", resourceId)
         .add("generation", objectGeneration)
         .toString();
+  }
+
+  private void invalidateBufferedContent() {
+    bufferedContent = null;
+    bufferedContentReadOffset = 0;
+    if (streamForBufferedContent != null) {
+      try {
+        streamForBufferedContent.close();
+        streamForBufferedContent = null;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -64,7 +64,8 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     new ZeroCopyMessageMarshaller(GetObjectMediaResponse.getDefaultInstance());
   private static final MethodDescriptor<GetObjectMediaRequest, GetObjectMediaResponse> getObjectMediaMethod =
     StorageGrpc.getGetObjectMediaMethod()
-      .toBuilder().setResponseMarshaller(getObjectMediaResponseMarshaller)
+      .toBuilder()
+      .setResponseMarshaller(getObjectMediaResponseMarshaller)
       .build();
   private static final boolean useZeroCopyMarshaller = ZeroCopyReadinessChecker.isReady();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
@@ -1,16 +1,19 @@
 /*
  * Copyright 2021 Google Inc. All Rights Reserved.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.cloud.hadoop.gcsio;
 
 import com.google.protobuf.ByteString;
@@ -76,7 +79,7 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
             && ((HasByteBuffer) stream).byteBufferSupported()) {
           // Stream is now detached here and should be closed later.
           stream = ((Detachable) stream).detach();
-          // This mark call is to keep buffer while travelsing buffers using skip.
+          // This mark call is to keep buffer while traversing buffers using skip.
           stream.mark(size);
           List<ByteString> byteStrings = new ArrayList<>();
           while (stream.available() != 0) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
@@ -26,11 +26,10 @@ import io.grpc.Detachable;
 import io.grpc.HasByteBuffer;
 import io.grpc.KnownLength;
 import io.grpc.MethodDescriptor.PrototypeMarshaller;
-import io.grpc.protobuf.lite.ProtoLiteUtils;
 import io.grpc.Status;
-import io.grpc.MethodDescriptor;
-import java.io.InputStream;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +43,8 @@ import java.util.Map;
 // Hence, it exposes the input stream to applications (through popStream) and applications are
 // responsible to close it when it's no longer needed. Otherwise, it'd cause memory leak.
 class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarshaller<T> {
-  private Map<T, InputStream> unclosedStreams = Collections.synchronizedMap(new IdentityHashMap<>());
+  private Map<T, InputStream> unclosedStreams =
+      Collections.synchronizedMap(new IdentityHashMap<>());
   private final Parser<T> parser;
   private final PrototypeMarshaller<T> baseMarshaller;
 
@@ -74,7 +74,8 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
     try {
       if (stream instanceof KnownLength) {
         int size = stream.available();
-        if (stream instanceof Detachable && stream instanceof HasByteBuffer
+        if (stream instanceof Detachable
+            && stream instanceof HasByteBuffer
             && ((HasByteBuffer) stream).byteBufferSupported()) {
           // Stream is now detached here and should be closed later.
           stream = ((Detachable) stream).detach();
@@ -101,7 +102,10 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
       try {
         message = parseFrom(cis);
       } catch (InvalidProtocolBufferException ipbe) {
-        throw Status.INTERNAL.withDescription("Invalid protobuf byte sequence").withCause(ipbe).asRuntimeException();
+        throw Status.INTERNAL
+            .withDescription("Invalid protobuf byte sequence")
+            .withCause(ipbe)
+            .asRuntimeException();
       }
       unclosedStreams.put(message, stream);
       return message;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
@@ -97,6 +97,7 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
         try {
           message = parseFrom(codedInputStream);
         } catch (InvalidProtocolBufferException ipbe) {
+          stream.close();
           throw Status.INTERNAL
               .withDescription("Invalid protobuf byte sequence")
               .withCause(ipbe)

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
@@ -74,8 +74,7 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
     try {
       if (stream instanceof KnownLength) {
         int size = stream.available();
-        if (stream instanceof Detachable
-            && stream instanceof HasByteBuffer
+        if (stream instanceof Detachable && stream instanceof HasByteBuffer
             && ((HasByteBuffer) stream).byteBufferSupported()) {
           // Stream is now detached here and should be closed later.
           stream = ((Detachable) stream).detach();
@@ -102,15 +101,14 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
       try {
         message = parseFrom(cis);
       } catch (InvalidProtocolBufferException ipbe) {
-        throw Status.INTERNAL.withDescription("Invalid protobuf byte sequence")
-            .withCause(ipbe).asRuntimeException();
+        throw Status.INTERNAL.withDescription("Invalid protobuf byte sequence").withCause(ipbe).asRuntimeException();
       }
       unclosedStreams.put(message, stream);
-      return message;      
+      return message;
     } else {
       // slow path
       return baseMarshaller.parse(stream);
-    }   
+    }
   }
 
   private T parseFrom(CodedInputStream stream) throws InvalidProtocolBufferException {
@@ -128,5 +126,5 @@ class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarsh
   // call stream.close() function to return it to the pool.
   public InputStream popStream(T message) {
     return unclosedStreams.remove(message);
-  }  
+  }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshaller.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hadoop.gcsio;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.MessageLite;
+import com.google.protobuf.Parser;
+import com.google.protobuf.UnsafeByteOperations;
+import io.grpc.Detachable;
+import io.grpc.HasByteBuffer;
+import io.grpc.KnownLength;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
+import io.grpc.Status;
+import io.grpc.MethodDescriptor;
+import java.io.InputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+// Custom gRPC marshaller to use zero memory copy feature of gRPC when deserializing messages.
+// This achieves zero-copy by deserializing proto messages pointing to the buffers in the input
+// stream to avoid memory copy so stream should live as long as the message can be referenced.
+// Hence, it exposes the input stream to applications (through popStream) and applications are
+// responsible to close it when it's no longer needed. Otherwise, it'd cause memory leak.
+class ZeroCopyMessageMarshaller<T extends MessageLite> implements PrototypeMarshaller<T> {
+  private Map<T, InputStream> unclosedStreams = Collections.synchronizedMap(new IdentityHashMap<>());
+  private final Parser<T> parser;
+  private final PrototypeMarshaller<T> baseMarshaller;
+
+  ZeroCopyMessageMarshaller(T defaultInstance) {
+    parser = (Parser<T>) defaultInstance.getParserForType();
+    baseMarshaller = (PrototypeMarshaller<T>) ProtoLiteUtils.marshaller(defaultInstance);
+  }
+
+  @Override
+  public Class<T> getMessageClass() {
+    return baseMarshaller.getMessageClass();
+  }
+
+  @Override
+  public T getMessagePrototype() {
+    return baseMarshaller.getMessagePrototype();
+  }
+
+  @Override
+  public InputStream stream(T value) {
+    return baseMarshaller.stream(value);
+  }
+
+  @Override
+  public T parse(InputStream stream) {
+    CodedInputStream cis = null;
+    try {
+      if (stream instanceof KnownLength) {
+        int size = stream.available();
+        if (stream instanceof Detachable
+            && stream instanceof HasByteBuffer
+            && ((HasByteBuffer) stream).byteBufferSupported()) {
+          // Stream is now detached here and should be closed later.
+          stream = ((Detachable) stream).detach();
+          // This mark call is to keep buffer while travelsing buffers using skip.
+          stream.mark(size);
+          List<ByteString> byteStrings = new ArrayList<>();
+          while (stream.available() != 0) {
+            ByteBuffer buffer = ((HasByteBuffer) stream).getByteBuffer();
+            byteStrings.add(UnsafeByteOperations.unsafeWrap(buffer));
+            stream.skip(buffer.remaining());
+          }
+          stream.reset();
+          cis = ByteString.copyFrom(byteStrings).newCodedInput();
+          cis.enableAliasing(true);
+          cis.setSizeLimit(Integer.MAX_VALUE);
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    if (cis != null) {
+      // fast path (no memory copy)
+      T message;
+      try {
+        message = parseFrom(cis);
+      } catch (InvalidProtocolBufferException ipbe) {
+        throw Status.INTERNAL.withDescription("Invalid protobuf byte sequence")
+            .withCause(ipbe).asRuntimeException();
+      }
+      unclosedStreams.put(message, stream);
+      return message;      
+    } else {
+      // slow path
+      return baseMarshaller.parse(stream);
+    }   
+  }
+
+  private T parseFrom(CodedInputStream stream) throws InvalidProtocolBufferException {
+    T message = parser.parseFrom(stream);
+    try {
+      stream.checkLastTagWas(0);
+      return message;
+    } catch (InvalidProtocolBufferException e) {
+      e.setUnfinishedMessage(message);
+      throw e;
+    }
+  }
+
+  // Application needs to call this function to get the stream for the message and
+  // call stream.close() function to return it to the pool.
+  public InputStream popStream(T message) {
+    return unclosedStreams.remove(message);
+  }  
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
@@ -16,10 +16,16 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import com.google.common.flogger.GoogleLogger;
 import com.google.protobuf.MessageLite;
 import io.grpc.KnownLength;
 
-public class ZeroCopyReadinessChecker {
+/**
+ * Checker to test whether a zero-copy masharller is available from the versions of gRPC and
+ * Protobuf.
+ */
+class ZeroCopyReadinessChecker {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private static final boolean isZeroCopyReady;
 
   static {
@@ -37,6 +43,7 @@ public class ZeroCopyReadinessChecker {
       Class<?> detachableClass = Class.forName(detachableClassName);
       detachableClassExists = (detachableClass != null);
     } catch (ClassNotFoundException ex) {
+      logger.atFine().withCause(ex).log("io.grpc.Detachable not found");
     }
     // Check whether com.google.protobuf.UnsafeByteOperations exists?
     boolean unsafeByteOperationsClassExists = false;
@@ -49,6 +56,7 @@ public class ZeroCopyReadinessChecker {
       Class<?> unsafeByteOperationsClass = Class.forName(unsafeByteOperationsClassName);
       unsafeByteOperationsClassExists = (unsafeByteOperationsClass != null);
     } catch (ClassNotFoundException ex) {
+      logger.atFine().withCause(ex).log("com.google.protobuf.UnsafeByteOperations not found");
     }
     isZeroCopyReady = detachableClassExists && unsafeByteOperationsClassExists;
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
@@ -18,9 +18,6 @@ package com.google.cloud.hadoop.gcsio;
 
 import com.google.protobuf.MessageLite;
 import io.grpc.KnownLength;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.security.Provider;
 
 public class ZeroCopyReadinessChecker {
   private static final boolean isZeroCopyReady;
@@ -34,8 +31,9 @@ public class ZeroCopyReadinessChecker {
       // done indirectly to handle the case where gRPC is being shaded in a
       // different package.
       String knownLengthClassName = KnownLength.class.getName();
-      String detachableClassName = knownLengthClassName.substring(0, knownLengthClassName.lastIndexOf('.') + 1)
-          + "Detachable";
+      String detachableClassName =
+          knownLengthClassName.substring(0, knownLengthClassName.lastIndexOf('.') + 1)
+              + "Detachable";
       Class<?> detachableClass = Class.forName(detachableClassName);
       detachableClassExists = (detachableClass != null);
     } catch (ClassNotFoundException ex) {
@@ -45,8 +43,9 @@ public class ZeroCopyReadinessChecker {
     try {
       // Same above
       String messageLiteClassName = MessageLite.class.getName();
-      String unsafeByteOperationsClassName = messageLiteClassName.substring(0,
-          messageLiteClassName.lastIndexOf('.') + 1) + "UnsafeByteOperations";
+      String unsafeByteOperationsClassName =
+          messageLiteClassName.substring(0, messageLiteClassName.lastIndexOf('.') + 1)
+              + "UnsafeByteOperations";
       Class<?> unsafeByteOperationsClass = Class.forName(unsafeByteOperationsClassName);
       unsafeByteOperationsClassExists = (unsafeByteOperationsClass != null);
     } catch (ClassNotFoundException ex) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
@@ -23,38 +23,38 @@ import java.lang.reflect.Method;
 import java.security.Provider;
 
 public class ZeroCopyReadinessChecker {
-    private static final boolean isZeroCopyReady;
+  private static final boolean isZeroCopyReady;
 
-    static {
-        // Check whether io.grpc.Detachable exists?
-        boolean detachableClassExists = false;
-        try {
-            // Try to load Detachable interface in the package where KnownLength is in.
-            // This can be done directly by looking up io.grpc.Detachable but rather
-            // done indirectly to handle the case where gRPC is being shaded in a
-            // different package.
-            String knownLengthClassName = KnownLength.class.getName();
-            String detachableClassName = knownLengthClassName.substring(0, knownLengthClassName.lastIndexOf('.') + 1)
-                    + "Detachable";
-            Class<?> detachableClass = Class.forName(detachableClassName);
-            detachableClassExists = (detachableClass != null);
-        } catch (ClassNotFoundException ex) {
-        }
-        // Check whether com.google.protobuf.UnsafeByteOperations exists?
-        boolean unsafeByteOperationsClassExists = false;
-        try {
-            // Same above
-            String messageLiteClassName = MessageLite.class.getName();
-            String unsafeByteOperationsClassName = messageLiteClassName.substring(0, messageLiteClassName.lastIndexOf('.') + 1)
-                    + "UnsafeByteOperations";
-            Class<?> unsafeByteOperationsClass = Class.forName(unsafeByteOperationsClassName);
-            unsafeByteOperationsClassExists = (unsafeByteOperationsClass != null);            
-        } catch (ClassNotFoundException ex) {
-        }
-        isZeroCopyReady = detachableClassExists && unsafeByteOperationsClassExists;
+  static {
+    // Check whether io.grpc.Detachable exists?
+    boolean detachableClassExists = false;
+    try {
+      // Try to load Detachable interface in the package where KnownLength is in.
+      // This can be done directly by looking up io.grpc.Detachable but rather
+      // done indirectly to handle the case where gRPC is being shaded in a
+      // different package.
+      String knownLengthClassName = KnownLength.class.getName();
+      String detachableClassName = knownLengthClassName.substring(0, knownLengthClassName.lastIndexOf('.') + 1)
+          + "Detachable";
+      Class<?> detachableClass = Class.forName(detachableClassName);
+      detachableClassExists = (detachableClass != null);
+    } catch (ClassNotFoundException ex) {
     }
+    // Check whether com.google.protobuf.UnsafeByteOperations exists?
+    boolean unsafeByteOperationsClassExists = false;
+    try {
+      // Same above
+      String messageLiteClassName = MessageLite.class.getName();
+      String unsafeByteOperationsClassName = messageLiteClassName.substring(0,
+          messageLiteClassName.lastIndexOf('.') + 1) + "UnsafeByteOperations";
+      Class<?> unsafeByteOperationsClass = Class.forName(unsafeByteOperationsClassName);
+      unsafeByteOperationsClassExists = (unsafeByteOperationsClass != null);
+    } catch (ClassNotFoundException ex) {
+    }
+    isZeroCopyReady = detachableClassExists && unsafeByteOperationsClassExists;
+  }
 
-    public static boolean isReady() {
-        return isZeroCopyReady;
-    }
+  public static boolean isReady() {
+    return isZeroCopyReady;
+  }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.hadoop.gcsio;
 
 import com.google.protobuf.MessageLite;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ZeroCopyReadinessChecker.java
@@ -1,0 +1,44 @@
+package com.google.cloud.hadoop.gcsio;
+
+import com.google.protobuf.MessageLite;
+import io.grpc.KnownLength;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Provider;
+
+public class ZeroCopyReadinessChecker {
+    private static final boolean isZeroCopyReady;
+
+    static {
+        // Check whether io.grpc.Detachable exists?
+        boolean detachableClassExists = false;
+        try {
+            // Try to load Detachable interface in the package where KnownLength is in.
+            // This can be done directly by looking up io.grpc.Detachable but rather
+            // done indirectly to handle the case where gRPC is being shaded in a
+            // different package.
+            String knownLengthClassName = KnownLength.class.getName();
+            String detachableClassName = knownLengthClassName.substring(0, knownLengthClassName.lastIndexOf('.') + 1)
+                    + "Detachable";
+            Class<?> detachableClass = Class.forName(detachableClassName);
+            detachableClassExists = (detachableClass != null);
+        } catch (ClassNotFoundException ex) {
+        }
+        // Check whether com.google.protobuf.UnsafeByteOperations exists?
+        boolean unsafeByteOperationsClassExists = false;
+        try {
+            // Same above
+            String messageLiteClassName = MessageLite.class.getName();
+            String unsafeByteOperationsClassName = messageLiteClassName.substring(0, messageLiteClassName.lastIndexOf('.') + 1)
+                    + "UnsafeByteOperations";
+            Class<?> unsafeByteOperationsClass = Class.forName(unsafeByteOperationsClassName);
+            unsafeByteOperationsClassExists = (unsafeByteOperationsClass != null);            
+        } catch (ClassNotFoundException ex) {
+        }
+        isZeroCopyReady = detachableClassExists && unsafeByteOperationsClassExists;
+    }
+
+    public static boolean isReady() {
+        return isZeroCopyReady;
+    }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshallerTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ZeroCopyMessageMarshallerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.google.storage.v1.GetObjectRequest;
+import io.grpc.StatusRuntimeException;
+import io.grpc.internal.ReadableBuffer;
+import io.grpc.internal.ReadableBuffers;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ZeroCopyMessageMarshallerTest {
+  private GetObjectRequest REQUEST =
+      GetObjectRequest.newBuilder().setBucket("b").setObject("o").build();
+
+  private ZeroCopyMessageMarshaller<GetObjectRequest> createMarshaller() {
+    return new ZeroCopyMessageMarshaller<>(GetObjectRequest.getDefaultInstance());
+  }
+
+  private byte[] dropLastOneByte(byte[] bytes) {
+    return Arrays.copyOfRange(bytes, 0, bytes.length - 1);
+  }
+
+  private InputStream createInputStream(byte[] bytes, boolean isZeroCopyable) {
+    ReadableBuffer buffer =
+        isZeroCopyable ? ReadableBuffers.wrap(ByteBuffer.wrap(bytes)) : ReadableBuffers.wrap(bytes);
+    return ReadableBuffers.openStream(buffer, true);
+  }
+
+  @Test
+  public void testParseOnFastPath() throws IOException {
+    InputStream stream = createInputStream(REQUEST.toByteArray(), true);
+    ZeroCopyMessageMarshaller<GetObjectRequest> marshaller = createMarshaller();
+    GetObjectRequest request = marshaller.parse(stream);
+    assertThat(request).isEqualTo(REQUEST);
+    InputStream stream2 = marshaller.popStream(request);
+    assertThat(stream2).isNotNull();
+    stream2.close();
+    InputStream stream3 = marshaller.popStream(request);
+    assertThat(stream3).isNull();
+  }
+
+  @Test
+  public void testParseOnSlowPath() {
+    InputStream stream = createInputStream(REQUEST.toByteArray(), false);
+    ZeroCopyMessageMarshaller<GetObjectRequest> marshaller = createMarshaller();
+    GetObjectRequest request = marshaller.parse(stream);
+    assertThat(request).isEqualTo(REQUEST);
+    InputStream stream2 = marshaller.popStream(request);
+    assertThat(stream2).isNull();
+  }
+
+  @Test
+  public void testParseBrokenMessageOnFastPath() {
+    InputStream stream = createInputStream(dropLastOneByte(REQUEST.toByteArray()), true);
+    ZeroCopyMessageMarshaller<GetObjectRequest> marshaller = createMarshaller();
+    assertThrows(
+        StatusRuntimeException.class,
+        () -> {
+          marshaller.parse(stream);
+        });
+  }
+
+  @Test
+  public void testParseBrokenMessageOnSlowPath() {
+    InputStream stream = createInputStream(dropLastOneByte(REQUEST.toByteArray()), false);
+    ZeroCopyMessageMarshaller<GetObjectRequest> marshaller = createMarshaller();
+    assertThrows(
+        StatusRuntimeException.class,
+        () -> {
+          marshaller.parse(stream);
+        });
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <google.http-client.version>1.39.2-sp.1</google.http-client.version>
     <google.oauth-client.version>1.31.5</google.oauth-client.version>
     <google.protobuf.version>3.17.3</google.protobuf.version>
-    <grpc.version>1.38.1</grpc.version>
+    <grpc.version>1.39.0</grpc.version>
     <hadoop.two.version>2.10.1</hadoop.two.version>
     <hadoop.three.version>3.2.2</hadoop.three.version>
 


### PR DESCRIPTION
This PR add an gRPC read optimization using the zero-copy deserializer and reduces two memory copies involved. This is based on https://github.com/grpc/grpc-java/pull/8102 which will be released from grpc-java 1.39.0 and tested earlier with https://github.com/GoogleCloudPlatform/grpc-gcp-java/pull/77. 