### PR TITLE
Support Hadoop 3.3.1

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -163,7 +163,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -160,6 +160,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/gcs/src/test/resources/contract/gs.xml
+++ b/gcs/src/test/resources/contract/gs.xml
@@ -30,6 +30,11 @@
   </property>
 
   <property>
+    <name>fs.contract.rename-returns-false-if-dest-exists</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <name>fs.contract.rename-remove-dest-if-empty-dir</name>
     <value>false</value>
   </property>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <junit.version>4.13.2</junit.version>
     <mockito.version>3.11.2</mockito.version>
     <system-lambda.version>1.2.0</system-lambda.version>
+    <!-- TODO: remove AssertJ dependency when Hadoop will fix transitive test dependencies -->
     <assertj.version>3.12.2</assertj.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
     <junit.version>4.13.2</junit.version>
     <mockito.version>3.11.2</mockito.version>
     <system-lambda.version>1.2.0</system-lambda.version>
+    <assertj.version>3.12.2</assertj.version>
   </properties>
 
   <modules>
@@ -279,6 +280,53 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <!--
+     This is a profile to enable the use of the ASF snapshot and staging repositories
+     during a build. It is useful when testing against nightly or RC releases of dependencies.
+     -->
+    <profile>
+      <id>snapshots-and-staging</id>
+      <properties>
+        <!-- override point for ASF staging/snapshot repos -->
+        <asf.staging>https://repository.apache.org/content/groups/staging/</asf.staging>
+        <asf.snapshots>https://repository.apache.org/content/repositories/snapshots/</asf.snapshots>
+      </properties>
+
+      <pluginRepositories>
+        <pluginRepository>
+          <id>ASF Staging</id>
+          <url>${asf.staging}</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>ASF Snapshots</id>
+          <url>${asf.snapshots}</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </pluginRepository>
+
+      </pluginRepositories>
+      <repositories>
+        <repository>
+          <id>ASF Staging</id>
+          <url>${asf.staging}</url>
+        </repository>
+        <repository>
+          <id>ASF Snapshots</id>
+          <url>${asf.snapshots}</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </repository>
+      </repositories>
     </profile>
   </profiles>
 
@@ -487,6 +535,12 @@
         <groupId>com.github.stefanbirkner</groupId>
         <artifactId>system-lambda</artifactId>
         <version>${system-lambda.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
To build and test against Hadoop 3.3.1 

* the staging repo needs to be supported as an optional profile
 "snapshots-and-staging". This is only needed when qualifying a hadoop RC.
* AssertJ needs to be added as a dependency.
  (Nobody knows why hadoop-common test jar's declaration isn't picked up)
* the gs.xml contract needs to declare that gcs returns false when
  renaming a file over an existing file, so a new test knows the
  expected behavior.