### PR TITLE
Fix resumable upload from offset of last chunk

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -370,7 +370,7 @@ public class GoogleHadoopFileSystemConfiguration {
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
 
   /** Configuration key for the number of requests to be buffered for uploads to GCS. */
-  public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_REQUESTS_BUFFER =
+  public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.buffered.requests", 20L);
 
   /**
@@ -528,7 +528,7 @@ public class GoogleHadoopFileSystemConfiguration {
             GCS_OUTPUT_STREAM_DIRECT_UPLOAD_ENABLE.get(config, config::getBoolean))
         .setGrpcChecksumsEnabled(GCS_GRPC_CHECKSUMS_ENABLE.get(config, config::getBoolean))
         .setGrpcWriteTimeout(GCS_GRPC_WRITE_TIMEOUT_MS.get(config, config::getLong))
-        .setNumberOfRequestsBuffered(GCS_GRPC_UPLOAD_REQUESTS_BUFFER.get(config, config::getLong))
+        .setNumberOfRequestsBuffered(GCS_GRPC_UPLOAD_BUFFERED_REQUESTS.get(config, config::getLong))
         .build();
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -347,39 +347,27 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.enable", false);
 
-  /**
-   * Configuration key for enabling checksum validation for the gRPC API.
-   */
+  /** Configuration key for enabling checksum validation for the gRPC API. */
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_CHECKSUMS_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.checksums.enable", false);
 
-  /**
-   * Configuration key for the Cloud Storage gRPC server address.
-   */
+  /** Configuration key for the Cloud Storage gRPC server address. */
   public static final HadoopConfigurationProperty<String> GCS_GRPC_SERVER_ADDRESS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.server.address");
 
-  /**
-   * Configuration key for the connect timeout (in millisecond) for gRPC read requests to GCS.
-   */
+  /** Configuration key for the connect timeout (in millisecond) for gRPC read requests to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_READ_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
 
-  /**
-   * Configuration key for the connect timeout (in millisecond) for gRPC metadata requests to GCS.
-   */
+  /** Configuration key for the connect timeout (in millisecond) for gRPC metadata requests to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_READ_METADATA_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
 
-  /**
-   * Configuration key for the number of requests to be buffered for uploads to GCS.
-   */
+  /** Configuration key for the number of requests to be buffered for uploads to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.buffered.requests", 20L);
 
-  /**
-   * Configuration key for the connect timeout (in millisecond) for gRPC write requests to GCS.
-   */
+  /** Configuration key for the connect timeout (in millisecond) for gRPC write requests to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_WRITE_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
 
@@ -390,9 +378,7 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_COOPERATIVE_LOCKING_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.cooperative.locking.enable", false);
 
-  /**
-   * Configuration key for lock expiration when using cooperative locking.
-   */
+  /** Configuration key for lock expiration when using cooperative locking. */
   public static final HadoopConfigurationProperty<Long>
       GCS_COOPERATIVE_LOCKING_EXPIRATION_TIMEOUT_MS =
           new HadoopConfigurationProperty<>(

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -347,11 +347,15 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.enable", false);
 
-  /** Configuration key for enabling checksum validation for the gRPC API. */
+  /**
+   * Configuration key for enabling checksum validation for the gRPC API.
+   */
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_CHECKSUMS_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.checksums.enable", false);
 
-  /** Configuration key for the Cloud Storage gRPC server address. */
+  /**
+   * Configuration key for the Cloud Storage gRPC server address.
+   */
   public static final HadoopConfigurationProperty<String> GCS_GRPC_SERVER_ADDRESS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.server.address");
 
@@ -361,15 +365,21 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_READ_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
 
-  /** Configuration key for the connect timeout (in millisecond) for gRPC metadata requests to GCS. */
+  /**
+   * Configuration key for the connect timeout (in millisecond) for gRPC metadata requests to GCS.
+   */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_READ_METADATA_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
 
-  /** Configuration key for the connect timeout (in millisecond) for gRPC write requests to GCS. */
+  /**
+   * Configuration key for the connect timeout (in millisecond) for gRPC write requests to GCS.
+   */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_WRITE_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
 
-  /** Configuration key for the number of requests to be buffered for uploads to GCS. */
+  /**
+   * Configuration key for the number of requests to be buffered for uploads to GCS.
+   */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.buffered.requests", 20L);
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -364,6 +364,9 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_WRITE_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
 
+  public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_REQUESTS_BUFFER =
+      new HadoopConfigurationProperty<>("fs.gs.grpc.write.requests.buffered", 20L);
+
   /**
    * Configuration key for using cooperative locking to achieve a directory mutation operations
    * isolation.
@@ -371,7 +374,9 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_COOPERATIVE_LOCKING_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.cooperative.locking.enable", false);
 
-  /** Configuration key for lock expiration when using cooperative locking. */
+  /**
+   * Configuration key for lock expiration when using cooperative locking.
+   */
   public static final HadoopConfigurationProperty<Long>
       GCS_COOPERATIVE_LOCKING_EXPIRATION_TIMEOUT_MS =
           new HadoopConfigurationProperty<>(
@@ -517,6 +522,7 @@ public class GoogleHadoopFileSystemConfiguration {
             GCS_OUTPUT_STREAM_DIRECT_UPLOAD_ENABLE.get(config, config::getBoolean))
         .setGrpcChecksumsEnabled(GCS_GRPC_CHECKSUMS_ENABLE.get(config, config::getBoolean))
         .setGrpcWriteTimeout(GCS_GRPC_WRITE_TIMEOUT_MS.get(config, config::getLong))
+        .setNumberOfRequestsBuffered(GCS_GRPC_UPLOAD_REQUESTS_BUFFER.get(config, config::getLong))
         .build();
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -381,7 +381,7 @@ public class GoogleHadoopFileSystemConfiguration {
    * Configuration key for the number of requests to be buffered for uploads to GCS.
    */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
-      new HadoopConfigurationProperty<>("fs.gs.outputstream.grpc.buffered.requests", 20L);
+      new HadoopConfigurationProperty<>("fs.gs.grpc.outputstream.buffered.requests", 20L);
 
   /**
    * Configuration key for using cooperative locking to achieve a directory mutation operations

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -528,7 +528,7 @@ public class GoogleHadoopFileSystemConfiguration {
             GCS_OUTPUT_STREAM_DIRECT_UPLOAD_ENABLE.get(config, config::getBoolean))
         .setGrpcChecksumsEnabled(GCS_GRPC_CHECKSUMS_ENABLE.get(config, config::getBoolean))
         .setGrpcWriteTimeout(GCS_GRPC_WRITE_TIMEOUT_MS.get(config, config::getLong))
-        .setNumberOfRequestsBuffered(GCS_GRPC_UPLOAD_BUFFERED_REQUESTS.get(config, config::getLong))
+        .setNumberOfBufferedRequests(GCS_GRPC_UPLOAD_BUFFERED_REQUESTS.get(config, config::getLong))
         .build();
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -381,7 +381,7 @@ public class GoogleHadoopFileSystemConfiguration {
    * Configuration key for the number of requests to be buffered for uploads to GCS.
    */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
-      new HadoopConfigurationProperty<>("fs.gs.grpc.write.buffered.requests", 20L);
+      new HadoopConfigurationProperty<>("fs.gs.outputstream.grpc.buffered.requests", 20L);
 
   /**
    * Configuration key for using cooperative locking to achieve a directory mutation operations

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -372,16 +372,16 @@ public class GoogleHadoopFileSystemConfiguration {
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
 
   /**
+   * Configuration key for the number of requests to be buffered for uploads to GCS.
+   */
+  public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
+      new HadoopConfigurationProperty<>("fs.gs.grpc.write.buffered.requests", 20L);
+
+  /**
    * Configuration key for the connect timeout (in millisecond) for gRPC write requests to GCS.
    */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_WRITE_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
-
-  /**
-   * Configuration key for the number of requests to be buffered for uploads to GCS.
-   */
-  public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_BUFFERED_REQUESTS =
-      new HadoopConfigurationProperty<>("fs.gs.grpc.outputstream.buffered.requests", 20L);
 
   /**
    * Configuration key for using cooperative locking to achieve a directory mutation operations

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -355,17 +355,23 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<String> GCS_GRPC_SERVER_ADDRESS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.server.address");
 
+  /**
+   * Configuration key for the connect timeout (in millisecond) for gRPC read requests to GCS.
+   */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_READ_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
 
+  /** Configuration key for the connect timeout (in millisecond) for gRPC metadata requests to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_READ_METADATA_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
 
+  /** Configuration key for the connect timeout (in millisecond) for gRPC write requests to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_WRITE_TIMEOUT_MS =
       new HadoopConfigurationProperty<>("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
 
+  /** Configuration key for the number of requests to be buffered for uploads to GCS. */
   public static final HadoopConfigurationProperty<Long> GCS_GRPC_UPLOAD_REQUESTS_BUFFER =
-      new HadoopConfigurationProperty<>("fs.gs.grpc.write.requests.buffered", 20L);
+      new HadoopConfigurationProperty<>("fs.gs.grpc.write.buffered.requests", 20L);
 
   /**
    * Configuration key for using cooperative locking to achieve a directory mutation operations

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -80,7 +80,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
           put("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
-          put("fs.gs.grpc.write.requests.buffered", 20L);
+          put("fs.gs.grpc.write.buffered.requests", 20L);
           put("fs.gs.http.connect-timeout", 20_000);
           put("fs.gs.http.max.retry", 10);
           put("fs.gs.http.read-timeout", 20_000);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -19,6 +19,10 @@ import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ENCRYPTION_ALGORITHM;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ENCRYPTION_KEY;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ENCRYPTION_KEY_HASH;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_READ_METADATA_TIMEOUT_MS;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_READ_TIMEOUT_MS;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_UPLOAD_BUFFERED_REQUESTS;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_WRITE_TIMEOUT_MS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_HTTP_HEADERS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ROOT_URL;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_SERVICE_PATH;
@@ -29,6 +33,7 @@ import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_U
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.cloud.hadoop.util.testing.HadoopConfigurationUtils.getDefaultProperties;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.GcsFileChecksumType;
@@ -321,5 +326,30 @@ public class GoogleHadoopFileSystemConfigurationTest {
     assertThrows(
         RuntimeException.class,
         () -> GoogleHadoopFileSystemConfiguration.getGcsOptionsBuilder(config).build());
+  }
+
+  @Test
+  public void testGrpcConfiguration() {
+    Configuration config = new Configuration();
+    long grpcReadTimeout = 10;
+    long grpcReadMetadataTimeout = 15;
+    long grpcWriteTimeout = 20;
+    long grpcUploadBufferedRequests = 25;
+
+    config.set(GCS_GRPC_READ_TIMEOUT_MS.getKey(), String.valueOf(grpcReadTimeout));
+    config.set(GCS_GRPC_READ_METADATA_TIMEOUT_MS.getKey(), String.valueOf(grpcReadMetadataTimeout));
+    config.set(GCS_GRPC_WRITE_TIMEOUT_MS.getKey(), String.valueOf(grpcWriteTimeout));
+    config.set(GCS_GRPC_UPLOAD_BUFFERED_REQUESTS.getKey(),
+        String.valueOf(grpcUploadBufferedRequests));
+
+    GoogleCloudStorageOptions options =
+        GoogleHadoopFileSystemConfiguration.getGcsOptionsBuilder(config).build();
+
+    assertEquals(options.getReadChannelOptions().getGrpcReadTimeoutMillis(), grpcReadTimeout);
+    assertEquals(options.getReadChannelOptions().getGrpcReadMetadataTimeoutMillis(),
+        grpcReadMetadataTimeout);
+    assertEquals(options.getWriteChannelOptions().getGrpcWriteTimeout(), grpcWriteTimeout);
+    assertEquals(options.getWriteChannelOptions().getNumberOfBufferedRequests(),
+        grpcUploadBufferedRequests);
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -76,11 +76,11 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.glob.algorithm", GlobAlgorithm.CONCURRENT);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.enable", false);
-          put("fs.gs.grpc.server.address", null);
+          put("fs.gs.grpc.outputstream.buffered.requests", 20L);
           put("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
           put("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
+          put("fs.gs.grpc.server.address", null);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
-          put("fs.gs.grpc.write.buffered.requests", 20L);
           put("fs.gs.http.connect-timeout", 20_000);
           put("fs.gs.http.max.retry", 10);
           put("fs.gs.http.read-timeout", 20_000);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -76,10 +76,10 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.glob.algorithm", GlobAlgorithm.CONCURRENT);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.enable", false);
-          put("fs.gs.grpc.outputstream.buffered.requests", 20L);
           put("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
           put("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
           put("fs.gs.grpc.server.address", null);
+          put("fs.gs.grpc.write.buffered.requests", 20L);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
           put("fs.gs.http.connect-timeout", 20_000);
           put("fs.gs.http.max.retry", 10);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -80,6 +80,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.grpc.read.timeout.ms", 20 * 60 * 1000L);
           put("fs.gs.grpc.read.metadata.timeout.ms", 60 * 1000L);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
+          put("fs.gs.grpc.write.requests.buffered", 20L);
           put("fs.gs.http.connect-timeout", 20_000);
           put("fs.gs.http.max.retry", 10);
           put("fs.gs.http.read-timeout", 20_000);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -33,7 +33,6 @@ import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_U
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.USER_IMPERSONATION_SERVICE_ACCOUNT_SUFFIX;
 import static com.google.cloud.hadoop.util.testing.HadoopConfigurationUtils.getDefaultProperties;
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.GcsFileChecksumType;
@@ -345,11 +344,12 @@ public class GoogleHadoopFileSystemConfigurationTest {
     GoogleCloudStorageOptions options =
         GoogleHadoopFileSystemConfiguration.getGcsOptionsBuilder(config).build();
 
-    assertEquals(options.getReadChannelOptions().getGrpcReadTimeoutMillis(), grpcReadTimeout);
-    assertEquals(options.getReadChannelOptions().getGrpcReadMetadataTimeoutMillis(),
+    assertThat(options.getReadChannelOptions().getGrpcReadTimeoutMillis())
+        .isEqualTo(grpcReadTimeout);
+    assertThat(options.getReadChannelOptions().getGrpcReadMetadataTimeoutMillis()).isEqualTo(
         grpcReadMetadataTimeout);
-    assertEquals(options.getWriteChannelOptions().getGrpcWriteTimeout(), grpcWriteTimeout);
-    assertEquals(options.getWriteChannelOptions().getNumberOfBufferedRequests(),
+    assertThat(options.getWriteChannelOptions().getGrpcWriteTimeout()).isEqualTo(grpcWriteTimeout);
+    assertThat(options.getWriteChannelOptions().getNumberOfBufferedRequests()).isEqualTo(
         grpcUploadBufferedRequests);
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -225,7 +225,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
               ByteString.readFrom(
                   ByteStreams.limit(pipeSource, MAX_BYTES_PER_MESSAGE), MAX_BYTES_PER_MESSAGE);
           dataChunkMap.put(writeOffset, data);
-          if (dataChunkMap.size() >= channelOptions.getNumberOfRequestsBuffered()) {
+          if (dataChunkMap.size() >= channelOptions.getNumberOfBufferedRequests()) {
             dataChunkMap.remove(dataChunkMap.firstKey());
           }
           insertRequest = buildInsertRequest(writeOffset, data, false);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -73,7 +73,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
   // more complex implementation that periodically queries the service to find out the last
   // committed offset, to determine what's safe to discard, but that would also impose a performance
   // penalty.
-  private static final int NUMBER_OF_REQUESTS_TO_RETAIN = 5;
+  private static final int NUMBER_OF_REQUESTS_TO_RETAIN = 20;
   // A set that defines all transient errors on which retry can be attempted.
   private static final ImmutableSet<Status.Code> TRANSIENT_ERRORS =
       ImmutableSet.of(
@@ -320,7 +320,8 @@ public final class GoogleCloudStorageGrpcWriteChannel
       InsertObjectRequest request = null;
       if (dataChunkMap.size() > 0 && dataChunkMap.firstKey() <= writeOffset) {
         for (Map.Entry<Long, ByteString> entry : dataChunkMap.entrySet()) {
-          if (entry.getKey() + entry.getValue().size() > writeOffset) {
+          if (entry.getKey() + entry.getValue().size() > writeOffset
+              || entry.getKey() == writeOffset) {
             Long writeOffsetToResume = entry.getKey();
             ByteString chunkData = entry.getValue();
             request = buildInsertRequest(writeOffsetToResume, chunkData, true);

--- a/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
@@ -20,44 +20,69 @@ import com.google.api.client.googleapis.media.MediaHttpUploader;
 import com.google.auto.value.AutoValue;
 import com.google.common.flogger.GoogleLogger;
 
-/** Options for the {@link AbstractGoogleAsyncWriteChannel}. */
+/**
+ * Options for the {@link AbstractGoogleAsyncWriteChannel}.
+ */
 @AutoValue
 public abstract class AsyncWriteChannelOptions {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  /** Pipe used for output stream. */
+  /**
+   * Pipe used for output stream.
+   */
   public enum PipeType {
     NIO_CHANNEL_PIPE,
     IO_STREAM_PIPE,
   }
 
-  /** Default upload buffer size. */
+  /**
+   * Default upload buffer size.
+   */
   public static final int BUFFER_SIZE_DEFAULT = 8 * 1024 * 1024;
 
-  /** Default pipe buffer size. */
+  /**
+   * Default pipe buffer size.
+   */
   public static final int PIPE_BUFFER_SIZE_DEFAULT = 1024 * 1024;
 
-  /** Upload chunk size granularity */
+  /**
+   * Upload chunk size granularity
+   */
   public static final int UPLOAD_CHUNK_SIZE_GRANULARITY = 8 * 1024 * 1024;
 
-  /** Default upload chunk size. */
+  /**
+   * Default upload chunk size.
+   */
   public static final int UPLOAD_CHUNK_SIZE_DEFAULT =
       Runtime.getRuntime().maxMemory() < 512 * 1024 * 1024
           ? UPLOAD_CHUNK_SIZE_GRANULARITY
           : 8 * UPLOAD_CHUNK_SIZE_GRANULARITY;
 
-  /** Default upload cache size. */
+  /**
+   * Default upload cache size.
+   */
   public static final int UPLOAD_CACHE_SIZE_DEFAULT = 0;
 
-  /** Default of whether to use direct upload. */
+  /**
+   * Default of whether to use direct upload.
+   */
   public static final boolean DIRECT_UPLOAD_ENABLED_DEFAULT = false;
 
-  /** Default of whether to enabled checksums for gRPC. */
+  /**
+   * Default of whether to enabled checksums for gRPC.
+   */
   public static final boolean GRPC_CHECKSUMS_ENABLED_DEFAULT = false;
 
-  /** Default timeout for grpc write stream. */
+  /**
+   * Default timeout for grpc write stream.
+   */
   public static final long DEFAULT_GRPC_WRITE_TIMEOUT = 10 * 60 * 1000;
+
+  /**
+   * Default number of insert requests to retain, in case we need to rewind and resume an upload
+   */
+  public static final long DEFAULT_NUM_REQUESTS_BUFFERED_GRPC = 20;
 
   public static final PipeType PIPE_TYPE_DEFAULT = PipeType.IO_STREAM_PIPE;
 
@@ -72,7 +97,8 @@ public abstract class AsyncWriteChannelOptions {
         .setUploadCacheSize(UPLOAD_CACHE_SIZE_DEFAULT)
         .setDirectUploadEnabled(DIRECT_UPLOAD_ENABLED_DEFAULT)
         .setGrpcChecksumsEnabled(GRPC_CHECKSUMS_ENABLED_DEFAULT)
-        .setGrpcWriteTimeout(DEFAULT_GRPC_WRITE_TIMEOUT);
+        .setGrpcWriteTimeout(DEFAULT_GRPC_WRITE_TIMEOUT)
+        .setNumberOfRequestsBuffered(DEFAULT_NUM_REQUESTS_BUFFERED_GRPC);
   }
 
   public abstract Builder toBuilder();
@@ -93,7 +119,11 @@ public abstract class AsyncWriteChannelOptions {
 
   public abstract long getGrpcWriteTimeout();
 
-  /** Mutable builder for the GoogleCloudStorageWriteChannelOptions class. */
+  public abstract long getNumberOfRequestsBuffered();
+
+  /**
+   * Mutable builder for the GoogleCloudStorageWriteChannelOptions class.
+   */
   @AutoValue.Builder
   public abstract static class Builder {
 
@@ -110,6 +140,8 @@ public abstract class AsyncWriteChannelOptions {
     public abstract Builder setDirectUploadEnabled(boolean directUploadEnabled);
 
     public abstract Builder setGrpcWriteTimeout(long grpcWriteTimeout);
+
+    public abstract Builder setNumberOfRequestsBuffered(long numberOfRequestsBuffered);
 
     /**
      * Enable gRPC checksumming. On by default. It is strongly recommended to leave this enabled, to

--- a/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
@@ -20,9 +20,7 @@ import com.google.api.client.googleapis.media.MediaHttpUploader;
 import com.google.auto.value.AutoValue;
 import com.google.common.flogger.GoogleLogger;
 
-/**
- * Options for the {@link AbstractGoogleAsyncWriteChannel}.
- */
+/** Options for the {@link AbstractGoogleAsyncWriteChannel}. */
 @AutoValue
 public abstract class AsyncWriteChannelOptions {
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
@@ -28,60 +28,40 @@ public abstract class AsyncWriteChannelOptions {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
-  /**
-   * Pipe used for output stream.
-   */
+  /** Pipe used for output stream. */
   public enum PipeType {
     NIO_CHANNEL_PIPE,
     IO_STREAM_PIPE,
   }
 
-  /**
-   * Default upload buffer size.
-   */
+  /** Default upload buffer size. */
   public static final int BUFFER_SIZE_DEFAULT = 8 * 1024 * 1024;
 
-  /**
-   * Default pipe buffer size.
-   */
+  /** Default pipe buffer size. */
   public static final int PIPE_BUFFER_SIZE_DEFAULT = 1024 * 1024;
 
-  /**
-   * Upload chunk size granularity
-   */
+  /** Upload chunk size granularity */
   public static final int UPLOAD_CHUNK_SIZE_GRANULARITY = 8 * 1024 * 1024;
 
-  /**
-   * Default upload chunk size.
-   */
+  /** Default upload chunk size. */
   public static final int UPLOAD_CHUNK_SIZE_DEFAULT =
       Runtime.getRuntime().maxMemory() < 512 * 1024 * 1024
           ? UPLOAD_CHUNK_SIZE_GRANULARITY
           : 8 * UPLOAD_CHUNK_SIZE_GRANULARITY;
 
-  /**
-   * Default upload cache size.
-   */
+  /** Default upload cache size. */
   public static final int UPLOAD_CACHE_SIZE_DEFAULT = 0;
 
-  /**
-   * Default of whether to use direct upload.
-   */
+  /** Default of whether to use direct upload. */
   public static final boolean DIRECT_UPLOAD_ENABLED_DEFAULT = false;
 
-  /**
-   * Default of whether to enabled checksums for gRPC.
-   */
+  /** Default of whether to enabled checksums for gRPC. */
   public static final boolean GRPC_CHECKSUMS_ENABLED_DEFAULT = false;
 
-  /**
-   * Default timeout for grpc write stream.
-   */
+  /** Default timeout for grpc write stream. */
   public static final long DEFAULT_GRPC_WRITE_TIMEOUT = 10 * 60 * 1000;
 
-  /**
-   * Default number of insert requests to retain, in case we need to rewind and resume an upload
-   */
+  /** Default number of insert requests to retain, in case we need to rewind and resume an upload */
   public static final long DEFAULT_NUM_REQUESTS_BUFFERED_GRPC = 20;
 
   public static final PipeType PIPE_TYPE_DEFAULT = PipeType.IO_STREAM_PIPE;
@@ -121,9 +101,7 @@ public abstract class AsyncWriteChannelOptions {
 
   public abstract long getNumberOfBufferedRequests();
 
-  /**
-   * Mutable builder for the GoogleCloudStorageWriteChannelOptions class.
-   */
+  /** Mutable builder for the GoogleCloudStorageWriteChannelOptions class. */
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AsyncWriteChannelOptions.java
@@ -98,7 +98,7 @@ public abstract class AsyncWriteChannelOptions {
         .setDirectUploadEnabled(DIRECT_UPLOAD_ENABLED_DEFAULT)
         .setGrpcChecksumsEnabled(GRPC_CHECKSUMS_ENABLED_DEFAULT)
         .setGrpcWriteTimeout(DEFAULT_GRPC_WRITE_TIMEOUT)
-        .setNumberOfRequestsBuffered(DEFAULT_NUM_REQUESTS_BUFFERED_GRPC);
+        .setNumberOfBufferedRequests(DEFAULT_NUM_REQUESTS_BUFFERED_GRPC);
   }
 
   public abstract Builder toBuilder();
@@ -119,7 +119,7 @@ public abstract class AsyncWriteChannelOptions {
 
   public abstract long getGrpcWriteTimeout();
 
-  public abstract long getNumberOfRequestsBuffered();
+  public abstract long getNumberOfBufferedRequests();
 
   /**
    * Mutable builder for the GoogleCloudStorageWriteChannelOptions class.
@@ -141,7 +141,7 @@ public abstract class AsyncWriteChannelOptions {
 
     public abstract Builder setGrpcWriteTimeout(long grpcWriteTimeout);
 
-    public abstract Builder setNumberOfRequestsBuffered(long numberOfRequestsBuffered);
+    public abstract Builder setNumberOfBufferedRequests(long numberOfBufferedRequests);
 
     /**
      * Enable gRPC checksumming. On by default. It is strongly recommended to leave this enabled, to


### PR DESCRIPTION
* In case of failure in last chunk, the resumable upload offset is equal to `bufferedChunkDataMap.key`, since the size of data is `0`. Adding additional condition to account for this case
   * `entry.getKey() == writeOffset`   ensures that only the chunk with data size `0` is selected but not the chunk before as condition `
entry.getKey() + entry.getValue().size() == writeOffset` is satisfied by both the chunks in the buffer
* Also Increase number of requests to be buffered for resumable upload to 20
