### PR TITLE
Update the AuthorizationHandler interface

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/authorization/AuthorizationHandler.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/authorization/AuthorizationHandler.java
@@ -1,9 +1,11 @@
 package com.google.cloud.hadoop.gcsio.authorization;
 
+import com.google.common.collect.ImmutableSet;
 import java.net.URI;
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * All custom authorization handler implementation should implement this interface.
@@ -27,8 +29,9 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleListObjects(URI resource) throws AccessDeniedException;
+  String handleListObjects(URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/objects/insert>insert object
@@ -36,8 +39,9 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleInsertObject(URI resource) throws AccessDeniedException;
+  String handleInsertObject(URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/objects/compose>compose
@@ -46,8 +50,9 @@ public interface AuthorizationHandler {
    * @param destinationResource URI of destination GCS object.
    * @param sourceResources A list of source GCS objects' URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleComposeObject(URI destinationResource, List<URI> sourceResources)
+  String handleComposeObject(URI destinationResource, List<URI> sourceResources)
       throws AccessDeniedException;
 
   /**
@@ -56,8 +61,9 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleGetObject(URI resource) throws AccessDeniedException;
+  String handleGetObject(URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/objects/delete>delete object
@@ -65,8 +71,9 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleDeleteObject(URI resource) throws AccessDeniedException;
+  String handleDeleteObject(URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite>rewrite
@@ -75,8 +82,9 @@ public interface AuthorizationHandler {
    * @param sourceResource The source GCS object URI.
    * @param destinationResource The destination GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleRewriteObject(URI sourceResource, URI destinationResource)
+  String handleRewriteObject(URI sourceResource, URI destinationResource)
       throws AccessDeniedException;
 
   /**
@@ -86,8 +94,9 @@ public interface AuthorizationHandler {
    * @param sourceResource The source GCS object URI.
    * @param destinationResource The destination GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleCopyObject(URI sourceResource, URI destinationResource) throws AccessDeniedException;
+  String handleCopyObject(URI sourceResource, URI destinationResource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/objects/patch>patch object
@@ -95,8 +104,9 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS object URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handlePatchObject(URI resource) throws AccessDeniedException;
+  String handlePatchObject(URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/buckets/list>list bucket
@@ -104,8 +114,9 @@ public interface AuthorizationHandler {
    *
    * @param project A GCP project ID in which buckets are listed.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleListBuckets(String project) throws AccessDeniedException;
+  String handleListBuckets(String project) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/buckets/insert>insert bucket
@@ -114,8 +125,9 @@ public interface AuthorizationHandler {
    * @param project A GCP project ID where bucket created.
    * @param resource A GCS bucket URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleInsertBucket(String project, URI resource) throws AccessDeniedException;
+  String handleInsertBucket(String project, URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/buckets/get>get bucket
@@ -123,8 +135,9 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS bucket URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleGetBucket(URI resource) throws AccessDeniedException;
+  String handleGetBucket(URI resource) throws AccessDeniedException;
 
   /**
    * Handles <a href=https://cloud.google.com/storage/docs/json_api/v1/buckets/delete>delete bucket
@@ -132,6 +145,46 @@ public interface AuthorizationHandler {
    *
    * @param resource A GCS bucket URI.
    * @throws AccessDeniedException Thrown when access denied.
+   * @return Access Token.
    */
-  void handleDeleteBucket(URI resource) throws AccessDeniedException;
+  String handleDeleteBucket(URI resource) throws AccessDeniedException;
+
+  /**
+   * Returns the information used to acquire an access token.
+   *
+   * @param accessToken The access token.
+   * @return Authorization Request information.
+   */
+  AuthorizationRequest getAuthorizationRequestByAccessToken(String accessToken);
+
+  final class AuthorizationRequest {
+    private final String bucket;
+    private final String objectPath;
+    private final String user;
+    private final Set<String> userGroup;
+
+    public AuthorizationRequest(String bucket, String objectPath, String user,
+        Set<String> userGroup) {
+      this.bucket = bucket;
+      this.objectPath = objectPath;
+      this.user = user;
+      this.userGroup = ImmutableSet.copyOf(userGroup);
+    }
+
+    public String getBucket() {
+      return bucket;
+    }
+
+    public String getObjectPath() {
+      return objectPath;
+    }
+
+    public String getUser() {
+      return user;
+    }
+
+    public Set<String> getUserGroup() {
+      return userGroup;
+    }
+  }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/authorization/StorageRequestAuthorizer.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/authorization/StorageRequestAuthorizer.java
@@ -57,18 +57,19 @@ public class StorageRequestAuthorizer {
    *
    * @param request Storage request to be authorized.
    * @throws AccessDeniedException Thrown when access denied by AuthorizationHandler.
+   * @return access token.
    */
-  public void authorize(StorageRequest<?> request) throws AccessDeniedException {
+  public String authorize(StorageRequest<?> request) throws AccessDeniedException {
     logger.atFiner().log("authorizeStorageRequest(%s)", request);
 
     // Objects
     if (request instanceof Storage.Objects.List) {
       Storage.Objects.List listRequest = (Storage.Objects.List) request;
-      authorizationHandler.handleListObjects(
+      return authorizationHandler.handleListObjects(
           getGcsUri(listRequest.getBucket(), listRequest.getPrefix()));
     } else if (request instanceof Storage.Objects.Insert) {
       Storage.Objects.Insert insertRequest = (Storage.Objects.Insert) request;
-      authorizationHandler.handleInsertObject(
+      return authorizationHandler.handleInsertObject(
           getGcsUri(insertRequest.getBucket(), ((StorageObject) getData(request)).getName()));
     } else if (request instanceof Storage.Objects.Compose) {
       Storage.Objects.Compose composeRequest = (Storage.Objects.Compose) request;
@@ -79,44 +80,44 @@ public class StorageRequestAuthorizer {
               .getSourceObjects().stream()
                   .map(source -> getGcsUri(bucket, source.getName()))
                   .collect(toImmutableList());
-      authorizationHandler.handleComposeObject(destination, sources);
+      return authorizationHandler.handleComposeObject(destination, sources);
     } else if (request instanceof Storage.Objects.Get) {
       Storage.Objects.Get getRequest = (Storage.Objects.Get) request;
-      authorizationHandler.handleGetObject(
+      return authorizationHandler.handleGetObject(
           getGcsUri(getRequest.getBucket(), getRequest.getObject()));
     } else if (request instanceof Storage.Objects.Delete) {
       Storage.Objects.Delete deleteRequest = (Storage.Objects.Delete) request;
-      authorizationHandler.handleDeleteObject(
+      return authorizationHandler.handleDeleteObject(
           getGcsUri(deleteRequest.getBucket(), deleteRequest.getObject()));
     } else if (request instanceof Storage.Objects.Rewrite) {
       Storage.Objects.Rewrite rewriteRequest = (Storage.Objects.Rewrite) request;
-      authorizationHandler.handleRewriteObject(
+      return authorizationHandler.handleRewriteObject(
           getGcsUri(rewriteRequest.getSourceBucket(), rewriteRequest.getSourceObject()),
           getGcsUri(rewriteRequest.getDestinationBucket(), rewriteRequest.getDestinationObject()));
 
     } else if (request instanceof Storage.Objects.Copy) {
       Storage.Objects.Copy copyRequest = (Storage.Objects.Copy) request;
-      authorizationHandler.handleCopyObject(
+      return authorizationHandler.handleCopyObject(
           getGcsUri(copyRequest.getSourceBucket(), copyRequest.getSourceObject()),
           getGcsUri(copyRequest.getDestinationBucket(), copyRequest.getDestinationObject()));
     } else if (request instanceof Storage.Objects.Patch) {
       Storage.Objects.Patch patchRequest = (Storage.Objects.Patch) request;
-      authorizationHandler.handlePatchObject(
+      return authorizationHandler.handlePatchObject(
           getGcsUri(patchRequest.getBucket(), patchRequest.getObject()));
     }
 
     // Buckets
     else if (request instanceof Storage.Buckets.List) {
-      authorizationHandler.handleListBuckets(((Storage.Buckets.List) request).getProject());
+      return authorizationHandler.handleListBuckets(((Storage.Buckets.List) request).getProject());
     } else if (request instanceof Storage.Buckets.Insert) {
-      authorizationHandler.handleInsertBucket(
+      return authorizationHandler.handleInsertBucket(
           ((Storage.Buckets.Insert) request).getProject(),
           getGcsUri(((Bucket) getData(request)).getName(), /* objectPath= */ null));
     } else if (request instanceof Storage.Buckets.Get) {
-      authorizationHandler.handleGetBucket(
+      return authorizationHandler.handleGetBucket(
           getGcsUri(((Storage.Buckets.Get) request).getBucket(), /* objectPath= */ null));
     } else if (request instanceof Storage.Buckets.Delete) {
-      authorizationHandler.handleDeleteBucket(
+      return authorizationHandler.handleDeleteBucket(
           getGcsUri(((Storage.Buckets.Delete) request).getBucket(), /* objectPath= */ null));
     }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/authorization/FakeAuthorizationHandler.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/authorization/FakeAuthorizationHandler.java
@@ -2,6 +2,7 @@ package com.google.cloud.hadoop.gcsio.authorization;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableSet;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -17,38 +18,67 @@ public class FakeAuthorizationHandler implements AuthorizationHandler {
   }
 
   @Override
-  public void handleListObjects(URI resource) {}
+  public String handleListObjects(URI resource) {
+    return "";
+  }
 
   @Override
-  public void handleInsertObject(URI resource) {}
+  public String handleInsertObject(URI resource)  {
+    return "";
+  }
 
   @Override
-  public void handleComposeObject(URI destinationResource, List<URI> sourceResources) {}
+  public String handleComposeObject(URI destinationResource, List<URI> sourceResources)  {
+    return "";
+  }
 
   @Override
-  public void handleGetObject(URI resource) {}
+  public String handleGetObject(URI resource)  {
+    return "";
+  }
 
   @Override
-  public void handleDeleteObject(URI resource) {}
+  public String handleDeleteObject(URI resource)  {
+    return "";
+  }
 
   @Override
-  public void handleRewriteObject(URI sourceResource, URI destinationResource) {}
+  public String handleRewriteObject(URI sourceResource, URI destinationResource)  {
+    return "";
+  }
 
   @Override
-  public void handleCopyObject(URI sourceResource, URI destinationResource) {}
+  public String handleCopyObject(URI sourceResource, URI destinationResource)  {
+    return "";
+  }
 
   @Override
-  public void handlePatchObject(URI resource) {}
+  public String handlePatchObject(URI resource)  {
+    return "";
+  }
 
   @Override
-  public void handleListBuckets(String project) {}
+  public String handleListBuckets(String project)  {
+    return "";
+  }
 
   @Override
-  public void handleInsertBucket(String project, URI resource) {}
+  public String handleInsertBucket(String project, URI resource)  {
+    return "";
+  }
 
   @Override
-  public void handleGetBucket(URI resource) {}
+  public String handleGetBucket(URI resource)  {
+    return "";
+  }
 
   @Override
-  public void handleDeleteBucket(URI resource) {}
+  public String handleDeleteBucket(URI resource)  {
+    return "";
+  }
+
+  @Override
+  public AuthorizationRequest getAuthorizationRequestByAccessToken(String accessToken) {
+    return new AuthorizationRequest( "test-bucket", "test-object", "test-user", ImmutableSet.of("test-group"));
+  }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/authorization/StorageRequestAuthorizerTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/authorization/StorageRequestAuthorizerTest.java
@@ -2,12 +2,13 @@ package com.google.cloud.hadoop.gcsio.authorization;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -76,14 +77,15 @@ public class StorageRequestAuthorizerTest {
     // Any StorageRequest will do
     Storage.Objects.List list = newStorage().objects().list(BUCKET_NAME).setPrefix(OBJECT_NAME);
 
-    doNothing().when(mockHandler).handleListObjects(any(URI.class));
+    when(mockHandler.handleListObjects(any(URI.class))).thenReturn("AccessTokenString");
 
     StorageRequestAuthorizer authorizer = new StorageRequestAuthorizer(mockHandler);
 
-    authorizer.authorize(list);
+    String actualToken = authorizer.authorize(list);
 
     // Nothing should happen when access allowed.
     verify(mockHandler).handleListObjects(any(URI.class));
+    assertEquals("AccessTokenString", actualToken);
   }
 
   @Test


### PR DESCRIPTION
Changes:
1. Change the AuthorizationHandler interface to return an access token from all requests.
2. Inject the Authorization header if the access token was provided by the Authorization Handler.