### PR TITLE
Evict gRPC channel from pool, for transient errors

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -581,6 +581,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private void recreateStub(StatusRuntimeException e) {
     if (stubProvider.isStubBroken(Status.fromThrowable(e).getCode())) {
+      stubProvider.evictChannelFromPool(stub.getChannel());
       stub = stubProvider.newBlockingStub();
     }
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -335,6 +335,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
 
     private void recreateStub(Status.Code statusCode) {
       if (stubProvider.isStubBroken(statusCode)) {
+        stubProvider.evictChannelFromPool(stub.getChannel());
         stub = stubProvider.newAsyncStub();
       }
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -159,12 +159,12 @@ class StorageStubProvider {
         return false;
       }
       ChannelAndRequestCounter that = (ChannelAndRequestCounter) o;
-      return com.google.common.base.Objects.equal(channel, that.channel);
+      return Objects.equals(channel, that.channel);
     }
 
     @Override
     public int hashCode() {
-      return com.google.common.base.Objects.hashCode(channel);
+      return Objects.hash(channel);
     }
   }
 


### PR DESCRIPTION
On transient errors, we re-create the Storage stub, which internally uses the same channel pool. We end up with re-using the same channel (as number of active requests may not have altered the priority order in the pool) and error for the next attempt as well.

Evicting the channel from pool, will ensure that the same channel is not re-used in new stubs.