### PR TITLE
Prevent on using dot in a bucket name when running integration tests

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -245,7 +245,8 @@ public class GoogleCloudStorageTestHelper {
     }
 
     private static String makeBucketName(String prefix) {
-      String username = System.getProperty("user.name", "unknown").replace("-", "");
+      String username = System.getProperty("user.name", "unknown")
+          .replace("-", "").replace(".", "");
       username = username.substring(0, Math.min(username.length(), 10));
       String uuidSuffix = UUID.randomUUID().toString().substring(0, 8);
       return prefix + DELIMITER + username + DELIMITER + uuidSuffix;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -245,8 +245,7 @@ public class GoogleCloudStorageTestHelper {
     }
 
     private static String makeBucketName(String prefix) {
-      String username = System.getProperty("user.name", "unknown")
-          .replace("-", "").replace(".", "");
+      String username = System.getProperty("user.name", "unknown").replaceAll("[-.]", "");
       username = username.substring(0, Math.min(username.length(), 10));
       String uuidSuffix = UUID.randomUUID().toString().substring(0, 8);
       return prefix + DELIMITER + username + DELIMITER + uuidSuffix;


### PR DESCRIPTION
This small PR is removing the occurrence of . ("dot") character in the system username for generating the bucket name when running the integration test. 

To reproduce the error:
Set the `user.name` property with any username that has dot character in it, and run the integration tests.