### PR TITLE
Adding `com.google` debug logging configuration flag 

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -213,6 +213,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Long> GCS_REWRITE_MAX_BYTES_PER_CALL =
       new HadoopConfigurationProperty<>("fs.gs.rewrite.max.bytes.per.call", 512 * 1024 * 1024L);
 
+  /** Configuration key for enabling gcs debug logging. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_ENABLE_DEBUG_LOGGING =
+      new HadoopConfigurationProperty<>("fs.gs.debug.logging.enable", false);
+
   /** Configuration key for number of items to return per call to the list* GCS RPCs. */
   public static final HadoopConfigurationProperty<Long> GCS_MAX_LIST_ITEMS_PER_CALL =
       new HadoopConfigurationProperty<>("fs.gs.list.max.items.per.call", 1024L);
@@ -445,6 +449,7 @@ public class GoogleHadoopFileSystemConfiguration {
         .setAutoRepairImplicitDirectoriesEnabled(
             GCS_REPAIR_IMPLICIT_DIRECTORIES_ENABLE.get(config, config::getBoolean))
         .setCopyWithRewriteEnabled(GCS_COPY_WITH_REWRITE_ENABLE.get(config, config::getBoolean))
+        .setEnableDebugLogging(GCS_ENABLE_DEBUG_LOGGING.get(config, config::getBoolean))
         .setMaxBytesRewrittenPerCall(GCS_REWRITE_MAX_BYTES_PER_CALL.get(config, config::getLong))
         .setTransportType(
             HTTP_TRANSPORT_SUFFIX.withPrefixes(CONFIG_KEY_PREFIXES).get(config, config::getEnum))

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -121,6 +121,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.storage.root.url", "https://storage.googleapis.com/");
           put("fs.gs.storage.service.path", "storage/v1/");
           put("fs.gs.working.dir", "/");
+          put("fs.gs.debug.logging.enable", false);
         }
       };
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -101,6 +101,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
 /**
@@ -239,6 +241,10 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   // Function that generates downscoped access token.
   private final Function<List<AccessBoundary>, String> downscopedAccessTokenFn;
 
+  // Google root logger, logger that spans over the <package_shading_prefix>.com.google.* coverage.
+  private static final Logger googleLogger = Logger.getLogger(
+      GoogleLogger.class.getName().replaceAll("(com\\.google).*", "$1"));
+
   /**
    * Constructs an instance of GoogleCloudStorageImpl.
    *
@@ -355,6 +361,11 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
 
     this.storageRequestAuthorizer = initializeStorageRequestAuthorizer(storageOptions);
     this.downscopedAccessTokenFn = downscopedAccessTokenFn;
+
+    // Set GSC connector logging-level based on the passed debug logging option.
+    if (googleLogger.getLevel() == null) {
+      googleLogger.setLevel(this.storageOptions.isEnableDebugLogging() ? Level.CONFIG : Level.INFO);
+    }
   }
 
   private static Storage createStorage(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -91,6 +91,8 @@ public abstract class GoogleCloudStorageOptions {
   public static final Map<String, String> AUTHORIZATION_HANDLER_PROPERTIES_DEFAULT =
       ImmutableMap.of();
 
+  public static final boolean ENABLE_DEBUG_LOGGING_DEFAULT = false;
+
   public static final GoogleCloudStorageOptions DEFAULT = builder().build();
 
   public static Builder builder() {
@@ -114,6 +116,7 @@ public abstract class GoogleCloudStorageOptions {
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setRequesterPaysOptions(RequesterPaysOptions.DEFAULT)
         .setCooperativeLockingOptions(CooperativeLockingOptions.DEFAULT)
+        .setEnableDebugLogging(ENABLE_DEBUG_LOGGING_DEFAULT)
         .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT)
         .setAuthorizationHandlerImplClass(AUTHORIZATION_HANDLER_IMPL_CLASS_DEFAULT)
         .setAuthorizationHandlerProperties(AUTHORIZATION_HANDLER_PROPERTIES_DEFAULT);
@@ -167,6 +170,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract long getMaxBytesRewrittenPerCall();
 
   public abstract GoogleCloudStorageReadOptions getReadChannelOptions();
+
+  public abstract boolean isEnableDebugLogging();
 
   public abstract AsyncWriteChannelOptions getWriteChannelOptions();
 
@@ -258,6 +263,8 @@ public abstract class GoogleCloudStorageOptions {
 
     public abstract Builder setCooperativeLockingOptions(
         CooperativeLockingOptions cooperativeLockingOptions);
+
+    public abstract Builder setEnableDebugLogging(boolean enableDebugLogging);
 
     public abstract Builder setHttpRequestHeaders(Map<String, String> httpRequestHeaders);
 


### PR DESCRIPTION
There could be a common use cases where the user needs to enable the debug log for the connector but has no access to the JVM/cluster that is running it , where attaching the logging configuration can't be done.

This PR is adding a new Hadoop configuration `fs.gs.debug.logging.enable` for enabling the global debug logging (`com.google.*`) which might include:
* `com.google.api.client.http` for HTTP requests logging
* `com.google.cloud.hadoop.gcsio`
* `com.google.cloud.hadoop.util`