### PR TITLE
Revert "Use 8-jdk-slim base image for CI"

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile creates an image for running presubmit tests.
-FROM openjdk:8-jdk-slim
+FROM openjdk:8-jdk
 
 # Copy everything into the container to allow concurrent build execution
 COPY . /hadoop-connectors


### PR DESCRIPTION
Reason or rollback: breaks code coverage that needs `curl` that is absent in slim image