### PR TITLE
Add new maven profile for vpc tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
                 <include>**/*IntegrationTest.java</include>
               </includes>
               <excludes>
-                <exclude>**/GoogleCloudStorageGrpcIntegrationTest.java</exclude>
+                <exclude>**/*GrpcIntegrationTest.java</exclude>
               </excludes>
               <reuseForks>false</reuseForks>
               <forkCount>4</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,43 @@
     </profile>
 
     <profile>
+      <id>integration-test-vpc</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <includes>
+                <include>**/*IntegrationTest.java</include>
+              </includes>
+              <excludes>
+                <exclude>**/GoogleCloudStorageGrpcIntegrationTest.java</exclude>
+              </excludes>
+              <reuseForks>false</reuseForks>
+              <forkCount>4</forkCount>
+              <argLine>-Xmx2g @{argLine}</argLine>
+              <reportNameSuffix>sponge_log</reportNameSuffix>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>coverage</id>
       <build>
         <plugins>


### PR DESCRIPTION
Adding a new maven profile for VPC-SC tests temporarily, ignores gRPC integration tests till VPC-SC tests are supported over gRPC