### PR TITLE
Add integration tests for retrieving dir info using file name

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -331,6 +331,58 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
   }
 
   @Test
+  public void getDirInfo_implicit_objectName_sequential() throws Exception {
+    TrackingHttpRequestInitializer gcsRequestsTracker =
+        new TrackingHttpRequestInitializer(httpRequestsInitializer);
+    GoogleCloudStorageFileSystem gcsFs =
+        newGcsFs(newGcsFsOptions().setStatusParallelEnabled(false).build(), gcsRequestsTracker);
+
+    String bucketName = gcsfsIHelper.sharedBucketName1;
+    String dirObject = getTestResource();
+    URI dirObjectUri = new URI("gs://" + bucketName).resolve("/" + dirObject);
+
+    gcsfsIHelper.createObjects(
+        bucketName, dirObject + "/file1", dirObject + "/file2", dirObject + "/file3");
+
+    FileInfo dirInfo = gcsFs.getFileInfo(new URI("gs://" + bucketName).resolve(dirObject));
+
+    assertThat(gcsRequestsTracker.getAllRequestStrings())
+        .containsExactly(
+            getRequestString(bucketName, dirObject),
+            listRequestWithTrailingDelimiter(
+                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null))
+        .inOrder();
+
+    assertThat(dirInfo.exists()).isTrue();
+    assertThat(dirInfo.getPath().toString()).isEqualTo(dirObjectUri + "/");
+  }
+
+  @Test
+  public void getDirInfo_implicit_dirName_sequential() throws Exception {
+    TrackingHttpRequestInitializer gcsRequestsTracker =
+        new TrackingHttpRequestInitializer(httpRequestsInitializer);
+    GoogleCloudStorageFileSystem gcsFs =
+        newGcsFs(newGcsFsOptions().setStatusParallelEnabled(false).build(), gcsRequestsTracker);
+
+    String bucketName = gcsfsIHelper.sharedBucketName1;
+    String dirObject = getTestResource();
+    URI dirObjectUri = new URI("gs://" + bucketName).resolve("/" + dirObject);
+
+    gcsfsIHelper.createObjects(
+        bucketName, dirObject + "/file1", dirObject + "/file2", dirObject + "/file3");
+
+    FileInfo dirInfo = gcsFs.getFileInfo(new URI("gs://" + bucketName).resolve(dirObject + "/"));
+
+    assertThat(gcsRequestsTracker.getAllRequestStrings())
+        .containsExactly(
+            listRequestWithTrailingDelimiter(
+                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null));
+
+    assertThat(dirInfo.exists()).isTrue();
+    assertThat(dirInfo.getPath().toString()).isEqualTo(dirObjectUri + "/");
+  }
+
+  @Test
   public void getDirInfo_objectName_parallel() throws Exception {
     GoogleCloudStorageFileSystemOptions gcsFsOptions =
         newGcsFsOptions().setStatusParallelEnabled(true).build();
@@ -372,6 +424,61 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
     URI dirObjectUri = new URI("gs://" + bucketName).resolve("/" + dirObject);
 
     gcsfsIHelper.createObjectsWithSubdirs(
+        bucketName, dirObject + "/file1", dirObject + "/file2", dirObject + "/file3");
+
+    FileInfo dirInfo = gcsFs.getFileInfo(new URI("gs://" + bucketName).resolve(dirObject + "/"));
+
+    assertThat(gcsRequestsTracker.getAllRequestStrings())
+        .containsExactly(
+            listRequestWithTrailingDelimiter(
+                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null));
+
+    assertThat(dirInfo.exists()).isTrue();
+    assertThat(dirInfo.getPath().toString()).isEqualTo(dirObjectUri + "/");
+  }
+
+  @Test
+  public void getDirInfo_implicit_objectName_parallel() throws Exception {
+    GoogleCloudStorageFileSystemOptions gcsFsOptions =
+        newGcsFsOptions().setStatusParallelEnabled(true).build();
+
+    TrackingHttpRequestInitializer gcsRequestsTracker =
+        new TrackingHttpRequestInitializer(httpRequestsInitializer);
+    GoogleCloudStorageFileSystem gcsFs = newGcsFs(gcsFsOptions, gcsRequestsTracker);
+
+    String bucketName = gcsfsIHelper.sharedBucketName1;
+    String dirObject = getTestResource();
+    URI dirObjectUri = new URI("gs://" + bucketName).resolve("/" + dirObject);
+
+    gcsfsIHelper.createObjects(
+        bucketName, dirObject + "/file1", dirObject + "/file2", dirObject + "/file3");
+
+    FileInfo dirInfo = gcsFs.getFileInfo(new URI("gs://" + bucketName).resolve(dirObject));
+
+    assertThat(gcsRequestsTracker.getAllRequestStrings())
+        .containsExactly(
+            getRequestString(bucketName, dirObject),
+            listRequestWithTrailingDelimiter(
+                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null));
+
+    assertThat(dirInfo.exists()).isTrue();
+    assertThat(dirInfo.getPath().toString()).isEqualTo(dirObjectUri + "/");
+  }
+
+  @Test
+  public void getDirInfo_implicit_dirName_parallel() throws Exception {
+    GoogleCloudStorageFileSystemOptions gcsFsOptions =
+        newGcsFsOptions().setStatusParallelEnabled(true).build();
+
+    TrackingHttpRequestInitializer gcsRequestsTracker =
+        new TrackingHttpRequestInitializer(httpRequestsInitializer);
+    GoogleCloudStorageFileSystem gcsFs = newGcsFs(gcsFsOptions, gcsRequestsTracker);
+
+    String bucketName = gcsfsIHelper.sharedBucketName1;
+    String dirObject = getTestResource();
+    URI dirObjectUri = new URI("gs://" + bucketName).resolve("/" + dirObject);
+
+    gcsfsIHelper.createObjects(
         bucketName, dirObject + "/file1", dirObject + "/file2", dirObject + "/file3");
 
     FileInfo dirInfo = gcsFs.getFileInfo(new URI("gs://" + bucketName).resolve(dirObject + "/"));

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTest.java
@@ -296,8 +296,10 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
 
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
+            getRequestString(bucketName, dirObject),
             listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null));
+                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null))
+        .inOrder();
 
     assertThat(dirInfo.exists()).isTrue();
     assertThat(dirInfo.getPath().toString()).isEqualTo(dirObjectUri + "/");
@@ -348,6 +350,7 @@ public class GoogleCloudStorageFileSystemNewIntegrationTest {
 
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
+            getRequestString(bucketName, dirObject),
             listRequestWithTrailingDelimiter(
                 bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null));
 


### PR DESCRIPTION
Add test that retrieves non-empty regular and implicit directory info using its object name (i.e. without trailing `/`)