### PR TITLE
Switch gRPC lb policy to round_robin

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -658,7 +658,6 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
                 requestContext.detach(toReattach);
               }
             } catch (StatusRuntimeException e) {
-              recreateStub(e);
               throw convertError(e, resourceId);
             }
             return null;
@@ -711,7 +710,6 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
               }
               return moreDataAvailable;
             } catch (StatusRuntimeException e) {
-              recreateStub(e);
               throw convertError(e, resourceId);
             }
           },
@@ -721,13 +719,6 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     } catch (Exception e) {
       cancelCurrentRequest();
       throw new IOException(String.format("Error reading '%s'", resourceId), e);
-    }
-  }
-
-  private void recreateStub(StatusRuntimeException e) {
-    if (stubProvider.isStubBroken(Status.fromThrowable(e).getCode())) {
-      stubProvider.evictChannelFromPool(stub.getChannel());
-      stub = stubProvider.newBlockingStub();
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -18,41 +18,20 @@ import com.google.storage.v2.StorageGrpc;
 import com.google.storage.v2.StorageGrpc.StorageBlockingStub;
 import com.google.storage.v2.StorageGrpc.StorageStub;
 import com.google.storage.v2.StorageProto;
-import io.grpc.CallOptions;
-import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
-import io.grpc.Context;
-import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
-import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.alts.GoogleDefaultChannelBuilder;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.stub.AbstractStub;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nullable;
 
 /** Provides gRPC stubs for accessing the Storage gRPC API. */
 class StorageStubProvider {
 
   // The maximum number of times to automatically retry gRPC requests.
   private static final double GRPC_MAX_RETRY_ATTEMPTS = 10;
-
-  // The maximum number of media channels this provider will hand out. If more channels are
-  // requested, the provider will reuse existing ones, favoring the one with the fewest ongoing
-  // requests.
-  private static final int MEDIA_CHANNEL_MAX_POOL_SIZE = 12;
 
   private static final ImmutableSet<Status.Code> STUB_BROKEN_ERROR_CODES =
       ImmutableSet.of(Status.Code.DEADLINE_EXCEEDED, Status.Code.UNAVAILABLE);
@@ -67,107 +46,12 @@ class StorageStubProvider {
   private final GoogleCloudStorageReadOptions readOptions;
   private final String userAgent;
   private final ExecutorService backgroundTasksThreadPool;
-  private final List<ChannelAndRequestCounter> mediaChannelPool;
+  private final ManagedChannel channel;
   private final GrpcDecorator grpcDecorator;
 
   @VisibleForTesting
   GrpcDecorator getGrpcDecorator() {
     return grpcDecorator;
-  }
-
-  // An interceptor that can be added around a gRPC channel which keeps a count of the number
-  // of requests that are active at any given moment.
-  final class ActiveRequestCounter implements ClientInterceptor {
-
-    // A count of the number of RPCs currently underway for one gRPC channel channel.
-    private final AtomicInteger ongoingRequestCount;
-
-    public ActiveRequestCounter() {
-      ongoingRequestCount = new AtomicInteger(0);
-    }
-
-    @Override
-    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-        MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel channel) {
-      ClientCall<ReqT, RespT> newCall = channel.newCall(methodDescriptor, callOptions);
-      AtomicBoolean countedCancel = new AtomicBoolean(false);
-
-      // A streaming call might be terminated in one of several possible ways:
-      // * The call completes normally -> onClose() will be invoked.
-      // * The context is cancelled -> CancellationListener.cancelled() will be called.
-      // * The call itself is cancelled (doesn't currently happen) -> ClientCall.cancel()
-      // called.
-      //
-      // It's possible more than one of these could happen, so we use countedCancel to make
-      // sure we
-      // don't double count a decrement.
-      Context.current()
-          .addListener(
-              context -> {
-                if (countedCancel.compareAndSet(false, true)) {
-                  ongoingRequestCount.decrementAndGet();
-                }
-              },
-              backgroundTasksThreadPool);
-
-      return new SimpleForwardingClientCall<ReqT, RespT>(newCall) {
-        @Override
-        public void cancel(@Nullable String message, @Nullable Throwable cause) {
-          if (countedCancel.compareAndSet(false, true)) {
-            ongoingRequestCount.decrementAndGet();
-          }
-          super.cancel(message, cause);
-        }
-
-        @Override
-        public void start(Listener<RespT> responseListener, Metadata headers) {
-          ongoingRequestCount.incrementAndGet();
-          this.delegate()
-              .start(
-                  new SimpleForwardingClientCallListener<RespT>(responseListener) {
-                    @Override
-                    public void onClose(Status status, Metadata trailers) {
-                      if (countedCancel.compareAndSet(false, true)) {
-                        ongoingRequestCount.decrementAndGet();
-                      }
-                      super.onClose(status, trailers);
-                    }
-                  },
-                  headers);
-        }
-      };
-    }
-  }
-
-  class ChannelAndRequestCounter {
-    private final ManagedChannel channel;
-    private final ActiveRequestCounter counter;
-
-    public ChannelAndRequestCounter(ManagedChannel channel, ActiveRequestCounter counter) {
-      this.channel = channel;
-      this.counter = counter;
-    }
-
-    public int activeRequests() {
-      return counter.ongoingRequestCount.get();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof ChannelAndRequestCounter)) {
-        return false;
-      }
-      ChannelAndRequestCounter that = (ChannelAndRequestCounter) o;
-      return Objects.equals(channel, that.channel);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(channel);
-    }
   }
 
   StorageStubProvider(
@@ -177,24 +61,18 @@ class StorageStubProvider {
     this.readOptions = options.getReadChannelOptions();
     this.userAgent = options.getAppName();
     this.backgroundTasksThreadPool = backgroundTasksThreadPool;
-    this.mediaChannelPool = new ArrayList<>();
     this.grpcDecorator = checkNotNull(grpcDecorator, "grpcDecorator cannot be null");
+    this.channel = buildManagedChannel();
   }
 
-  private ChannelAndRequestCounter buildManagedChannel() {
-    ActiveRequestCounter counter = new ActiveRequestCounter();
+  private ManagedChannel buildManagedChannel() {
     String target =
         isNullOrEmpty(readOptions.getGrpcServerAddress())
             ? DEFAULT_GCS_GRPC_SERVER_ADDRESS
             : readOptions.getGrpcServerAddress();
     ManagedChannel channel =
-        grpcDecorator
-            .createChannelBuilder(target)
-            .enableRetry()
-            .intercept(counter)
-            .userAgent(userAgent)
-            .build();
-    return new ChannelAndRequestCounter(channel, counter);
+        grpcDecorator.createChannelBuilder(target).enableRetry().userAgent(userAgent).build();
+    return channel;
   }
 
   public static boolean isStubBroken(Status.Code statusCode) {
@@ -206,14 +84,6 @@ class StorageStubProvider {
     return (StorageBlockingStub) grpcDecorator.applyCallOption(stub);
   }
 
-  public void evictChannelFromPool(Channel channel) {
-    if (channel instanceof ManagedChannel) {
-      ManagedChannel managedChannel = (ManagedChannel) channel;
-      mediaChannelPool.remove(
-          new ChannelAndRequestCounter(managedChannel, new ActiveRequestCounter()));
-    }
-  }
-
   public StorageStub newAsyncStub() {
     StorageStub stub =
         StorageGrpc.newStub(getManagedChannel()).withExecutor(backgroundTasksThreadPool);
@@ -221,20 +91,11 @@ class StorageStubProvider {
   }
 
   private synchronized ManagedChannel getManagedChannel() {
-    if (mediaChannelPool.size() >= MEDIA_CHANNEL_MAX_POOL_SIZE) {
-      return mediaChannelPool.stream()
-          .min(Comparator.comparingInt(ChannelAndRequestCounter::activeRequests))
-          .get()
-          .channel;
-    }
-
-    ChannelAndRequestCounter channel = buildManagedChannel();
-    mediaChannelPool.add(channel);
-    return channel.channel;
+    return channel;
   }
 
   public void shutdown() {
-    mediaChannelPool.parallelStream().forEach(c -> c.channel.shutdownNow());
+    channel.shutdownNow();
   }
 
   interface GrpcDecorator {
@@ -296,18 +157,10 @@ class StorageStubProvider {
       Map<String, Object> methodConfig =
           ImmutableMap.of("name", ImmutableList.of(name), "retryPolicy", retryPolicy);
 
-      // When channel pooling is enabled, force the pick_first grpclb strategy.
-      // This is necessary to avoid the multiplicative effect of creating channel pool
-      // with
-      // `poolSize` number of `ManagedChannel`s, each with a `subSetting` number of
-      // number of
-      // subchannels.
-      // See the service config proto definition for more details:
-      // https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto#L182
-      Map<String, Object> pickFirstStrategy = ImmutableMap.of("pick_first", ImmutableMap.of());
+      Map<String, Object> childLbStrategy = ImmutableMap.of("round_robin", ImmutableMap.of());
 
       Map<String, Object> childPolicy =
-          ImmutableMap.of("childPolicy", ImmutableList.of(pickFirstStrategy));
+          ImmutableMap.of("childPolicy", ImmutableList.of(childLbStrategy));
 
       Map<String, Object> grpcLbPolicy = ImmutableMap.of("grpclb", childPolicy);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -46,8 +46,8 @@ class StorageStubProvider {
   private final GoogleCloudStorageReadOptions readOptions;
   private final String userAgent;
   private final ExecutorService backgroundTasksThreadPool;
-  private final ManagedChannel channel;
   private final GrpcDecorator grpcDecorator;
+  private ManagedChannel channel;
 
   @VisibleForTesting
   GrpcDecorator getGrpcDecorator() {
@@ -62,7 +62,6 @@ class StorageStubProvider {
     this.userAgent = options.getAppName();
     this.backgroundTasksThreadPool = backgroundTasksThreadPool;
     this.grpcDecorator = checkNotNull(grpcDecorator, "grpcDecorator cannot be null");
-    this.channel = buildManagedChannel();
   }
 
   private ManagedChannel buildManagedChannel() {
@@ -91,6 +90,9 @@ class StorageStubProvider {
   }
 
   private synchronized ManagedChannel getManagedChannel() {
+    if (channel == null) {
+      channel = buildManagedChannel();
+    }
     return channel;
   }
 


### PR DESCRIPTION
Switched gRPC LoadBalance Policy to `round_robin` from `pick_first`. For this change, a channel pool should be replaced with a simple gRPC channel because a round-robin channel has a built-in channel management inside (having many subchannels) so just having a single gRPC channel should be enough. Due to no need to maintain a pool, channel eviction and active call counting on every channel can be removed altogether.