### PR TITLE
gson and gRPC version upgrade with bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,12 @@
     <google.cloud-bigquerystorage.version>1.22.5</google.cloud-bigquerystorage.version>
     <google.cloud-storage.grpc.version>2.0.1-alpha</google.cloud-storage.grpc.version>
     <google.flogger.version>0.7.1</google.flogger.version>
-    <google.gson.version>2.8.8</google.gson.version>
+    <google.gson.version>2.8.9</google.gson.version>
     <google.guava.version>31.0.1-jre</google.guava.version>
     <google.http-client.version>1.40.1</google.http-client.version>
     <google.oauth-client.version>1.32.1</google.oauth-client.version>
     <google.protobuf.version>3.18.1</google.protobuf.version>
-    <grpc.version>1.41.0</grpc.version>
+    <grpc.version>1.41.1</grpc.version>
     <hadoop.version>3.3.1</hadoop.version>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
@mprashanthsagar @maen-allaga  These versions of gson and gRPC have bug fixes and satisfy our requirement. While this PR is not necessary for our requirement, it's better for GCS Connector users in general to have dependencies with the bugs fixed.

- gson: https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327. Some users (who use Snyk) saw advisory on old version of gson: [example](https://github.com/googleapis/java-spanner-jdbc/issues/657).
- gRPC: https://github.com/grpc/grpc-java/releases/tag/v1.41.1
