### PR TITLE
Added Traffic Director support

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -389,6 +389,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_DIRECTPATH_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.grpc.directpath.enable", true);
 
+  /** Configuration key for enabling use of traffic director gRPC API for read/write. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_TRAFFICDIRECTOR_ENABLE =
+      new HadoopConfigurationProperty<>("fs.gs.grpc.trafficdirector.enable", false);
+
   /**
    * Configuration key for using cooperative locking to achieve a directory mutation operations
    * isolation.
@@ -481,7 +485,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setEncryptionKeyHash(RedactedString.create(GCS_ENCRYPTION_KEY_HASH.getPassword(config)))
         .setGrpcEnabled(GCS_GRPC_ENABLE.get(config, config::getBoolean))
         .setGrpcServerAddress(GCS_GRPC_SERVER_ADDRESS.get(config, config::get))
-        .setDirectPathPreferred(GCS_GRPC_DIRECTPATH_ENABLE.get(config, config::getBoolean));
+        .setDirectPathPreferred(GCS_GRPC_DIRECTPATH_ENABLE.get(config, config::getBoolean))
+        .setTrafficDirectorEnabled(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -23,6 +23,7 @@ import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_READ_METADATA_TIMEOUT_MS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_READ_SPEED_BYTES_PER_SEC;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_READ_TIMEOUT_MS;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_TRAFFICDIRECTOR_ENABLE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_UPLOAD_BUFFERED_REQUESTS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_GRPC_WRITE_TIMEOUT_MS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_HTTP_HEADERS;
@@ -309,7 +310,8 @@ public class GoogleHadoopFileSystemConfigurationTest {
     long grpcWriteTimeout = 20;
     long grpcUploadBufferedRequests = 25;
     long grpcReadSpeedBytesPerSec = 100 * 1024 * 1024;
-    boolean isDirectPathEnabled = false;
+    boolean isDirectPathEnabled = true;
+    boolean isTrafficDirectorEnabled = true;
     boolean isGrpcEnabled = true;
 
     config.set(GCS_GRPC_ENABLE.getKey(), String.valueOf(isGrpcEnabled));
@@ -319,6 +321,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
     config.set(
         GCS_GRPC_UPLOAD_BUFFERED_REQUESTS.getKey(), String.valueOf(grpcUploadBufferedRequests));
     config.set(GCS_GRPC_DIRECTPATH_ENABLE.getKey(), String.valueOf(isDirectPathEnabled));
+    config.set(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.getKey(), String.valueOf(isTrafficDirectorEnabled));
     config.set(
         GCS_GRPC_READ_SPEED_BYTES_PER_SEC.getKey(), String.valueOf(grpcReadSpeedBytesPerSec));
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -85,7 +85,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.grpc.read.zerocopy.enable", true);
           put("fs.gs.grpc.directpath.enable", true);
           put("fs.gs.grpc.server.address", "storage.googleapis.com");
-          put("fs.gs.grpc.trafficdirector.enable", true);
+          put("fs.gs.grpc.trafficdirector.enable", false);
           put("fs.gs.grpc.write.buffered.requests", 20L);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
           put("fs.gs.http.connect-timeout", 20_000);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -85,6 +85,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.grpc.read.zerocopy.enable", true);
           put("fs.gs.grpc.directpath.enable", true);
           put("fs.gs.grpc.server.address", "storage.googleapis.com");
+          put("fs.gs.grpc.trafficdirector.enable", true);
           put("fs.gs.grpc.write.buffered.requests", 20L);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
           put("fs.gs.http.connect-timeout", 20_000);
@@ -310,18 +311,18 @@ public class GoogleHadoopFileSystemConfigurationTest {
     long grpcWriteTimeout = 20;
     long grpcUploadBufferedRequests = 25;
     long grpcReadSpeedBytesPerSec = 100 * 1024 * 1024;
-    boolean isDirectPathEnabled = true;
-    boolean isTrafficDirectorEnabled = true;
-    boolean isGrpcEnabled = true;
+    boolean directPathEnabled = true;
+    boolean trafficDirectorEnabled = true;
+    boolean grpcEnabled = true;
 
-    config.set(GCS_GRPC_ENABLE.getKey(), String.valueOf(isGrpcEnabled));
+    config.set(GCS_GRPC_ENABLE.getKey(), String.valueOf(grpcEnabled));
     config.set(GCS_GRPC_READ_TIMEOUT_MS.getKey(), String.valueOf(grpcReadTimeout));
     config.set(GCS_GRPC_READ_METADATA_TIMEOUT_MS.getKey(), String.valueOf(grpcReadMetadataTimeout));
     config.set(GCS_GRPC_WRITE_TIMEOUT_MS.getKey(), String.valueOf(grpcWriteTimeout));
     config.set(
         GCS_GRPC_UPLOAD_BUFFERED_REQUESTS.getKey(), String.valueOf(grpcUploadBufferedRequests));
-    config.set(GCS_GRPC_DIRECTPATH_ENABLE.getKey(), String.valueOf(isDirectPathEnabled));
-    config.set(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.getKey(), String.valueOf(isTrafficDirectorEnabled));
+    config.set(GCS_GRPC_DIRECTPATH_ENABLE.getKey(), String.valueOf(directPathEnabled));
+    config.set(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.getKey(), String.valueOf(trafficDirectorEnabled));
     config.set(
         GCS_GRPC_READ_SPEED_BYTES_PER_SEC.getKey(), String.valueOf(grpcReadSpeedBytesPerSec));
 
@@ -335,8 +336,8 @@ public class GoogleHadoopFileSystemConfigurationTest {
     assertThat(options.getWriteChannelOptions().getGrpcWriteTimeout()).isEqualTo(grpcWriteTimeout);
     assertThat(options.getWriteChannelOptions().getNumberOfBufferedRequests())
         .isEqualTo(grpcUploadBufferedRequests);
-    assertThat(options.isDirectPathPreferred()).isEqualTo(isDirectPathEnabled);
-    assertThat(options.isGrpcEnabled()).isEqualTo(isGrpcEnabled);
+    assertThat(options.isDirectPathPreferred()).isEqualTo(directPathEnabled);
+    assertThat(options.isGrpcEnabled()).isEqualTo(grpcEnabled);
     assertThat(options.getReadChannelOptions().getGrpcReadSpeedBytesPerSec())
         .isEqualTo(grpcReadSpeedBytesPerSec);
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -38,6 +38,9 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for enabling use of GCS gRPC API. */
   public static final boolean ENABLE_GRPC_DEFAULT = false;
 
+  /** Default setting for enabling use of the Traffic Director for GCS gRPC API. */
+  public static final boolean ENABLE_TRAFFIC_DIRECTOR_DEFAULT = false;
+
   /** Default setting to prefer DirectPath for gRPC. */
   public static final boolean DIRECT_PATH_PREFERRED_DEFAULT = true;
 
@@ -95,6 +98,7 @@ public abstract class GoogleCloudStorageOptions {
   public static Builder builder() {
     return new AutoValue_GoogleCloudStorageOptions.Builder()
         .setGrpcEnabled(ENABLE_GRPC_DEFAULT)
+        .setTrafficDirectorEnabled(ENABLE_TRAFFIC_DIRECTOR_DEFAULT)
         .setDirectPathPreferred(DIRECT_PATH_PREFERRED_DEFAULT)
         .setStorageRootUrl(STORAGE_ROOT_URL_DEFAULT)
         .setStorageServicePath(STORAGE_SERVICE_PATH_DEFAULT)
@@ -121,6 +125,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract boolean isGrpcEnabled();
 
   public abstract String getGrpcServerAddress();
+
+  public abstract boolean isTrafficDirectorEnabled();
 
   public abstract boolean isDirectPathPreferred();
 
@@ -203,6 +209,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setGrpcEnabled(boolean grpcEnabled);
 
     public abstract Builder setGrpcServerAddress(String rootUrl);
+    
+    public abstract Builder setTrafficDirectorEnabled(boolean trafficDirectorEnabled);
 
     public abstract Builder setDirectPathPreferred(boolean directPathPreffered);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -209,7 +209,7 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setGrpcEnabled(boolean grpcEnabled);
 
     public abstract Builder setGrpcServerAddress(String rootUrl);
-    
+
     public abstract Builder setTrafficDirectorEnabled(boolean trafficDirectorEnabled);
 
     public abstract Builder setDirectPathPreferred(boolean directPathPreffered);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -157,17 +157,15 @@ class StorageStubProvider {
         credential != null
             && java.util.Objects.equals(
                 credential.getTokenServerEncodedUrl(), ComputeCredential.TOKEN_SERVER_ENCODED_URL);
+    GrpcDecorator decorator;
     if (options.isTrafficDirectorEnabled() && isDefaultServiceAccount) {
-      return new StorageStubProvider(
-          options, backgroundTasksThreadPool, new TrafficDirectorGrpcDecorator());
+      decorator = new TrafficDirectorGrpcDecorator();
+    } else if (options.isDirectPathPreferred() && isDefaultServiceAccount) {
+      decorator = new DirectPathGrpcDecorator(options.getReadChannelOptions());
     } else {
-      return new StorageStubProvider(
-          options,
-          backgroundTasksThreadPool,
-          options.isDirectPathPreferred() && isDefaultServiceAccount
-              ? new DirectPathGrpcDecorator(options.getReadChannelOptions())
-              : new CloudPathGrpcDecorator(new CredentialAdapter(credential)));
+      decorator = new CloudPathGrpcDecorator(new CredentialAdapter(credential));
     }
+    return new StorageStubProvider(options, backgroundTasksThreadPool, decorator);
   }
 
   public static StorageStubProvider newInstance(
@@ -175,16 +173,14 @@ class StorageStubProvider {
       ExecutorService backgroundTasksThreadPool,
       Credentials credentials) {
     boolean isDefaultServiceAccount = credentials instanceof ComputeEngineCredentials;
+    GrpcDecorator decorator;
     if (options.isTrafficDirectorEnabled() && isDefaultServiceAccount) {
-      return new StorageStubProvider(
-          options, backgroundTasksThreadPool, new TrafficDirectorGrpcDecorator());
+      decorator = new TrafficDirectorGrpcDecorator();
+    } else if (options.isDirectPathPreferred() && isDefaultServiceAccount) {
+      decorator = new DirectPathGrpcDecorator(options.getReadChannelOptions());
     } else {
-      return new StorageStubProvider(
-          options,
-          backgroundTasksThreadPool,
-          options.isDirectPathPreferred() && isDefaultServiceAccount
-              ? new DirectPathGrpcDecorator(options.getReadChannelOptions())
-              : new CloudPathGrpcDecorator(credentials));
+      decorator = new CloudPathGrpcDecorator(credentials);
     }
+    return new StorageStubProvider(options, backgroundTasksThreadPool, decorator);
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -14,10 +14,13 @@ import com.google.common.collect.ImmutableSet;
 import com.google.storage.v2.StorageGrpc;
 import com.google.storage.v2.StorageGrpc.StorageBlockingStub;
 import com.google.storage.v2.StorageGrpc.StorageStub;
+import com.google.storage.v2.StorageProto;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.alts.GoogleDefaultChannelBuilder;
+import io.grpc.alts.GoogleDefaultChannelCredentials;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.stub.AbstractStub;
 import java.util.Map;
@@ -133,34 +136,55 @@ class StorageStubProvider {
     }
   }
 
+  static class TrafficDirectorGrpcDecorator implements GrpcDecorator {
+    TrafficDirectorGrpcDecorator() {}
+
+    public ManagedChannelBuilder<?> createChannelBuilder(String target) {
+      return Grpc.newChannelBuilder(
+          "google-c2p:///" + target, GoogleDefaultChannelCredentials.create());
+    }
+
+    public AbstractStub<?> applyCallOption(AbstractStub<?> stub) {
+      return stub;
+    }
+  }
+
   public static StorageStubProvider newInstance(
       GoogleCloudStorageOptions options,
       ExecutorService backgroundTasksThreadPool,
       Credential credential) {
-    boolean useDirectpath =
-        options.isDirectPathPreferred()
-            && credential != null
+    boolean isDefaultServiceAccount =
+        credential != null
             && java.util.Objects.equals(
                 credential.getTokenServerEncodedUrl(), ComputeCredential.TOKEN_SERVER_ENCODED_URL);
-    return new StorageStubProvider(
-        options,
-        backgroundTasksThreadPool,
-        useDirectpath
-            ? new DirectPathGrpcDecorator(options.getReadChannelOptions())
-            : new CloudPathGrpcDecorator(new CredentialAdapter(credential)));
+    if (options.isTrafficDirectorEnabled() && isDefaultServiceAccount) {
+      return new StorageStubProvider(
+          options, backgroundTasksThreadPool, new TrafficDirectorGrpcDecorator());
+    } else {
+      return new StorageStubProvider(
+          options,
+          backgroundTasksThreadPool,
+          options.isDirectPathPreferred() && isDefaultServiceAccount
+              ? new DirectPathGrpcDecorator(options.getReadChannelOptions())
+              : new CloudPathGrpcDecorator(new CredentialAdapter(credential)));
+    }
   }
 
   public static StorageStubProvider newInstance(
       GoogleCloudStorageOptions options,
       ExecutorService backgroundTasksThreadPool,
       Credentials credentials) {
-    boolean useDirectpath =
-        options.isDirectPathPreferred() && credentials instanceof ComputeEngineCredentials;
-    return new StorageStubProvider(
-        options,
-        backgroundTasksThreadPool,
-        useDirectpath
-            ? new DirectPathGrpcDecorator(options.getReadChannelOptions())
-            : new CloudPathGrpcDecorator(credentials));
+    boolean isDefaultServiceAccount = credentials instanceof ComputeEngineCredentials;
+    if (options.isTrafficDirectorEnabled() && isDefaultServiceAccount) {
+      return new StorageStubProvider(
+          options, backgroundTasksThreadPool, new TrafficDirectorGrpcDecorator());
+    } else {
+      return new StorageStubProvider(
+          options,
+          backgroundTasksThreadPool,
+          options.isDirectPathPreferred() && isDefaultServiceAccount
+              ? new DirectPathGrpcDecorator(options.getReadChannelOptions())
+              : new CloudPathGrpcDecorator(credentials));
+    }
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -14,7 +14,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.storage.v2.StorageGrpc;
 import com.google.storage.v2.StorageGrpc.StorageBlockingStub;
 import com.google.storage.v2.StorageGrpc.StorageStub;
-import com.google.storage.v2.StorageProto;
 import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
@@ -74,4 +74,20 @@ public class GoogleCloudStorageImplCreateTest {
     assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
         .isInstanceOf(StorageStubProvider.CloudPathGrpcDecorator.class);
   }
+
+  @Test
+  public void create_grpcAndTrafficDirector_useTrafficDirector() throws IOException {
+    GoogleCloudStorageImpl gcs =
+        new GoogleCloudStorageImpl(
+            GoogleCloudStorageOptions.builder()
+                .setAppName("app")
+                .setGrpcEnabled(true)
+                .setTrafficDirectorEnabled(true)
+                .build(),
+            createStorage(),
+            ComputeEngineCredentials.newBuilder().build(),
+            null);
+    assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
+        .isInstanceOf(StorageStubProvider.TrafficDirectorGrpcDecorator.class);
+  }
 }


### PR DESCRIPTION
Added a new option `fs.gs.grpc.trafficdirector.enable` (false, by default) to enable Traffic Directory for GCS/gRPC API.