### PR TITLE
Enable TCP keep alive by default

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -1,5 +1,7 @@
 ### 2.1.7 - 2020-XX-XX
 
+1.  Enable TCP keep alive by default.
+
 ### 2.1.6 - 2020-11-06
 
 1.  Increment Hadoop `FileSystem.Statistics` counters for read and write

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
@@ -174,14 +174,13 @@ public class GoogleCloudStorageNewIntegrationTest {
     List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER);
 
     assertThat(listedObjects).containsExactly(testDir + "f1", testDir + "f2", testDir + "subdir/");
-    // Assert that 5 GCS requests were sent
+    // Assert that 4 GCS requests were sent
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
             listRequestString(testBucket, testDir, maxResultsPerRequest, /* pageToken= */ null),
             listRequestString(testBucket, testDir, maxResultsPerRequest, "token_1"),
             listRequestString(testBucket, testDir, maxResultsPerRequest, "token_2"),
-            listRequestString(testBucket, testDir, maxResultsPerRequest, "token_3"),
-            listRequestString(testBucket, testDir, maxResultsPerRequest, "token_4"));
+            listRequestString(testBucket, testDir, maxResultsPerRequest, "token_3"));
   }
 
   @Test

--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -24,18 +24,28 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.Authenticator;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
+import java.net.Socket;
+import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import javax.annotation.Nullable;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
 
 /**
@@ -187,8 +197,11 @@ public class HttpTransportFactory {
           });
     }
 
+    SslKeepAliveSocketFactory sslSocketFactory =
+        new SslKeepAliveSocketFactory(HttpsURLConnection.getDefaultSSLSocketFactory());
     return new NetHttpTransport.Builder()
         .trustCertificates(GoogleUtils.getCertificateTrustStore())
+        .setSslSocketFactory(sslSocketFactory)
         .setProxy(
             proxyUri == null
                 ? null
@@ -226,6 +239,70 @@ public class HttpTransportFactory {
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(
           String.format("Invalid proxy address '%s'.", proxyAddress), e);
+    }
+  }
+
+  /** Wrapper class to have socketKeepAlive property while creating the socket */
+  @VisibleForTesting
+  static class SslKeepAliveSocketFactory extends SSLSocketFactory {
+
+    private final SSLSocketFactory wrappedSockedFactory;
+
+    public SslKeepAliveSocketFactory(SSLSocketFactory wrappedSocketFactory) {
+      this.wrappedSockedFactory = wrappedSocketFactory;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+      return wrappedSockedFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+      return wrappedSockedFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+      return setSocketKeepAlive(wrappedSockedFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, InputStream consumed, boolean autoClose)
+        throws IOException {
+      return setSocketKeepAlive(wrappedSockedFactory.createSocket(s, consumed, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose)
+        throws IOException {
+      return setSocketKeepAlive(wrappedSockedFactory.createSocket(s, host, port, autoClose));
+    }
+
+    public Socket createSocket(String host, int port) throws IOException {
+      return setSocketKeepAlive(wrappedSockedFactory.createSocket(host, port));
+    }
+
+    public Socket createSocket(InetAddress address, int port) throws IOException {
+      return setSocketKeepAlive(wrappedSockedFactory.createSocket(address, port));
+    }
+
+    public Socket createSocket(String host, int port, InetAddress clientAddress, int clientPort)
+        throws IOException {
+      return setSocketKeepAlive(
+          wrappedSockedFactory.createSocket(host, port, clientAddress, clientPort));
+    }
+
+    public Socket createSocket(
+        InetAddress address, int port, InetAddress clientAddress, int clientPort)
+        throws IOException {
+      return setSocketKeepAlive(
+          wrappedSockedFactory.createSocket(address, port, clientAddress, clientPort));
+    }
+
+    private static Socket setSocketKeepAlive(Socket socket) throws SocketException {
+      socket.setKeepAlive(true);
+      return socket;
     }
   }
 }

--- a/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
@@ -17,14 +17,25 @@ package com.google.cloud.hadoop.util;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.hadoop.util.HttpTransportFactory.SslKeepAliveSocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLSocketFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class HttpTransportFactoryTest {
+
+  private static final FakeSslSocketFactory FAKE_SOCKET_FACTORY = new FakeSslSocketFactory();
+  private static final String[] SUPPORTED_TEST_SUITES = {"testSuite"};
+  private static final String[] DEFAULT_CIPHER_SUITES = {"testDefaultCipherSuite"};
 
   @Test
   public void testParseProxyAddress() throws Exception {
@@ -104,6 +115,98 @@ public class HttpTransportFactoryTest {
     assertThat(thrown)
         .hasMessageThat()
         .contains("Invalid proxy address 'foo-host:1234/some/path'.");
+  }
+
+  @Test
+  public void testKeepAliveSocketFactoryDefaultCipherSuites() {
+    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
+        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+
+    assertThat(sslKeepAliveSocketFactory.getDefaultCipherSuites()).isEqualTo(DEFAULT_CIPHER_SUITES);
+  }
+
+  @Test
+  public void testKeepAliveSocketFactorySupportedCipherSuites() {
+    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
+        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+
+    assertThat(sslKeepAliveSocketFactory.getSupportedCipherSuites())
+        .isEqualTo(SUPPORTED_TEST_SUITES);
+  }
+
+  @Test
+  public void testKeepAliveSocketFactoryKeepAliveTrue() throws IOException {
+    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
+        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+
+    assertThat(sslKeepAliveSocketFactory.createSocket().getKeepAlive()).isTrue();
+
+    assertThat(sslKeepAliveSocketFactory.createSocket(null, "localhost", 80, false).getKeepAlive())
+        .isTrue();
+
+    assertThat(sslKeepAliveSocketFactory.createSocket(null, null, false).getKeepAlive()).isTrue();
+
+    assertThat(sslKeepAliveSocketFactory.createSocket("localhost", 80).getKeepAlive()).isTrue();
+
+    assertThat(sslKeepAliveSocketFactory.createSocket("localhost", 80, null, 443).getKeepAlive())
+        .isTrue();
+
+    InetAddress fakeInet = InetAddress.getByName("10.0.0.0");
+    assertThat(sslKeepAliveSocketFactory.createSocket(fakeInet, 443).getKeepAlive()).isTrue();
+
+    assertThat(sslKeepAliveSocketFactory.createSocket(fakeInet, 443, fakeInet, 80).getKeepAlive())
+        .isTrue();
+  }
+
+  private static class FakeSslSocketFactory extends SSLSocketFactory {
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+      return DEFAULT_CIPHER_SUITES;
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+      return SUPPORTED_TEST_SUITES;
+    }
+
+    @Override
+    public Socket createSocket() {
+      return new Socket();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
+      return createSocket();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, InputStream inputStream, boolean b)
+        throws IOException {
+      return createSocket();
+    }
+
+    @Override
+    public Socket createSocket(String s, int i) throws IOException, UnknownHostException {
+      return createSocket();
+    }
+
+    @Override
+    public Socket createSocket(String s, int i, InetAddress inetAddress, int i1)
+        throws IOException, UnknownHostException {
+      return createSocket();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int i) throws IOException {
+      return createSocket();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1)
+        throws IOException {
+      return createSocket();
+    }
   }
 
   private static URI getURI(String scheme, String host, int port) throws URISyntaxException {

--- a/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
@@ -17,7 +17,8 @@ package com.google.cloud.hadoop.util;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.cloud.hadoop.util.HttpTransportFactory.SslKeepAliveSocketFactory;
+import com.google.cloud.hadoop.util.HttpTransportFactory.ApacheSslKeepAliveSocketFactory;
+import com.google.cloud.hadoop.util.HttpTransportFactory.JavaxSslKeepAliveSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -118,43 +119,49 @@ public class HttpTransportFactoryTest {
   }
 
   @Test
-  public void testKeepAliveSocketFactoryDefaultCipherSuites() {
-    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
-        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
-
-    assertThat(sslKeepAliveSocketFactory.getDefaultCipherSuites()).isEqualTo(DEFAULT_CIPHER_SUITES);
+  public void testApacheKeepAliveSocketFactory() throws IOException {
+    Socket socket = new ApacheSslKeepAliveSocketFactory().createSocket();
+    assertThat(socket.getKeepAlive()).isTrue();
   }
 
   @Test
-  public void testKeepAliveSocketFactorySupportedCipherSuites() {
-    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
-        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+  public void testJavaxKeepAliveSocketFactoryDefaultCipherSuites() {
+    JavaxSslKeepAliveSocketFactory javaxSslKeepAliveSocketFactory =
+        new JavaxSslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
 
-    assertThat(sslKeepAliveSocketFactory.getSupportedCipherSuites())
+    assertThat(javaxSslKeepAliveSocketFactory.getDefaultCipherSuites()).isEqualTo(DEFAULT_CIPHER_SUITES);
+  }
+
+  @Test
+  public void testJavaxKeepAliveSocketFactorySupportedCipherSuites() {
+    JavaxSslKeepAliveSocketFactory javaxSslKeepAliveSocketFactory =
+        new JavaxSslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+
+    assertThat(javaxSslKeepAliveSocketFactory.getSupportedCipherSuites())
         .isEqualTo(SUPPORTED_TEST_SUITES);
   }
 
   @Test
-  public void testKeepAliveSocketFactoryKeepAliveTrue() throws IOException {
-    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
-        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+  public void testJavaxKeepAliveSocketFactoryKeepAliveTrue() throws IOException {
+    JavaxSslKeepAliveSocketFactory javaxSslKeepAliveSocketFactory =
+        new JavaxSslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
 
-    assertThat(sslKeepAliveSocketFactory.createSocket().getKeepAlive()).isTrue();
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket().getKeepAlive()).isTrue();
 
-    assertThat(sslKeepAliveSocketFactory.createSocket(null, "localhost", 80, false).getKeepAlive())
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket(null, "localhost", 80, false).getKeepAlive())
         .isTrue();
 
-    assertThat(sslKeepAliveSocketFactory.createSocket(null, null, false).getKeepAlive()).isTrue();
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket(null, null, false).getKeepAlive()).isTrue();
 
-    assertThat(sslKeepAliveSocketFactory.createSocket("localhost", 80).getKeepAlive()).isTrue();
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket("localhost", 80).getKeepAlive()).isTrue();
 
-    assertThat(sslKeepAliveSocketFactory.createSocket("localhost", 80, null, 443).getKeepAlive())
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket("localhost", 80, null, 443).getKeepAlive())
         .isTrue();
 
     InetAddress fakeInet = InetAddress.getByName("10.0.0.0");
-    assertThat(sslKeepAliveSocketFactory.createSocket(fakeInet, 443).getKeepAlive()).isTrue();
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket(fakeInet, 443).getKeepAlive()).isTrue();
 
-    assertThat(sslKeepAliveSocketFactory.createSocket(fakeInet, 443, fakeInet, 80).getKeepAlive())
+    assertThat(javaxSslKeepAliveSocketFactory.createSocket(fakeInet, 443, fakeInet, 80).getKeepAlive())
         .isTrue();
   }
 


### PR DESCRIPTION
Cherry picking #696 didn't work because this branch has older version of google-http-client and we don't want to upgrade discussion [here](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/697#discussion_r794764439)

Reimplemented the default SslSocketFactory by modifying the socket keep alive.