### PR TITLE
Fix integration test

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
@@ -174,14 +174,13 @@ public class GoogleCloudStorageNewIntegrationTest {
     List<String> listedObjects = gcs.listObjectNames(testBucket, testDir, PATH_DELIMITER);
 
     assertThat(listedObjects).containsExactly(testDir + "f1", testDir + "f2", testDir + "subdir/");
-    // Assert that 5 GCS requests were sent
+    // Assert that 4 GCS requests were sent
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
             listRequestString(testBucket, testDir, maxResultsPerRequest, /* pageToken= */ null),
             listRequestString(testBucket, testDir, maxResultsPerRequest, "token_1"),
             listRequestString(testBucket, testDir, maxResultsPerRequest, "token_2"),
-            listRequestString(testBucket, testDir, maxResultsPerRequest, "token_3"),
-            listRequestString(testBucket, testDir, maxResultsPerRequest, "token_4"));
+            listRequestString(testBucket, testDir, maxResultsPerRequest, "token_3"));
   }
 
   @Test


### PR DESCRIPTION
I don't know when it started failing because the last commit to this branch was in Nov 2020.
Looking at it seems like we should only have 4 requests. Maybe GCS behavior changed to not send the sub-directory as a separate response. From S3, I remember every object is just a key value and the sub-directory i.e. "/", doesn't mean anything.