### PR TITLE
[Backport to 2.2.x] Upgrade grpc-google-cloud-storage-v2 to 2.2.2-alpha

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -530,7 +530,7 @@ public final class GoogleCloudStorageGrpcWriteChannel
             String.format("Failed to get committed write size for '%s'", resourceId), e);
       }
 
-      return responseObserver.getResponse().getCommittedSize();
+      return responseObserver.getResponse().getPersistedSize();
     }
 
     /** Stream observer for single response RPCs. */

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
@@ -109,8 +109,8 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
         newWriteChannel(options, writeConditions, /* requesterPaysProject= */ null);
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
-                QueryWriteStatusResponse.newBuilder().setCommittedSize(0).build(),
-                QueryWriteStatusResponse.newBuilder().setCommittedSize(0).build())
+                QueryWriteStatusResponse.newBuilder().setPersistedSize(0).build(),
+                QueryWriteStatusResponse.newBuilder().setPersistedSize(0).build())
             .iterator());
 
     ByteString data = ByteString.copyFromUtf8("test data");
@@ -163,10 +163,10 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(GCS_MINIMUM_CHUNK_SIZE)
+                    .setPersistedSize(GCS_MINIMUM_CHUNK_SIZE)
                     .build(),
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(2 * GCS_MINIMUM_CHUNK_SIZE)
+                    .setPersistedSize(2 * GCS_MINIMUM_CHUNK_SIZE)
                     .build())
             .iterator());
 
@@ -193,10 +193,10 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(GCS_MINIMUM_CHUNK_SIZE)
+                    .setPersistedSize(GCS_MINIMUM_CHUNK_SIZE)
                     .build(),
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(2 * GCS_MINIMUM_CHUNK_SIZE)
+                    .setPersistedSize(2 * GCS_MINIMUM_CHUNK_SIZE)
                     .build())
             .iterator());
 
@@ -219,7 +219,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(GCS_MINIMUM_CHUNK_SIZE * 3 / 4)
+                    .setPersistedSize(GCS_MINIMUM_CHUNK_SIZE * 3 / 4)
                     .build())
             .iterator());
 
@@ -330,7 +330,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(GCS_MINIMUM_CHUNK_SIZE * 3 / 4)
+                    .setPersistedSize(GCS_MINIMUM_CHUNK_SIZE * 3 / 4)
                     .build())
             .iterator());
 
@@ -348,7 +348,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
                 QueryWriteStatusResponse.newBuilder()
-                    .setCommittedSize(GCS_MINIMUM_CHUNK_SIZE)
+                    .setPersistedSize(GCS_MINIMUM_CHUNK_SIZE)
                     .build())
             .iterator());
 
@@ -370,7 +370,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setInsertObjectExceptions(
         ImmutableList.of(new StatusException(Status.DEADLINE_EXCEEDED)));
     fakeService.setQueryWriteStatusResponses(
-        ImmutableList.of(QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build())
+        ImmutableList.of(QueryWriteStatusResponse.newBuilder().setPersistedSize(1).build())
             .iterator());
     ByteString chunk = createTestData(GCS_MINIMUM_CHUNK_SIZE);
     ArgumentCaptor<WriteObjectRequest> requestCaptor =
@@ -398,7 +398,7 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     fakeService.setInsertObjectExceptions(
         ImmutableList.of(new StatusException(Status.DEADLINE_EXCEEDED)));
     fakeService.setQueryWriteStatusResponses(
-        ImmutableList.of(QueryWriteStatusResponse.newBuilder().setCommittedSize(-1).build())
+        ImmutableList.of(QueryWriteStatusResponse.newBuilder().setPersistedSize(-1).build())
             .iterator());
     ByteString chunk = createTestData(GCS_MINIMUM_CHUNK_SIZE);
 
@@ -423,10 +423,10 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
             new StatusException(Status.DEADLINE_EXCEEDED)));
     fakeService.setQueryWriteStatusResponses(
         ImmutableList.of(
-                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build(),
-                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build(),
-                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build(),
-                QueryWriteStatusResponse.newBuilder().setCommittedSize(1).build())
+                QueryWriteStatusResponse.newBuilder().setPersistedSize(1).build(),
+                QueryWriteStatusResponse.newBuilder().setPersistedSize(1).build(),
+                QueryWriteStatusResponse.newBuilder().setPersistedSize(1).build(),
+                QueryWriteStatusResponse.newBuilder().setPersistedSize(1).build())
             .iterator());
     ByteString chunk = createTestData(GCS_MINIMUM_CHUNK_SIZE);
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <google.auth.version>1.2.1</google.auth.version>
     <google.auto-value.version>1.8.2</google.auto-value.version>
     <google.cloud-bigquerystorage.version>1.22.5</google.cloud-bigquerystorage.version>
-    <google.cloud-storage.grpc.version>2.0.1-alpha</google.cloud-storage.grpc.version>
+    <google.cloud-storage.grpc.version>2.2.2-alpha</google.cloud-storage.grpc.version>
     <google.flogger.version>0.7.1</google.flogger.version>
     <google.gson.version>2.8.9</google.gson.version>
     <google.guava.version>31.0.1-jre</google.guava.version>


### PR DESCRIPTION
This is a partial backport of https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/670 getting the breaking change (https://github.com/googleapis/googleapis/commit/877d3d9d02591ad612a2c8654b42c37ba09ff9ec) of the gRPC GCS API. Without this, the client may see the  `java.lang.NoSuchMethodError: com.google.storage.v2.QueryWriteStatusResponse.getCommittedSize()` exception if they use the latest version of the API.