### PR TITLE
Fix integration test which had really long bucket name

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
@@ -750,7 +750,7 @@ public class GoogleCloudStorageNewIntegrationTest {
         new TrackingHttpRequestInitializer(httpRequestsInitializer);
     GoogleCloudStorage gcs = new GoogleCloudStorageImpl(gcsOptions, gcsRequestsTracker);
 
-    String testBucket = gcsfsIHelper.createUniqueBucket("lst-objs_incl-pfx_impl-dir-in-bckt");
+    String testBucket = gcsfsIHelper.createUniqueBucket("lst-obj_inc-pfx_imp-dir-in-bkt");
     gcsfsIHelper.createObjects(testBucket, "implDir/obj");
 
     List<GoogleCloudStorageItemInfo> listedObjects =


### PR DESCRIPTION
`gcsio-test_deependrap_97f3eac5_lst-objs_incl-pfx_impl-dir-in-bckt` This was the bucket created in test with 65 characters

And was failing with error

```
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Use of this bucket name is restricted: 'gcsio-test_deependrap_60440287_lst-obj_inc-pfxgfdsgdgs_imp-dir-in-bkt'",
    "reason" : "invalid"
  } ],
  "message" : "Use of this bucket name is restricted: 'gcsio-test_deependrap_60440287_lst-obj_inc-pfxgfdsgdgs_imp-dir-in-bkt'"
}
```

This says it should be max 63 characters https://cloud.google.com/storage/docs/naming-buckets