### PR TITLE
Decrease bucket prefix to not exceed max bucket size allowed

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -259,8 +259,8 @@ public class GoogleCloudStorageTestHelper {
 
     private static String makeBucketName(String prefix) {
       String username = System.getProperty("user.name", "unknown").replaceAll("[-.]", "");
-      username = username.substring(0, min(username.length(), 10));
-      String uuidSuffix = UUID.randomUUID().toString().substring(0, 8);
+      username = username.substring(0, min(username.length(), 9));
+      String uuidSuffix = UUID.randomUUID().toString().substring(0, 6);
       return prefix + DELIMITER + username + DELIMITER + uuidSuffix;
     }
 


### PR DESCRIPTION
Tests work for `prsagar` which is 7 characters but fails for `deependrap` which is 10. So adjusting remaining 3.

6 character UUID is sufficient to not cause collision.