### PR TITLE
Decrease bucket prefix to not exceed max bucket size allowed (#708)

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -204,8 +204,8 @@ public class GoogleCloudStorageTestHelper {
 
     private static String makeBucketName(String prefix) {
       String username = System.getProperty("user.name", "unknown").replace("-", "");
-      username = username.substring(0, Math.min(username.length(), 10));
-      String uuidSuffix = UUID.randomUUID().toString().substring(0, 8);
+      username = username.substring(0, Math.min(username.length(), 9));
+      String uuidSuffix = UUID.randomUUID().toString().substring(0, 6);
       return prefix + DELIMITER + username + DELIMITER + uuidSuffix;
     }
 


### PR DESCRIPTION
(cherry picked from commit 1518bae362be8c212e6d11318ea7b1c0e06ef393)