### PR TITLE
Removed the limit of default service account to use TD & Directpath

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
@@ -50,8 +50,7 @@ public class GoogleCloudStorageImplCreateTest {
   }
 
   @Test
-  public void create_grpcAndDisableDirectPathAndVmComputeEngineCredentials_useCloudpath()
-      throws IOException {
+  public void create_grpcAndDisableDirectPath_useCloudpath() throws IOException {
     GoogleCloudStorageImpl gcs =
         new GoogleCloudStorageImpl(
             GoogleCloudStorageOptions.builder()
@@ -62,16 +61,6 @@ public class GoogleCloudStorageImplCreateTest {
             createStorage(),
             ComputeEngineCredentials.newBuilder().build(),
             null);
-    assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
-        .isInstanceOf(StorageStubProvider.CloudPathGrpcDecorator.class);
-  }
-
-  @Test
-  public void create_grpcAndNonComputeEngineCredentials_useCloudpath() throws IOException {
-    GoogleCloudStorageImpl gcs =
-        new GoogleCloudStorageImpl(
-            GoogleCloudStorageOptions.builder().setAppName("app").setGrpcEnabled(true).build(),
-            createStorage());
     assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
         .isInstanceOf(StorageStubProvider.CloudPathGrpcDecorator.class);
   }


### PR DESCRIPTION
Since GCS started supporting non service default accounts, that limit in the GCSIO can be removed. Master branch already has this partially by https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/704 so this backport is made manually. (master branch got https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/734)