### PR TITLE
Migrate tests from using Mockito mocks except for mockBatchHelper and related mocks (#737)

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -240,7 +240,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   private ApiErrorExtractor errorExtractor = ApiErrorExtractor.INSTANCE;
 
   // Helper for interacting with objects involved with the API client libraries.
-  private ClientRequestHelper<StorageObject> clientRequestHelper = new ClientRequestHelper<>();
+  private final ClientRequestHelper<StorageObject> clientRequestHelper =
+      new ClientRequestHelper<>();
 
   // Factory for BatchHelpers setting up BatchRequests; can be swapped out for testing purposes.
   private BatchHelper.Factory batchFactory = new BatchHelper.Factory();
@@ -252,10 +253,10 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   private final GoogleCloudStorageOptions storageOptions;
 
   // Object to use to perform sleep operations
-  private Sleeper sleeper = Sleeper.DEFAULT;
+  private final Sleeper sleeper = Sleeper.DEFAULT;
 
   // BackOff objects are per-request, use this to make new ones.
-  private BackOffFactory backOffFactory = BackOffFactory.DEFAULT;
+  private final BackOffFactory backOffFactory = BackOffFactory.DEFAULT;
 
   // Determine if a given IOException is due to rate-limiting.
   private RetryDeterminer<IOException> rateLimitedRetryDeterminer = errorExtractor::rateLimited;
@@ -364,10 +365,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
 
     this.storage = checkNotNull(storage, "storage must not be null");
 
-    this.httpRequestInitializer =
-        this.storage.getRequestFactory() == null
-            ? null
-            : this.storage.getRequestFactory().getInitializer();
+    this.httpRequestInitializer = this.storage.getRequestFactory().getInitializer();
 
     // Create the gRPC stub if necessary;
     if (this.storageOptions.isGrpcEnabled()) {
@@ -449,23 +447,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   }
 
   @VisibleForTesting
-  void setClientRequestHelper(ClientRequestHelper<StorageObject> clientRequestHelper) {
-    this.clientRequestHelper = clientRequestHelper;
-  }
-
-  @VisibleForTesting
   void setBatchFactory(BatchHelper.Factory batchFactory) {
     this.batchFactory = batchFactory;
-  }
-
-  @VisibleForTesting
-  void setSleeper(Sleeper sleeper) {
-    this.sleeper = sleeper;
-  }
-
-  @VisibleForTesting
-  void setBackOffFactory(BackOffFactory factory) {
-    backOffFactory = factory;
   }
 
   @VisibleForTesting

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageWriteChannel.java
@@ -84,14 +84,12 @@ public class GoogleCloudStorageWriteChannel
             .setName(resourceId.getObjectName())
             .setKmsKeyName(createOptions.getKmsKeyName());
     writeConditions.apply(insert);
-    if (insert.getMediaHttpUploader() != null) {
-      insert
-          .getMediaHttpUploader()
-          .setDirectUploadEnabled(isDirectUploadEnabled())
-          .setProgressListener(
-              new LoggingMediaHttpUploaderProgressListener(
-                  resourceId.getObjectName(), MIN_LOGGING_INTERVAL_MS));
-    }
+    insert
+        .getMediaHttpUploader()
+        .setDirectUploadEnabled(isDirectUploadEnabled())
+        .setProgressListener(
+            new LoggingMediaHttpUploaderProgressListener(
+                resourceId.getObjectName(), MIN_LOGGING_INTERVAL_MS));
     return insert;
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplCreateTest.java
@@ -14,14 +14,32 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.testing.MockGoogleCloudStorageImplFactory.mockedGcs;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.arbitraryInputStreamSupplier;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.inputStreamResponse;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.jsonErrorResponse;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.mockTransport;
+import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.services.storage.Storage;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.cloud.hadoop.util.HttpTransportFactory;
 import com.google.cloud.hadoop.util.RetryHttpInitializer;
+import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import java.io.IOException;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,6 +55,9 @@ public class GoogleCloudStorageImplCreateTest {
             new RetryHttpInitializer(null, "foo-user-agent"))
         .build();
   }
+
+  private static final String BUCKET_NAME = "foo-bucket";
+  private static final String OBJECT_NAME = "bar-object";
 
   @Test
   public void create_grpcAndVmComputeEngineCredentials_useDirectpath() throws IOException {
@@ -79,5 +100,107 @@ public class GoogleCloudStorageImplCreateTest {
             null);
     assertThat(gcs.getStorageStubProvider().getGrpcDecorator())
         .isInstanceOf(StorageStubProvider.TrafficDirectorGrpcDecorator.class);
+  }
+
+  /**
+   * Test handling of various types of Errors thrown during JSON API call for
+   * GoogleCloudStorage.create(2).
+   */
+  @Test
+  public void testCreateObjectApiError() throws IOException {
+    // Set up the mock Insert to throw an exception when execute() is called.
+    Error fakeError = new Error("Fake error");
+    MockHttpTransport transport =
+        mockTransport(
+            jsonErrorResponse(ErrorResponses.NOT_FOUND),
+            inputStreamResponse(
+                CONTENT_LENGTH,
+                /* headerValue = */ 1,
+                new ThrowingInputStream(/* readException = */ null, fakeError)));
+    GoogleCloudStorageImpl gcs = mockedGcs(transport);
+
+    WritableByteChannel writeChannel = gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME));
+    assertThat(writeChannel.isOpen()).isTrue();
+
+    Error thrown = assertThrows(Error.class, writeChannel::close);
+    assertThat(thrown).isEqualTo(fakeError);
+  }
+
+  /**
+   * Test handling of various types of exceptions thrown during JSON API call for
+   * GoogleCloudStorage.create(2).
+   */
+  @Test
+  public void testCreateObjectApiRuntimeException() throws IOException {
+    // Set up the mock Insert to throw an exception when execute() is called.
+    RuntimeException fakeException = new RuntimeException("Fake exception");
+    MockHttpTransport transport =
+        mockTransport(
+            jsonErrorResponse(ErrorResponses.NOT_FOUND),
+            inputStreamResponse(
+                CONTENT_LENGTH,
+                /* headerValue = */ 1,
+                new ThrowingInputStream(/* readException = */ null, fakeException)));
+    GoogleCloudStorageImpl gcs = mockedGcs(transport);
+
+    WritableByteChannel writeChannel = gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME));
+    assertThat(writeChannel.isOpen()).isTrue();
+
+    IOException thrown = assertThrows(IOException.class, writeChannel::close);
+    assertThat(thrown).hasCauseThat().isEqualTo(fakeException);
+  }
+
+  /**
+   * Test handling when the parent thread waiting for the write to finish via the close call is
+   * interrupted, that the actual write is cancelled and interrupted as well.
+   */
+  @Test
+  public void testCreateObjectApiInterruptedException() throws Exception {
+    // Set up the mock Insert to wait forever.
+    CountDownLatch waitForEverLatch = new CountDownLatch(1);
+    CountDownLatch writeStartedLatch = new CountDownLatch(2);
+    CountDownLatch threadsDoneLatch = new CountDownLatch(2);
+    MockHttpTransport transport =
+        mockTransport(
+            jsonErrorResponse(ErrorResponses.NOT_FOUND),
+            arbitraryInputStreamSupplier(
+                () -> {
+                  try {
+                    writeStartedLatch.countDown();
+                    waitForEverLatch.await();
+                    fail("Unexpected to get here.");
+                  } catch (InterruptedException e) {
+                    // Expected test behavior. Do nothing.
+                  } finally {
+                    threadsDoneLatch.countDown();
+                  }
+                  return null;
+                }));
+    GoogleCloudStorageImpl gcs = mockedGcs(transport);
+
+    WritableByteChannel writeChannel = gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME));
+    assertThat(writeChannel.isOpen()).isTrue();
+
+    ExecutorService executorService = Executors.newCachedThreadPool();
+    Future<?> write =
+        executorService.submit(
+            () -> {
+              writeStartedLatch.countDown();
+              try {
+                IOException ioe = assertThrows(IOException.class, writeChannel::close);
+                assertThat(ioe).isInstanceOf(ClosedByInterruptException.class);
+              } finally {
+                threadsDoneLatch.countDown();
+              }
+            });
+    // Wait for the insert object to be executed, then cancel the writing thread, and finally wait
+    // for the two threads to finish.
+    assertWithMessage("Neither thread started.")
+        .that(writeStartedLatch.await(5000, TimeUnit.MILLISECONDS))
+        .isTrue();
+    write.cancel(/* interrupt= */ true);
+    assertWithMessage("Failed to wait for tasks to get interrupted.")
+        .that(threadsDoneLatch.await(5000, TimeUnit.MILLISECONDS))
+        .isTrue();
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageMockitoTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageMockitoTest.java
@@ -15,21 +15,16 @@
 package com.google.cloud.hadoop.gcsio;
 
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTest.newStorageObject;
-import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.fakeResponse;
+import static com.google.cloud.hadoop.gcsio.testing.MockGoogleCloudStorageImplFactory.mockedGcs;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.mockTransport;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -37,34 +32,16 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback;
 import com.google.api.client.googleapis.json.GoogleJsonError;
-import com.google.api.client.http.AbstractInputStreamContent;
 import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.util.BackOff;
-import com.google.api.client.util.DateTime;
-import com.google.api.client.util.NanoClock;
-import com.google.api.client.util.Sleeper;
+import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.Bucket;
 import com.google.api.services.storage.model.StorageObject;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.BackOffFactory;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
-import com.google.cloud.hadoop.util.ClientRequestHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.channels.ClosedByInterruptException;
-import java.nio.channels.WritableByteChannel;
-import java.util.Arrays;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +49,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.stubbing.Answer;
 
 /**
  * Unit tests for {@link GoogleCloudStorage} class that use Mockito. The underlying Storage API
@@ -82,42 +58,15 @@ import org.mockito.stubbing.Answer;
 @RunWith(JUnit4.class)
 public class GoogleCloudStorageMockitoTest {
 
-  private static final String APP_NAME = "GCS-Unit-Test";
   private static final String PROJECT_ID = "google.com:foo-project";
   private static final String BUCKET_NAME = "foo-bucket";
   private static final String OBJECT_NAME = "bar-object";
-  private static final String OBJECT_FIELDS =
-      "bucket,name,timeCreated,updated,generation,metageneration,size,contentType,contentEncoding"
-          + ",md5Hash,crc32c,metadata";
 
-  private ExecutorService executorService;
+  private GoogleCloudStorageImpl gcs;
 
-  @Mock private Storage mockStorage;
-  @Mock private Storage.Objects mockStorageObjects;
-  @Mock private Storage.Objects.Insert mockStorageObjectsInsert;
-  @Mock private Storage.Objects.Delete mockStorageObjectsDelete;
-  @Mock private Storage.Objects.Get mockStorageObjectsGet;
-  @Mock private Storage.Objects.Copy mockStorageObjectsCopy;
-  @Mock private Storage.Objects.Compose mockStorageObjectsCompose;
-  @Mock private Storage.Objects.List mockStorageObjectsList;
-  @Mock private Storage.Buckets mockStorageBuckets;
-  @Mock private Storage.Buckets.Insert mockStorageBucketsInsert;
-  @Mock private Storage.Buckets.Delete mockStorageBucketsDelete;
-  @Mock private Storage.Buckets.Get mockStorageBucketsGet;
-  @Mock private Storage.Buckets.Get mockStorageBucketsGet2;
-  @Mock private Storage.Buckets.List mockStorageBucketsList;
   @Mock private ApiErrorExtractor mockErrorExtractor;
   @Mock private BatchHelper.Factory mockBatchFactory;
   @Mock private BatchHelper mockBatchHelper;
-  @Mock private HttpHeaders mockHeaders;
-  @Mock private ClientRequestHelper<StorageObject> mockClientRequestHelper;
-  @Mock private Sleeper mockSleeper;
-  @Mock private NanoClock mockClock;
-  @Mock private BackOff mockBackOff;
-  @Mock private BackOff mockReadBackOff;
-  @Mock private BackOffFactory mockBackOffFactory;
-
-  private GoogleCloudStorage gcs;
 
   /**
    * Sets up new mocks and create new instance of GoogleCloudStorage configured to only interact
@@ -126,54 +75,14 @@ public class GoogleCloudStorageMockitoTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    executorService = Executors.newCachedThreadPool();
-    gcs = createTestInstance();
-  }
 
-  /**
-   * Creates an instance of GoogleCloudStorage using GoogleCloudStorageImpl as the concrete type and
-   * setting up the proper mocks.
-   */
-  protected GoogleCloudStorageOptions.Builder createDefaultCloudStorageOptionsBuilder() {
-    return GoogleCloudStorageOptions.builder().setAppName(APP_NAME).setProjectId(PROJECT_ID);
-  }
+    MockHttpTransport transport = mockTransport();
+    gcs = mockedGcs(transport);
+    gcs.setBatchFactory(mockBatchFactory);
+    gcs.setErrorExtractor(mockErrorExtractor);
 
-  /**
-   * Creates an instance of GoogleCloudStorage using GoogleCloudStorageImpl as the concrete type and
-   * setting up the proper mocks.
-   */
-  protected GoogleCloudStorage createTestInstance() {
-    return createTestInstance(createDefaultCloudStorageOptionsBuilder().build());
-  }
-
-  /**
-   * Creates an instance of GoogleCloudStorage with the specified options, using
-   * GoogleCloudStorageImpl as the concrete type, and setting up the proper mocks.
-   */
-  protected GoogleCloudStorage createTestInstance(GoogleCloudStorageOptions options) {
-    GoogleCloudStorageImpl gcsTestInstance = new GoogleCloudStorageImpl(options, mockStorage);
-    gcsTestInstance.setBackgroundTasksThreadPool(executorService);
-    gcsTestInstance.setErrorExtractor(mockErrorExtractor);
-    gcsTestInstance.setClientRequestHelper(mockClientRequestHelper);
-    gcsTestInstance.setBatchFactory(mockBatchFactory);
-    gcsTestInstance.setSleeper(mockSleeper);
-    gcsTestInstance.setBackOffFactory(mockBackOffFactory);
-    return gcsTestInstance;
-  }
-
-  protected void setupNonConflictedWrite(Throwable t) throws IOException {
-    setupNonConflictedWrite(
-        invocation -> {
-          throw t;
-        });
-  }
-
-  protected void setupNonConflictedWrite(Answer<StorageObject> answer) throws IOException {
-    when(mockStorageObjects.get(BUCKET_NAME, OBJECT_NAME)).thenReturn(mockStorageObjectsGet);
-    when(mockStorageObjectsGet.setFields(anyString())).thenReturn(mockStorageObjectsGet);
-    when(mockStorageObjectsGet.execute()).thenThrow(new IOException("NotFound"));
-    when(mockErrorExtractor.itemNotFound(any(IOException.class))).thenReturn(true);
-    when(mockStorageObjectsInsert.execute()).thenAnswer(answer);
+    when(mockBatchFactory.newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt()))
+        .thenReturn(mockBatchHelper);
   }
 
   /**
@@ -182,236 +91,9 @@ public class GoogleCloudStorageMockitoTest {
    */
   @After
   public void tearDown() {
-    verifyNoMoreInteractions(mockStorage);
-    verifyNoMoreInteractions(mockStorageObjects);
-    verifyNoMoreInteractions(mockStorageObjectsInsert);
-    verifyNoMoreInteractions(mockStorageObjectsDelete);
-    verifyNoMoreInteractions(mockStorageObjectsGet);
-    verifyNoMoreInteractions(mockStorageObjectsCopy);
-    verifyNoMoreInteractions(mockStorageObjectsCompose);
-    verifyNoMoreInteractions(mockStorageObjectsList);
-    verifyNoMoreInteractions(mockStorageBuckets);
-    verifyNoMoreInteractions(mockStorageBucketsInsert);
-    verifyNoMoreInteractions(mockStorageBucketsDelete);
-    verifyNoMoreInteractions(mockStorageBucketsGet);
-    verifyNoMoreInteractions(mockStorageBucketsGet2);
-    verifyNoMoreInteractions(mockStorageBucketsList);
     verifyNoMoreInteractions(mockErrorExtractor);
     verifyNoMoreInteractions(mockBatchFactory);
     verifyNoMoreInteractions(mockBatchHelper);
-    verifyNoMoreInteractions(mockHeaders);
-    verifyNoMoreInteractions(mockClientRequestHelper);
-    verifyNoMoreInteractions(mockSleeper);
-    verifyNoMoreInteractions(mockClock);
-    verifyNoMoreInteractions(mockBackOff);
-    verifyNoMoreInteractions(mockReadBackOff);
-    verifyNoMoreInteractions(mockBackOffFactory);
-  }
-
-  /**
-   * Test handling when the parent thread waiting for the write to finish via the close call is
-   * interrupted, that the actual write is cancelled and interrupted as well.
-   */
-  @Test
-  public void testCreateObjectApiInterruptedException() throws Exception {
-    // Prepare the mock return values before invoking the method being tested.
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-
-    when(mockStorageObjects.insert(
-            eq(BUCKET_NAME), any(StorageObject.class), any(AbstractInputStreamContent.class)))
-        .thenReturn(mockStorageObjectsInsert);
-    when(mockStorageObjectsInsert.setName(eq(OBJECT_NAME))).thenReturn(mockStorageObjectsInsert);
-    when(mockStorageObjectsInsert.setKmsKeyName(any())).thenReturn(mockStorageObjectsInsert);
-
-    // Set up the mock Insert to wait forever.
-    CountDownLatch waitForEverLatch = new CountDownLatch(1);
-    CountDownLatch writeStartedLatch = new CountDownLatch(2);
-    CountDownLatch threadsDoneLatch = new CountDownLatch(2);
-    setupNonConflictedWrite(
-        unused -> {
-          try {
-            writeStartedLatch.countDown();
-            waitForEverLatch.await();
-            fail("Unexpected to get here.");
-            return null;
-          } finally {
-            threadsDoneLatch.countDown();
-          }
-        });
-
-    WritableByteChannel writeChannel = gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME));
-    assertThat(writeChannel.isOpen()).isTrue();
-
-    Future<?> write =
-        executorService.submit(
-            () -> {
-              writeStartedLatch.countDown();
-              try {
-                IOException ioe = assertThrows(IOException.class, writeChannel::close);
-                assertThat(ioe).isInstanceOf(ClosedByInterruptException.class);
-              } finally {
-                threadsDoneLatch.countDown();
-              }
-            });
-    // Wait for the insert object to be executed, then cancel the writing thread, and finally wait
-    // for the two threads to finish.
-    assertWithMessage("Neither thread started.")
-        .that(writeStartedLatch.await(5000, TimeUnit.MILLISECONDS))
-        .isTrue();
-    write.cancel(/* interrupt= */ true);
-    assertWithMessage("Failed to wait for tasks to get interrupted.")
-        .that(threadsDoneLatch.await(5000, TimeUnit.MILLISECONDS))
-        .isTrue();
-
-    verify(mockStorage, times(2)).objects();
-    verify(mockStorageObjects)
-        .insert(eq(BUCKET_NAME), any(StorageObject.class), any(AbstractInputStreamContent.class));
-    verify(mockStorageObjectsInsert).setName(eq(OBJECT_NAME));
-    verify(mockStorageObjectsInsert).setKmsKeyName(any());
-    verify(mockStorageObjectsInsert).setDisableGZipContent(eq(true));
-    verify(mockClientRequestHelper).setChunkSize(any(Storage.Objects.Insert.class), anyInt());
-    verify(mockStorageObjectsInsert).setIfGenerationMatch(eq(0L));
-    verify(mockStorageObjects).get(eq(BUCKET_NAME), eq(OBJECT_NAME));
-    verify(mockStorageObjectsGet).setFields(eq(OBJECT_FIELDS));
-    verify(mockStorageObjectsGet).execute();
-    verify(mockErrorExtractor).itemNotFound(any(IOException.class));
-    verify(mockStorageObjectsInsert).execute();
-  }
-
-  /**
-   * Test handling of various types of exceptions thrown during JSON API call for
-   * GoogleCloudStorage.create(2).
-   */
-  @Test
-  public void testCreateObjectApiRuntimeException() throws IOException {
-    // Prepare the mock return values before invoking the method being tested.
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-
-    when(mockStorageObjects.insert(
-            eq(BUCKET_NAME), any(StorageObject.class), any(AbstractInputStreamContent.class)))
-        .thenReturn(mockStorageObjectsInsert);
-    when(mockStorageObjectsInsert.setName(eq(OBJECT_NAME))).thenReturn(mockStorageObjectsInsert);
-    when(mockStorageObjectsInsert.setKmsKeyName(any())).thenReturn(mockStorageObjectsInsert);
-
-    // Set up the mock Insert to throw an exception when execute() is called.
-    RuntimeException fakeException = new RuntimeException("Fake exception");
-    setupNonConflictedWrite(fakeException);
-
-    WritableByteChannel writeChannel = gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME));
-    assertThat(writeChannel.isOpen()).isTrue();
-
-    IOException thrown = assertThrows(IOException.class, writeChannel::close);
-    assertThat(thrown).hasCauseThat().isEqualTo(fakeException);
-
-    verify(mockStorageObjectsInsert).execute();
-    verify(mockStorage, times(2)).objects();
-    verify(mockStorageObjects)
-        .insert(eq(BUCKET_NAME), any(StorageObject.class), any(AbstractInputStreamContent.class));
-    verify(mockStorageObjects).get(eq(BUCKET_NAME), eq(OBJECT_NAME));
-    verify(mockErrorExtractor, atLeastOnce()).itemNotFound(any(IOException.class));
-    verify(mockStorageObjectsGet).execute();
-    verify(mockStorageObjectsInsert).setName(eq(OBJECT_NAME));
-    verify(mockStorageObjectsInsert).setKmsKeyName(any());
-    verify(mockStorageObjectsInsert).setDisableGZipContent(eq(true));
-    verify(mockStorageObjects).get(anyString(), anyString());
-    verify(mockStorageObjectsGet).setFields(eq(OBJECT_FIELDS));
-    verify(mockClientRequestHelper).setChunkSize(any(Storage.Objects.Insert.class), anyInt());
-    verify(mockStorageObjectsInsert).setIfGenerationMatch(anyLong());
-  }
-
-  /**
-   * Test handling of various types of Errors thrown during JSON API call for
-   * GoogleCloudStorage.create(2).
-   */
-  @Test
-  public void testCreateObjectApiError() throws IOException {
-    // Prepare the mock return values before invoking the method being tested.
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-
-    // Set up the mock Insert to throw an exception when execute() is called.
-    Error fakeError = new Error("Fake error");
-    setupNonConflictedWrite(fakeError);
-
-    when(mockStorageObjects.insert(
-            eq(BUCKET_NAME), any(StorageObject.class), any(AbstractInputStreamContent.class)))
-        .thenReturn(mockStorageObjectsInsert);
-    when(mockStorageObjectsInsert.setName(eq(OBJECT_NAME))).thenReturn(mockStorageObjectsInsert);
-    when(mockStorageObjectsInsert.setKmsKeyName(any())).thenReturn(mockStorageObjectsInsert);
-
-    WritableByteChannel writeChannel = gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME));
-    assertThat(writeChannel.isOpen()).isTrue();
-
-    Error thrown = assertThrows(Error.class, writeChannel::close);
-    assertThat(thrown).isEqualTo(fakeError);
-
-    verify(mockStorage, times(2)).objects();
-    verify(mockStorageObjects)
-        .insert(eq(BUCKET_NAME), any(StorageObject.class), any(AbstractInputStreamContent.class));
-    verify(mockStorageObjects).get(BUCKET_NAME, OBJECT_NAME);
-    verify(mockStorageObjectsGet).setFields(eq(OBJECT_FIELDS));
-    verify(mockStorageObjectsGet).execute();
-    verify(mockStorageObjectsInsert).setName(eq(OBJECT_NAME));
-    verify(mockStorageObjectsInsert).setKmsKeyName(any());
-    verify(mockStorageObjectsInsert).setDisableGZipContent(eq(true));
-    verify(mockStorageObjectsInsert).setIfGenerationMatch(eq(0L));
-    verify(mockErrorExtractor).itemNotFound(any(IOException.class));
-    verify(mockClientRequestHelper).setChunkSize(any(Storage.Objects.Insert.class), anyInt());
-    verify(mockStorageObjectsInsert).execute();
-  }
-
-  /**
-   * Helper for the shared boilerplate of setting up the low-level "API objects" like
-   * mockStorage.objects(), etc., that is common between test cases targeting {@code
-   * GoogleCloudStorage.open(StorageResourceId)}.
-   *
-   * @param size {@link StorageObject} size
-   */
-  private void setUpBasicMockBehaviorForOpeningReadChannel(long size) throws IOException {
-    setUpBasicMockBehaviorForOpeningReadChannel(size, null);
-  }
-
-  /**
-   * Helper for the shared boilerplate of setting up the low-level "API objects" like
-   * mockStorage.objects(), etc., that is common between test cases targeting {@code
-   * GoogleCloudStorage.open(StorageResourceId)}.
-   *
-   * @param size {@link StorageObject} size
-   * @param encoding {@link StorageObject} encoding
-   */
-  private void setUpBasicMockBehaviorForOpeningReadChannel(long size, String encoding)
-      throws IOException {
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-    when(mockStorageObjects.get(eq(BUCKET_NAME), eq(OBJECT_NAME)))
-        .thenReturn(mockStorageObjectsGet);
-    when(mockStorageObjectsGet.setFields(anyString())).thenReturn(mockStorageObjectsGet);
-    when(mockClientRequestHelper.getRequestHeaders(eq(mockStorageObjectsGet)))
-        .thenReturn(mockHeaders);
-    when(mockStorageObjectsGet.execute())
-        .thenReturn(
-            new StorageObject()
-                .setBucket(BUCKET_NAME)
-                .setName(OBJECT_NAME)
-                .setTimeCreated(new DateTime(11L))
-                .setUpdated(new DateTime(12L))
-                .setSize(BigInteger.valueOf(size))
-                .setContentEncoding(encoding)
-                .setGeneration(1L)
-                .setMetageneration(1L));
-  }
-
-  /**
-   * Helper for test cases involving {@code GoogleCloudStorage.open(StorageResourceId)} to set up
-   * the shared sleeper/clock/backoff mocks and set {@code maxRetries}. Also checks basic invariants
-   * of a fresh readChannel, such as its position() and isOpen().
-   */
-  private void setUpAndValidateReadChannelMocksAndSetMaxRetries(
-      GoogleCloudStorageReadChannel readChannel, int maxRetries) throws IOException {
-    readChannel.setSleeper(mockSleeper);
-    readChannel.setNanoClock(mockClock);
-    readChannel.setReadBackOff(mockReadBackOff);
-    readChannel.setMaxRetries(maxRetries);
-    assertThat(readChannel.isOpen()).isTrue();
-    assertThat(readChannel.position()).isEqualTo(0);
   }
 
   /**
@@ -420,18 +102,10 @@ public class GoogleCloudStorageMockitoTest {
    */
   @Test
   public void testDeleteObjectApiException() throws IOException {
-    when(mockBatchFactory.newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt()))
-        .thenReturn(mockBatchHelper);
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-    when(mockStorageObjects.delete(eq(BUCKET_NAME), eq(OBJECT_NAME)))
-        .thenReturn(mockStorageObjectsDelete);
-    when(mockStorageObjects.get(eq(BUCKET_NAME), eq(OBJECT_NAME)))
-        .thenReturn(mockStorageObjectsGet);
-
     // Make the errorExtractor claim that our fake notFoundException.
-    final GoogleJsonError notFoundError = new GoogleJsonError();
+    GoogleJsonError notFoundError = new GoogleJsonError();
     notFoundError.setMessage("Fake not-found exception");
-    final GoogleJsonError unexpectedError = new GoogleJsonError();
+    GoogleJsonError unexpectedError = new GoogleJsonError();
     unexpectedError.setMessage("Other API exception");
 
     doAnswer(
@@ -497,12 +171,7 @@ public class GoogleCloudStorageMockitoTest {
             gcs.deleteObjects(Lists.newArrayList(new StorageResourceId(BUCKET_NAME, OBJECT_NAME))));
 
     verify(mockBatchFactory, times(2))
-        .newBatchHelper(any(), eq(mockStorage), anyLong(), anyLong(), anyInt());
-    verify(mockStorage, times(4)).objects();
-    verify(mockStorageObjects, times(2)).delete(eq(BUCKET_NAME), eq(OBJECT_NAME));
-    verify(mockStorageObjects, times(2)).get(eq(BUCKET_NAME), eq(OBJECT_NAME));
-    verify(mockStorageObjectsGet, times(2)).setFields(eq("generation"));
-    verify(mockStorageObjectsDelete, times(2)).setIfGenerationMatch(eq(1L));
+        .newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt());
     verify(mockBatchHelper, times(4)).queue(any(), any());
     verify(mockErrorExtractor, times(2)).itemNotFound(any(IOException.class));
     verify(mockErrorExtractor).preconditionNotMet(any(IOException.class));
@@ -515,16 +184,9 @@ public class GoogleCloudStorageMockitoTest {
    */
   @Test
   public void testCopyObjectsApiExceptionSameBucket() throws IOException {
-    String dstObjectName = OBJECT_NAME + "-copy";
-    when(mockBatchFactory.newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt()))
-        .thenReturn(mockBatchHelper);
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-    when(mockStorageObjects.copy(
-            eq(BUCKET_NAME), eq(OBJECT_NAME), eq(BUCKET_NAME), eq(dstObjectName), isNull()))
-        .thenReturn(mockStorageObjectsCopy);
-    final GoogleJsonError notFoundError = new GoogleJsonError();
+    GoogleJsonError notFoundError = new GoogleJsonError();
     notFoundError.setMessage("Fake not-found exception");
-    final GoogleJsonError unexpectedError = new GoogleJsonError();
+    GoogleJsonError unexpectedError = new GoogleJsonError();
     unexpectedError.setMessage("Other API exception");
     doAnswer(
             invocation -> {
@@ -553,10 +215,11 @@ public class GoogleCloudStorageMockitoTest {
               return null;
             })
         .when(mockBatchHelper)
-        .queue(eq(mockStorageObjectsCopy), any());
+        .queue(any(Storage.Objects.Copy.class), any());
     doReturn(true).doReturn(false).when(mockErrorExtractor).itemNotFound(any(IOException.class));
 
     // Make the test output a little more friendly in case the exception class differs.
+    String dstObjectName = OBJECT_NAME + "-copy";
     assertThrows(
         FileNotFoundException.class,
         () ->
@@ -572,24 +235,17 @@ public class GoogleCloudStorageMockitoTest {
                 BUCKET_NAME, ImmutableList.of(dstObjectName)));
 
     verify(mockBatchFactory, times(2))
-        .newBatchHelper(any(), eq(mockStorage), anyLong(), anyLong(), anyInt());
-    verify(mockStorage, times(2)).objects();
-    verify(mockStorageObjects, times(2))
-        .copy(eq(BUCKET_NAME), eq(OBJECT_NAME), eq(BUCKET_NAME), eq(dstObjectName), isNull());
-    verify(mockBatchHelper, times(2)).queue(eq(mockStorageObjectsCopy), any());
+        .newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt());
+    verify(mockBatchHelper, times(2)).queue(any(Storage.Objects.Copy.class), any());
     verify(mockErrorExtractor, times(2)).itemNotFound(any(IOException.class));
     verify(mockBatchHelper, times(2)).flush();
   }
 
+  /** Test {@link BatchHelper} error handling. */
   @Test
   public void testGetItemInfosApiException() throws IOException {
-    when(mockBatchFactory.newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt()))
-        .thenReturn(mockBatchHelper);
-
     // Set up the return for the Bucket fetch.
-    when(mockStorage.buckets()).thenReturn(mockStorageBuckets);
-    when(mockStorageBuckets.get(eq(BUCKET_NAME))).thenReturn(mockStorageBucketsGet);
-    final GoogleJsonError unexpectedError = new GoogleJsonError();
+    GoogleJsonError unexpectedError = new GoogleJsonError();
     unexpectedError.setMessage("Unexpected API exception ");
     doAnswer(
             invocation -> {
@@ -604,13 +260,9 @@ public class GoogleCloudStorageMockitoTest {
               return null;
             })
         .when(mockBatchHelper)
-        .queue(eq(mockStorageBucketsGet), any());
+        .queue(any(Storage.Buckets.Get.class), any());
 
     // Set up the return for the StorageObject fetch.
-    when(mockStorage.objects()).thenReturn(mockStorageObjects);
-    when(mockStorageObjects.get(eq(BUCKET_NAME), eq(OBJECT_NAME)))
-        .thenReturn(mockStorageObjectsGet);
-    when(mockStorageObjectsGet.setFields(anyString())).thenReturn(mockStorageObjectsGet);
     doAnswer(
             invocation -> {
               Object[] args = invocation.getArguments();
@@ -625,7 +277,7 @@ public class GoogleCloudStorageMockitoTest {
               return null;
             })
         .when(mockBatchHelper)
-        .queue(eq(mockStorageObjectsGet), any());
+        .queue(any(Storage.Objects.Get.class), any());
 
     // We will claim both GoogleJsonErrors are unexpected errors.
     when(mockErrorExtractor.itemNotFound(any(IOException.class))).thenReturn(false);
@@ -644,62 +296,11 @@ public class GoogleCloudStorageMockitoTest {
     assertThat(ioe.getSuppressed()).hasLength(2);
     // All invocations still should have been attempted; the exception should have been thrown
     // at the very end.
-    verify(mockBatchFactory).newBatchHelper(any(), eq(mockStorage), anyLong(), anyLong(), anyInt());
-    verify(mockStorage).buckets();
-    verify(mockStorageBuckets).get(eq(BUCKET_NAME));
-    verify(mockBatchHelper).queue(eq(mockStorageBucketsGet), any());
-    verify(mockStorage).objects();
-    verify(mockStorageObjects).get(eq(BUCKET_NAME), eq(OBJECT_NAME));
-    verify(mockStorageObjectsGet).setFields(eq(OBJECT_FIELDS));
-    verify(mockBatchHelper).queue(eq(mockStorageObjectsGet), any());
+    verify(mockBatchFactory)
+        .newBatchHelper(any(), any(Storage.class), anyLong(), anyLong(), anyInt());
+    verify(mockBatchHelper).queue(any(Storage.Buckets.Get.class), any());
+    verify(mockBatchHelper).queue(any(Storage.Objects.Get.class), any());
     verify(mockErrorExtractor, times(2)).itemNotFound(any(IOException.class));
     verify(mockBatchHelper).flush();
-  }
-
-  @Test
-  public void testReadWithFailedInplaceSeekSucceeds() throws IOException {
-    byte[] testData = {0x01, 0x02, 0x03, 0x05, 0x08};
-    byte[] testData2 = Arrays.copyOfRange(testData, 3, testData.length);
-
-    setUpBasicMockBehaviorForOpeningReadChannel(testData.length);
-
-    InputStream mockExceptionStream = mock(InputStream.class);
-    when(mockExceptionStream.read(any(byte[].class), eq(0), eq(1))).thenReturn(1);
-    when(mockExceptionStream.read(any(byte[].class), eq(0), eq(2)))
-        .thenThrow(new IOException("In-place seek IOException"));
-
-    when(mockStorageObjectsGet.executeMedia())
-        .thenReturn(fakeResponse("Content-Length", testData.length, mockExceptionStream))
-        .thenReturn(
-            fakeResponse("Content-Length", testData2.length, new ByteArrayInputStream(testData2)));
-
-    GoogleCloudStorageReadChannel readChannel =
-        (GoogleCloudStorageReadChannel)
-            gcs.open(
-                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
-                GoogleCloudStorageReadOptions.builder().setInplaceSeekLimit(3).build());
-
-    setUpAndValidateReadChannelMocksAndSetMaxRetries(readChannel, 3);
-
-    assertThat(readChannel.read(ByteBuffer.wrap(new byte[1]))).isEqualTo(1);
-
-    readChannel.position(3);
-
-    byte[] byte3 = new byte[1];
-    assertThat(readChannel.read(ByteBuffer.wrap(byte3))).isEqualTo(1);
-
-    assertThat(byte3).isEqualTo(new byte[] {testData[3]});
-
-    verify(mockStorage, times(3)).objects();
-    verify(mockStorageObjects, times(3)).get(eq(BUCKET_NAME), eq(OBJECT_NAME));
-    verify(mockClientRequestHelper, times(2)).getRequestHeaders(any(Storage.Objects.Get.class));
-    verify(mockHeaders, times(2)).setAcceptEncoding(eq("gzip"));
-    verify(mockHeaders).setRange(eq("bytes=0-"));
-    verify(mockHeaders).setRange(eq("bytes=3-"));
-    verify(mockStorageObjectsGet, times(2)).setGeneration(any());
-    verify(mockStorageObjectsGet).setFields(eq(OBJECT_FIELDS));
-    verify(mockStorageObjectsGet).execute();
-    verify(mockStorageObjectsGet, times(2)).executeMedia();
-    verify(mockExceptionStream, times(2)).read(any(byte[].class), eq(0), anyInt());
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -21,23 +21,29 @@ import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.JSON_FAC
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.OBJECT_NAME;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils.createReadChannel;
 import static com.google.cloud.hadoop.gcsio.StorageResourceId.UNKNOWN_GENERATION_ID;
+import static com.google.cloud.hadoop.gcsio.testing.MockGoogleCloudStorageImplFactory.mockedGcs;
 import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.dataRangeResponse;
 import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.dataResponse;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.inputStreamResponse;
 import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.jsonDataResponse;
 import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.jsonErrorResponse;
 import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.mockTransport;
+import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.util.DateTime;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
+import com.google.common.collect.ImmutableMap;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -50,6 +56,8 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link GoogleCloudStorageReadChannel} class. */
 @RunWith(JUnit4.class)
 public class GoogleCloudStorageReadChannelTest {
+
+  private static final String PROJECT_ID = "google.com:foo-project";
 
   @Test
   public void metadataInitialization_eager() throws IOException {
@@ -534,6 +542,72 @@ public class GoogleCloudStorageReadChannelTest {
     assertThat(e)
         .hasMessageThat()
         .isEqualTo("Cannot read GZIP encoded files - content encoding support is disabled.");
+  }
+
+  /**
+   * Helper for test cases involving {@code GoogleCloudStorage.open(StorageResourceId)} to set up
+   * the shared sleeper/clock/backoff mocks and set {@code maxRetries}. Also checks basic invariants
+   * of a fresh readChannel, such as its position() and isOpen().
+   */
+  private void setUpAndValidateReadChannelMocksAndSetMaxRetries(
+      GoogleCloudStorageReadChannel readChannel, int maxRetries) throws IOException {
+    readChannel.setMaxRetries(maxRetries);
+    assertThat(readChannel.isOpen()).isTrue();
+    assertThat(readChannel.position()).isEqualTo(0);
+  }
+
+  /** Test error handling of {@link GoogleCloudStorageReadChannel#skipInPlace(long)} */
+  @Test
+  public void testReadWithFailedInplaceSeekSucceeds() throws IOException {
+    byte[] testData = {0x01, 0x02, 0x03, 0x05, 0x08};
+    byte[] testData2 = Arrays.copyOfRange(testData, 3, testData.length);
+
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                new StorageObject()
+                    .setBucket(BUCKET_NAME)
+                    .setName(OBJECT_NAME)
+                    .setTimeCreated(new DateTime(11L))
+                    .setUpdated(new DateTime(12L))
+                    .setSize(BigInteger.valueOf(testData.length))
+                    .setContentEncoding(null)
+                    .setGeneration(1L)
+                    .setMetageneration(1L)),
+            inputStreamResponse(
+                CONTENT_LENGTH,
+                testData.length,
+                new InputStream() {
+                  private int current = 0;
+
+                  @Override
+                  public synchronized int read() throws IOException {
+                    if (current == 0) {
+                      current += 1;
+                      return 1;
+                    }
+                    throw new IOException("In-place seek IOException");
+                  }
+                }),
+            dataResponse(ImmutableMap.of("Content-Length", testData2.length), testData2));
+    GoogleCloudStorage gcs = mockedGcs(transport);
+
+    GoogleCloudStorageReadChannel readChannel =
+        (GoogleCloudStorageReadChannel)
+            gcs.open(
+                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+                GoogleCloudStorageReadOptions.builder().setInplaceSeekLimit(3).build());
+
+    setUpAndValidateReadChannelMocksAndSetMaxRetries(readChannel, 3);
+
+    // Read once then skip to trigger a call to method under testing.
+    assertThat(readChannel.read(ByteBuffer.wrap(new byte[1]))).isEqualTo(1);
+    readChannel.position(3);
+
+    // IOException thrown. Trigger lazy-seek behavior.
+    byte[] byte3 = new byte[1];
+    assertThat(readChannel.read(ByteBuffer.wrap(byte3))).isEqualTo(1);
+    assertThat(byte3).isEqualTo(new byte[] {testData[3]});
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/testing/MockGoogleCloudStorageImplFactory.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/testing/MockGoogleCloudStorageImplFactory.java
@@ -1,0 +1,37 @@
+package com.google.cloud.hadoop.gcsio.testing;
+
+import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.storage.Storage;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
+import com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer;
+import com.google.cloud.hadoop.util.RetryHttpInitializer;
+import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
+
+public class MockGoogleCloudStorageImplFactory {
+
+  private static final String PROJECT_ID = "google.com:foo-project";
+
+  public static GoogleCloudStorageImpl mockedGcs(HttpTransport transport) {
+    Storage storage =
+        new Storage(
+            transport,
+            GsonFactory.getDefaultInstance(),
+            new TrackingHttpRequestInitializer(
+                new RetryHttpInitializer(
+                    new MockGoogleCredential.Builder().build(),
+                    RetryHttpInitializerOptions.builder()
+                        .setDefaultUserAgent("gcs-io-unit-test")
+                        .build()),
+                false));
+    return new GoogleCloudStorageImpl(
+        GoogleCloudStorageOptions.builder()
+            .setAppName("gcsio-unit-test")
+            .setProjectId(PROJECT_ID)
+            .build(),
+        storage,
+        null);
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/testing/MockHttpTransportHelper.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/testing/MockHttpTransportHelper.java
@@ -28,17 +28,13 @@ import static org.apache.http.HttpStatus.SC_GONE;
 import static org.apache.http.HttpStatus.SC_REQUESTED_RANGE_NOT_SATISFIABLE;
 
 import com.google.api.client.googleapis.json.GoogleJsonError;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -49,6 +45,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /** Utility methods for testing with {@link MockHttpTransport} */
 public final class MockHttpTransportHelper {
@@ -114,35 +111,6 @@ public final class MockHttpTransportHelper {
   public static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
 
   private MockHttpTransportHelper() {}
-
-  public static HttpResponse fakeResponse(String header, Object headerValue, InputStream content)
-      throws IOException {
-    return fakeResponse(ImmutableMap.of(header, headerValue), content);
-  }
-
-  public static HttpResponse fakeResponse(Map<String, Object> headers, InputStream content)
-      throws IOException {
-    HttpTransport transport =
-        new MockHttpTransport() {
-          @Override
-          public LowLevelHttpRequest buildRequest(String method, String url) {
-            return new MockLowLevelHttpRequest() {
-              @Override
-              public LowLevelHttpResponse execute() {
-                MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-                headers.forEach((h, hv) -> response.addHeader(h, String.valueOf(hv)));
-                return response.setContent(content);
-              }
-            };
-          }
-        };
-    HttpRequest request =
-        transport
-            .createRequestFactory()
-            .buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL)
-            .setResponseReturnRawInputStream(true);
-    return request.execute();
-  }
 
   public static MockHttpTransport mockTransport(Object... responsesIn) {
     return new MockHttpTransport() {
@@ -268,6 +236,20 @@ public final class MockHttpTransportHelper {
       Map<String, Object> headers, InputStream content) {
     return setHeaders(new MockLowLevelHttpResponse(), headers, UNKNOWN_CONTENT_LENGTH)
         .setContent(content);
+  }
+
+  /**
+   * Return an arbitrary InputStream supplier. This function should only be used to simulate
+   * arbitrary runtime behavior when calling {@code execute} and {@code executeMedia}.
+   */
+  public static MockLowLevelHttpResponse arbitraryInputStreamSupplier(
+      Supplier<InputStream> supplier) {
+    return new MockLowLevelHttpResponse() {
+      @Override
+      public InputStream getContent() {
+        return supplier.get();
+      }
+    };
   }
 
   private static MockLowLevelHttpResponse setHeaders(


### PR DESCRIPTION
Cherry pick of pr#737.
Made some minor changes to test utility.

pr#737:
Remove most of the mockito mocks. Mocks for Storage and requests are
completely removed. Only mocks for BatchHelper related objects remains.
    
Also moves the tests into their respective test class since they don't
use mockito now.