### PR TITLE
Log metadata and read data latencies

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -2155,9 +2155,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
           Thread.currentThread().getId(),
           requestDelay,
           resourceId,
-          requestDelay > 1000
-              ? getObject.getLastResponseHeaders().getFirstHeaderStringValue("x-guploader-uploadid")
-              : "");
+          getObject.getLastResponseHeaders().getFirstHeaderStringValue("x-guploader-uploadid"));
       return object;
     } catch (IOException e) {
       if (errorExtractor.itemNotFound(e)) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -2150,7 +2150,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       long startTimeOfMetadataRead = System.currentTimeMillis();
       StorageObject object = getObject.execute();
       long requestDelay = System.currentTimeMillis() - startTimeOfMetadataRead;
-      logger.atFine().log(
+      logger.atFinest().log(
           "GoogleCloudStorageImpl:getMetadata complete context:%d,time:%d,resource:%s,requestId:%s",
           Thread.currentThread().getId(),
           requestDelay,

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -26,6 +26,7 @@ import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback;
@@ -77,6 +78,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.base.Stopwatch;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -2147,9 +2149,9 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
             // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
             .setFields(OBJECT_FIELDS);
     try {
-      long startTimeOfMetadataRead = System.currentTimeMillis();
+      Stopwatch stopwatch = Stopwatch.createStarted();
       StorageObject object = getObject.execute();
-      long requestDelay = System.currentTimeMillis() - startTimeOfMetadataRead;
+      long requestDelay = stopwatch.elapsed(MILLISECONDS);
       logger.atFinest().log(
           "GoogleCloudStorageImpl:getMetadata complete context:%d,time:%d,resource:%s,requestId:%s",
           Thread.currentThread().getId(),

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -2129,7 +2129,18 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
             // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
             .setFields(OBJECT_FIELDS);
     try {
-      return getObject.execute();
+      long startTimeOfMetadataRead = System.currentTimeMillis();
+      StorageObject object = getObject.execute();
+      long requestDelay = System.currentTimeMillis() - startTimeOfMetadataRead;
+      logger.atFine().log(
+          "GoogleCloudStorageImpl:getMetadata complete context:%d,time:%d,resource:%s,requestId:%s",
+          Thread.currentThread().getId(),
+          requestDelay,
+          resourceId,
+          requestDelay > 1000
+              ? getObject.getLastResponseHeaders().getFirstHeaderStringValue("x-guploader-uploadid")
+              : "");
+      return object;
     } catch (IOException e) {
       if (errorExtractor.itemNotFound(e)) {
         logger.atFiner().withCause(e).log("getObject(%s): not found", resourceId);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -242,7 +242,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
               sleeper);
 
       long requestDelay = System.currentTimeMillis() - startTimeOfMetadataRead;
-      logger.atFine().log(
+      logger.atFinest().log(
           "GoogleCloudStorageReadChannel:getMetadata complete context:%d,time:%d,resource:%s,requestId:%s",
           Thread.currentThread().getId(),
           requestDelay,
@@ -949,7 +949,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       startTimeOfChannelOpen = System.currentTimeMillis();
       response = getObject.executeMedia();
       long requestDelay = System.currentTimeMillis() - startTimeOfChannelOpen;
-      logger.atFine().log(
+      logger.atFinest().log(
           "openStream complete context:%d,time:%d,bytesToRead:%d,rangeSize:%d,resource:%s,requestId:%s",
           Thread.currentThread().getId(),
           requestDelay,

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -247,9 +247,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           Thread.currentThread().getId(),
           requestDelay,
           resourceId,
-          requestDelay > 1000
-              ? getObject.getLastResponseHeaders().getFirstHeaderStringValue("x-guploader-uploadid")
-              : "");
+          getObject.getLastResponseHeaders().getFirstHeaderStringValue("x-guploader-uploadid"));
     } catch (IOException e) {
       throw errorExtractor.itemNotFound(e)
           ? createFileNotFoundException(resourceId, e)
@@ -956,9 +954,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
           bytesToRead,
           contentChannelEnd - contentChannelPosition,
           resourceId,
-          requestDelay > 1000
-              ? response.getHeaders().getFirstHeaderStringValue("x-guploader-uploadid")
-              : "");
+          response.getHeaders().getFirstHeaderStringValue("x-guploader-uploadid"));
       // TODO(b/110832992): validate response range header against expected/request range
     } catch (IOException e) {
       if (!metadataInitialized && errorExtractor.rangeNotSatisfiable(e) && currentPosition == 0) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -40,9 +40,9 @@ import com.google.cloud.hadoop.util.ResilientOperation;
 import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Stopwatch;
 import com.google.common.flogger.GoogleLogger;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -105,7 +105,6 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
   private long contentChannelEnd = -1;
 
   private Stopwatch stopwatch;
-
 
   // Whether to use bounded range requests or streaming requests.
   @VisibleForTesting boolean randomAccess;
@@ -245,11 +244,10 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
               IOException.class,
               sleeper);
 
-      long requestDelay = metadataStopwatch.elapsed(MILLISECONDS);
       logger.atFinest().log(
           "GoogleCloudStorageReadChannel:getMetadata complete context:%d,time:%d,resource:%s,requestId:%s",
           Thread.currentThread().getId(),
-          requestDelay,
+          metadataStopwatch.elapsed(MILLISECONDS),
           resourceId,
           getObject.getLastResponseHeaders().getFirstHeaderStringValue("x-guploader-uploadid"));
     } catch (IOException e) {
@@ -950,11 +948,11 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     try {
       stopwatch = Stopwatch.createStarted();
       response = getObject.executeMedia();
-      long requestDelay = stopwatch.elapsed(MILLISECONDS);
+
       logger.atFinest().log(
           "openStream complete context:%d,time:%d,bytesToRead:%d,rangeSize:%d,resource:%s,requestId:%s",
           Thread.currentThread().getId(),
-          requestDelay,
+          stopwatch.elapsed(MILLISECONDS),
           bytesToRead,
           contentChannelEnd - contentChannelPosition,
           resourceId,


### PR DESCRIPTION
Log metadata and read data latencies on the JSON read path. Moreover when the latency is more than a second, log the request id fetched from the response header