### PR TITLE
Enable HTTP trace event logs to Cloud Logging

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -215,6 +215,7 @@
                   <include>com.google.auth</include>
                   <include>com.google.cloud</include>
                   <include>com.google.cloud.bigdataoss</include>
+                  <include>com.google.cloud.logging</include>
                   <include>com.google.flogger</include>
                   <include>com.google.code.gson</include>
                   <include>com.google.guava</include>
@@ -241,6 +242,7 @@
                     <include>com.google.cloud.audit.**</include>
                     <include>com.google.cloud.hadoop.gcsio.**</include>
                     <include>com.google.cloud.hadoop.util.**</include>
+                    <include>com.google.cloud.logging.**</include>
                     <include>com.google.common.**</include>
                     <include>com.google.geo.**</include>
                     <include>com.google.gson.**</include>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -27,6 +27,7 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.GlobAlgorithm;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.OutputStreamType;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
@@ -419,6 +420,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<MetricsSink> GCS_METRICS_SINK =
       new HadoopConfigurationProperty<>("fs.gs.metrics.sink", MetricsSink.NONE);
 
+  /** Configuration key to enable publishing event logs to Google cloud logging. */
+  public static final HadoopConfigurationProperty<EventLogSink> GCS_EVENT_LOG_SINK =
+      new HadoopConfigurationProperty<>("fs.gs.eventlog.sink", EventLogSink.NONE);
+
   // TODO(b/120887495): This @VisibleForTesting annotation was being ignored by prod code.
   // Please check that removing it is correct, and remove this comment along with it.
   // @VisibleForTesting
@@ -473,7 +478,8 @@ public class GoogleHadoopFileSystemConfiguration {
             GCS_GRPC_CHECK_INTERVAL_TIMEOUT_MS.get(config, config::getLong))
         .setDirectPathPreferred(GCS_GRPC_DIRECTPATH_ENABLE.get(config, config::getBoolean))
         .setTrafficDirectorEnabled(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.get(config, config::getBoolean))
-        .setMetricsSink(GCS_METRICS_SINK.get(config, config::getEnum));
+        .setMetricsSink(GCS_METRICS_SINK.get(config, config::getEnum))
+        .setEventLogSink(GCS_EVENT_LOG_SINK.get(config, config::getEnum));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -27,8 +27,8 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.GlobAlgorithm;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.OutputStreamType;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.TraceLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.PerformanceCachingGoogleCloudStorageOptions;
@@ -421,8 +421,8 @@ public class GoogleHadoopFileSystemConfiguration {
       new HadoopConfigurationProperty<>("fs.gs.metrics.sink", MetricsSink.NONE);
 
   /** Configuration key to enable publishing event logs to Google cloud logging. */
-  public static final HadoopConfigurationProperty<EventLogSink> GCS_EVENT_LOG_SINK =
-      new HadoopConfigurationProperty<>("fs.gs.eventlog.sink", EventLogSink.NONE);
+  public static final HadoopConfigurationProperty<TraceLogSink> GCS_TRACE_LOG_SINK =
+      new HadoopConfigurationProperty<>("fs.gs.tracelog.sink", TraceLogSink.NONE);
 
   // TODO(b/120887495): This @VisibleForTesting annotation was being ignored by prod code.
   // Please check that removing it is correct, and remove this comment along with it.
@@ -479,7 +479,7 @@ public class GoogleHadoopFileSystemConfiguration {
         .setDirectPathPreferred(GCS_GRPC_DIRECTPATH_ENABLE.get(config, config::getBoolean))
         .setTrafficDirectorEnabled(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.get(config, config::getBoolean))
         .setMetricsSink(GCS_METRICS_SINK.get(config, config::getEnum))
-        .setEventLogSink(GCS_EVENT_LOG_SINK.get(config, config::getEnum));
+        .setTraceLogSink(GCS_TRACE_LOG_SINK.get(config, config::getEnum));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -45,6 +45,7 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.GlobAlgorithm;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.OutputStreamType;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PipeType;
@@ -77,6 +78,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.encryption.algorithm", null);
           put("fs.gs.encryption.key.hash", null);
           put("fs.gs.encryption.key", null);
+          put("fs.gs.eventlog.sink", EventLogSink.NONE);
           put("fs.gs.glob.algorithm", GlobAlgorithm.CONCURRENT);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.enable", false);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -45,8 +45,8 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.GlobAlgorithm;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.OutputStreamType;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.TraceLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PipeType;
 import com.google.cloud.hadoop.util.RedactedString;
@@ -78,7 +78,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.encryption.algorithm", null);
           put("fs.gs.encryption.key.hash", null);
           put("fs.gs.encryption.key", null);
-          put("fs.gs.eventlog.sink", EventLogSink.NONE);
+          put("fs.gs.tracelog.sink", TraceLogSink.NONE);
           put("fs.gs.glob.algorithm", GlobAlgorithm.CONCURRENT);
           put("fs.gs.grpc.checksums.enable", false);
           put("fs.gs.grpc.enable", false);

--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -167,6 +167,10 @@
       <artifactId>google-cloud-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
     </dependency>

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/EventLoggingHttpRequestInitializer.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/EventLoggingHttpRequestInitializer.java
@@ -1,0 +1,69 @@
+package com.google.cloud.hadoop.gcsio;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpResponse;
+import com.google.cloud.MonitoredResource;
+import com.google.cloud.logging.LogEntry;
+import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.Payload.JsonPayload;
+import com.google.cloud.logging.Severity;
+import com.google.common.base.Stopwatch;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class EventLoggingHttpRequestInitializer implements HttpRequestInitializer {
+
+  private final Map<HttpRequest, Stopwatch> requestTracker = new ConcurrentHashMap<>();
+  private final Logging logging;
+
+  public EventLoggingHttpRequestInitializer(Logging logging) {
+    this.logging = logging;
+  }
+
+  @Override
+  public void initialize(HttpRequest request) throws IOException {
+    request.setInterceptor(
+        httpRequest -> requestTracker.put(httpRequest, Stopwatch.createStarted()));
+    request.setResponseInterceptor(this::log);
+  }
+
+  private void log(HttpResponse httpResponse) {
+    HttpRequest request = httpResponse.getRequest();
+    Stopwatch stopwatch = requestTracker.get(request);
+    requestTracker.remove(request);
+    Long latency = (stopwatch == null) ? null : stopwatch.elapsed(MILLISECONDS);
+
+    Map<String, Object> jsonMap = new HashMap<>();
+    jsonMap.put("request_method", request.getRequestMethod());
+    jsonMap.put("request_url", request.getUrl().toString());
+    jsonMap.put("request_headers", request.getHeaders());
+    jsonMap.put("response_headers", httpResponse.getHeaders());
+    jsonMap.put("response_status_code", httpResponse.getStatusCode());
+    jsonMap.put("response_status_message", httpResponse.getStatusMessage());
+    jsonMap.put("latency", latency);
+    jsonMap.put("thread_name", Thread.currentThread().getName());
+    try {
+      jsonMap.put("hostname", InetAddress.getLocalHost().getHostName());
+    } catch (UnknownHostException e) {
+      // ignore
+    }
+    jsonMap.put("protocol", "json");
+    LogEntry logEntry =
+        LogEntry.newBuilder(JsonPayload.of(jsonMap))
+            .setSeverity(Severity.INFO)
+            .setLogName("dataproc-gcs-performance")
+            .setResource(
+                MonitoredResource.newBuilder("global").addLabel("library", "gcsio").build())
+            .build();
+
+    logging.write(Collections.singleton(logEntry));
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -54,8 +54,8 @@ import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.RewriteResponse;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.auth.Credentials;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.TraceLogSink;
 import com.google.cloud.hadoop.util.AbstractGoogleAsyncWriteChannel;
 import com.google.cloud.hadoop.util.AccessBoundary;
 import com.google.cloud.hadoop.util.ApiErrorExtractor;
@@ -341,7 +341,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     httpRequestInitializers.add(new StatisticsTrackingHttpRequestInitializer(statistics));
     httpRequestInitializers.add(
         new RetryHttpInitializer(credentials, options.toRetryHttpInitializerOptions()));
-    if (storageOptions.getEventLogSink() == EventLogSink.CLOUD_LOGGING) {
+    if (storageOptions.getTraceLogSink() == TraceLogSink.CLOUD_LOGGING) {
       checkNotNull(credentials, "credentials cannot be null when event logging enabled");
       this.cloudLogger =
           LoggingOptions.newBuilder()
@@ -349,7 +349,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
               .setCredentials(credentials)
               .build()
               .getService();
-      httpRequestInitializers.add(new EventLoggingHttpRequestInitializer(cloudLogger));
+      httpRequestInitializers.add(new TraceLoggingHttpRequestInitializer(cloudLogger));
     }
     HttpRequestInitializer retryHttpInitializer =
         new ChainingHttpRequestInitializer(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -100,6 +100,11 @@ public abstract class GoogleCloudStorageOptions {
     CLOUD_MONITORING,
   }
 
+  public enum EventLogSink {
+    NONE,
+    CLOUD_LOGGING
+  }
+
   public static final GoogleCloudStorageOptions DEFAULT = builder().build();
 
   public static Builder builder() {
@@ -125,7 +130,8 @@ public abstract class GoogleCloudStorageOptions {
         .setRequesterPaysOptions(RequesterPaysOptions.DEFAULT)
         .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT)
         .setGrpcMessageTimeoutCheckInterval(GRPC_MESSAGE_TIMEOUT_CHECK_INTERVAL)
-        .setMetricsSink(MetricsSink.NONE);
+        .setMetricsSink(MetricsSink.NONE)
+        .setEventLogSink(EventLogSink.NONE);
   }
 
   public abstract Builder toBuilder();
@@ -197,6 +203,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract long getGrpcMessageTimeoutCheckInterval();
 
   public abstract MetricsSink getMetricsSink();
+
+  public abstract EventLogSink getEventLogSink();
 
   public RetryHttpInitializerOptions toRetryHttpInitializerOptions() {
     return RetryHttpInitializerOptions.builder()
@@ -278,6 +286,8 @@ public abstract class GoogleCloudStorageOptions {
         long grpcMessageTimeoutInMillisCheckInterval);
 
     public abstract Builder setMetricsSink(MetricsSink metricsSink);
+
+    public abstract Builder setEventLogSink(EventLogSink eventLogSink);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -100,7 +100,7 @@ public abstract class GoogleCloudStorageOptions {
     CLOUD_MONITORING,
   }
 
-  public enum EventLogSink {
+  public enum TraceLogSink {
     NONE,
     CLOUD_LOGGING
   }
@@ -131,7 +131,7 @@ public abstract class GoogleCloudStorageOptions {
         .setHttpRequestHeaders(HTTP_REQUEST_HEADERS_DEFAULT)
         .setGrpcMessageTimeoutCheckInterval(GRPC_MESSAGE_TIMEOUT_CHECK_INTERVAL)
         .setMetricsSink(MetricsSink.NONE)
-        .setEventLogSink(EventLogSink.NONE);
+        .setTraceLogSink(TraceLogSink.NONE);
   }
 
   public abstract Builder toBuilder();
@@ -204,7 +204,7 @@ public abstract class GoogleCloudStorageOptions {
 
   public abstract MetricsSink getMetricsSink();
 
-  public abstract EventLogSink getEventLogSink();
+  public abstract TraceLogSink getTraceLogSink();
 
   public RetryHttpInitializerOptions toRetryHttpInitializerOptions() {
     return RetryHttpInitializerOptions.builder()
@@ -287,7 +287,7 @@ public abstract class GoogleCloudStorageOptions {
 
     public abstract Builder setMetricsSink(MetricsSink metricsSink);
 
-    public abstract Builder setEventLogSink(EventLogSink eventLogSink);
+    public abstract Builder setTraceLogSink(TraceLogSink traceLogSink);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/TraceLoggingHttpRequestInitializer.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/TraceLoggingHttpRequestInitializer.java
@@ -19,12 +19,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class EventLoggingHttpRequestInitializer implements HttpRequestInitializer {
+class TraceLoggingHttpRequestInitializer implements HttpRequestInitializer {
 
   private final Map<HttpRequest, Stopwatch> requestTracker = new ConcurrentHashMap<>();
   private final Logging logging;
 
-  public EventLoggingHttpRequestInitializer(Logging logging) {
+  public TraceLoggingHttpRequestInitializer(Logging logging) {
     this.logging = logging;
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
@@ -134,7 +135,22 @@ public class GoogleCloudStorageGrpcIntegrationTest {
                 .setMetricsSink(MetricsSink.CLOUD_MONITORING)
                 .build(),
             GoogleCloudStorageTestHelper.getCredentials());
-    StorageResourceId objectToCreate = new StorageResourceId(BUCKET_NAME, "testOpen_Object");
+    StorageResourceId objectToCreate =
+        new StorageResourceId(BUCKET_NAME, "testOpenWithMetricsEnabled_Object");
+    byte[] objectBytes = writeObject(rawStorage, objectToCreate, /* objectSize= */ 100);
+    assertObjectContent(rawStorage, objectToCreate, objectBytes);
+  }
+
+  @Test
+  public void testOpenWithEventlogEnabled() throws IOException {
+    GoogleCloudStorage rawStorage =
+        new GoogleCloudStorageImpl(
+            GoogleCloudStorageTestHelper.getStandardOptionBuilder()
+                .setEventLogSink(EventLogSink.CLOUD_LOGGING)
+                .build(),
+            GoogleCloudStorageTestHelper.getCredentials());
+    StorageResourceId objectToCreate =
+        new StorageResourceId(BUCKET_NAME, "testOpenWithEventlogEnabled_Object");
     byte[] objectBytes = writeObject(rawStorage, objectToCreate, /* objectSize= */ 100);
     assertObjectContent(rawStorage, objectToCreate, objectBytes);
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.assertThrows;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.EventLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.MetricsSink;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.TraceLogSink;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
@@ -146,7 +146,7 @@ public class GoogleCloudStorageGrpcIntegrationTest {
     GoogleCloudStorage rawStorage =
         new GoogleCloudStorageImpl(
             GoogleCloudStorageTestHelper.getStandardOptionBuilder()
-                .setEventLogSink(EventLogSink.CLOUD_LOGGING)
+                .setTraceLogSink(TraceLogSink.CLOUD_LOGGING)
                 .build(),
             GoogleCloudStorageTestHelper.getCredentials());
     StorageResourceId objectToCreate =

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
     <google.auto-value.version>1.9</google.auto-value.version>
     <google.cloud-bigquerystorage.version>2.7.0</google.cloud-bigquerystorage.version>
     <google.cloud-core.verion>2.5.4</google.cloud-core.verion>
+    <google.cloud-logging.version>3.7.1</google.cloud-logging.version>
     <google.cloud-storage.grpc.version>2.2.2-alpha</google.cloud-storage.grpc.version>
     <google.error-prone.version>2.10.0</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
@@ -413,6 +414,11 @@
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-core</artifactId>
         <version>${google.cloud-core.verion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-logging</artifactId>
+        <version>${google.cloud-logging.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.api</groupId>


### PR DESCRIPTION
Write structured logs to Cloud logging, to enable low level analysis via [log analytics preview](https://cloud.google.com/logging/docs/log-analytics) 