### PR TITLE
Run all gRPC integration tests also with TD enabled

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -24,7 +24,6 @@ steps:
     entrypoint: 'bash'
     args: ['/hadoop-connectors/cloudbuild/presubmit.sh', 'integrationtest']
     env:
-      - 'RUNNING_TESTS_FROM_GCP=true'
       - 'GCS_TEST_PROJECT_ID=$PROJECT_ID'
       - 'CODECOV_TOKEN=$_CODECOV_TOKEN'
       - 'VCS_BRANCH_NAME=$BRANCH_NAME'

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -24,6 +24,7 @@ steps:
     entrypoint: 'bash'
     args: ['/hadoop-connectors/cloudbuild/presubmit.sh', 'integrationtest']
     env:
+      - 'RUNNING_TESTS_FROM_GCP=true'
       - 'GCS_TEST_PROJECT_ID=$PROJECT_ID'
       - 'CODECOV_TOKEN=$_CODECOV_TOKEN'
       - 'VCS_BRANCH_NAME=$BRANCH_NAME'

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -18,6 +18,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -28,6 +29,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class GoogleCloudStorageGrpcIntegrationTest {
+
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   // Prefix this name with the prefix used in other gcs io integrate tests once it's whitelisted by
   // GCS to access gRPC API.
@@ -129,18 +132,14 @@ public class GoogleCloudStorageGrpcIntegrationTest {
 
   @Test
   public void testOpenWithTDEnabled() throws IOException {
-    String storageServicePath = System.getenv("GCS_TEST_STORAGE_SERVICE_PATH");
     String grpcServerAddress = System.getenv("GCS_TEST_GRPC_SERVER_ADDRESS");
-    String storageRootUrl = System.getenv("GCS_TEST_STORAGE_ROOT_URL");
-    System.err.println(
-        "Printing env vars " + storageServicePath + grpcServerAddress + storageRootUrl);
+    logger.atInfo().log("Printing env var for grpcServerAddress: " + grpcServerAddress);
+
     GoogleCloudStorageOptions.Builder optionsBuilder =
         GoogleCloudStorageTestHelper.getStandardOptionBuilder()
             .setGrpcEnabled(true)
             .setTrafficDirectorEnabled(true);
-    if (storageServicePath != null) optionsBuilder.setStorageServicePath(storageServicePath);
     if (grpcServerAddress != null) optionsBuilder.setGrpcServerAddress(grpcServerAddress);
-    if (storageRootUrl != null) optionsBuilder.setStorageRootUrl(storageRootUrl);
 
     GoogleCloudStorage rawStorage =
         new GoogleCloudStorageImpl(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -59,7 +59,7 @@ public class GoogleCloudStorageGrpcIntegrationTest {
   private static GoogleCloudStorageOptions.Builder configureDefaultOptions() {
     GoogleCloudStorageOptions.Builder optionsBuilder =
         GoogleCloudStorageTestHelper.getStandardOptionBuilder().setGrpcEnabled(true);
-    String grpcServerAddress = System.getenv("GRPC_SERVER_ADDRESS_OVERRIDE");
+    String grpcServerAddress = System.getenv("GCS_TEST_GRPC_SERVER_ADDRESS_OVERRIDE");
     if (grpcServerAddress != null) {
       optionsBuilder.setGrpcServerAddress(grpcServerAddress);
       logger.atInfo().log("Overriding gRPC server address to %s", grpcServerAddress);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -129,13 +129,22 @@ public class GoogleCloudStorageGrpcIntegrationTest {
 
   @Test
   public void testOpenWithTDEnabled() throws IOException {
-    GoogleCloudStorageOptions storageOptions =
+    String storageServicePath = System.getenv("GCS_TEST_STORAGE_SERVICE_PATH");
+    String grpcServerAddress = System.getenv("GCS_TEST_GRPC_SERVER_ADDRESS");
+    String storageRootUrl = System.getenv("GCS_TEST_STORAGE_ROOT_URL");
+    System.err.println(
+        "Printing env vars " + storageServicePath + grpcServerAddress + storageRootUrl);
+    GoogleCloudStorageOptions.Builder optionsBuilder =
         GoogleCloudStorageTestHelper.getStandardOptionBuilder()
             .setGrpcEnabled(true)
-            .setTrafficDirectorEnabled(true)
-            .build();
+            .setTrafficDirectorEnabled(true);
+    if (storageServicePath != null) optionsBuilder.setStorageServicePath(storageServicePath);
+    if (grpcServerAddress != null) optionsBuilder.setGrpcServerAddress(grpcServerAddress);
+    if (storageRootUrl != null) optionsBuilder.setStorageRootUrl(storageRootUrl);
+
     GoogleCloudStorage rawStorage =
-        new GoogleCloudStorageImpl(storageOptions, GoogleCloudStorageTestHelper.getCredentials());
+        new GoogleCloudStorageImpl(
+            optionsBuilder.build(), GoogleCloudStorageTestHelper.getCredentials());
     StorageResourceId objectToCreate =
         new StorageResourceId(BUCKET_NAME, "testOpen_Object_TD_Enabled");
     byte[] objectBytes = writeObject(rawStorage, objectToCreate, /* objectSize= */ 512);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -61,7 +61,7 @@ public class GoogleCloudStorageGrpcIntegrationTest {
         GoogleCloudStorageTestHelper.getStandardOptionBuilder()
             .setGrpcEnabled(true)
             .setTrafficDirectorEnabled(this.tdEnabled);
-    boolean runningTestsFromGCP = Boolean.parseBoolean(System.getenv("RUNNING_TESTS_FROM_GCP"));
+    boolean runningTestsFromGCP = Boolean.parseBoolean(System.getenv("RUNNING_TESTS_FROM_GCP_VM"));
     if (this.tdEnabled && runningTestsFromGCP) {
       optionsBuilder.setGrpcServerAddress("storage-force-dp.googleusercontent.com");
       logger.atInfo().log("Overriding gRPC server address to force-dp endpoint");


### PR DESCRIPTION
This is needed to test with "forced direct path" endpoint that would actually fail the GoogleCloudStorageGrpcIntegrationTest#testOpenWithTDEnabled test otherwise it may have used the fallback