### PR TITLE
Optimize write performance by avoiding a memcopy

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
@@ -1,6 +1,5 @@
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PIPE_BUFFER_SIZE_DEFAULT;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -358,16 +357,6 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     writeChannel.write(data.asReadOnlyByteBuffer());
 
     assertThrows(IOException.class, writeChannel::close);
-  }
-
-  @Test
-  public void writeHandlesErrorOnStartRequestFailure() throws Exception {
-    GoogleCloudStorageGrpcWriteChannel writeChannel = newWriteChannel();
-    fakeService.setStartRequestException(new IOException("Error"));
-    // test data has to be larger than PIPE_BUFFER_SIZE_DEFAULT in order to trigger a blocking call
-    ByteString data = createTestData(PIPE_BUFFER_SIZE_DEFAULT * 2);
-    writeChannel.initialize();
-    assertThrows(IOException.class, () -> writeChannel.write(data.asReadOnlyByteBuffer()));
   }
 
   @Test

--- a/util/src/main/java/com/google/cloud/hadoop/util/BaseAbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/BaseAbstractGoogleAsyncWriteChannel.java
@@ -196,7 +196,7 @@ public abstract class BaseAbstractGoogleAsyncWriteChannel<T> implements Writable
     }
   }
 
-  private void closeInternal() {
+  protected void closeInternal() {
     pipeSink = null;
     if (uploadOperation != null && !uploadOperation.isDone()) {
       uploadOperation.cancel(/* mayInterruptIfRunning= */ true);
@@ -242,7 +242,7 @@ public abstract class BaseAbstractGoogleAsyncWriteChannel<T> implements Writable
    *
    * @throws IOException on IO error
    */
-  private T waitForCompletionAndThrowIfUploadFailed() throws IOException {
+  protected T waitForCompletionAndThrowIfUploadFailed() throws IOException {
     try {
       return uploadOperation.get();
     } catch (InterruptedException e) {


### PR DESCRIPTION
This feature removes the Pipe based communication between upstream
thread and the upload thread which involved an additional memcopy.