### PR TITLE
Grpc read optimization to not prematurely close existing requests

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -308,7 +308,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   }
 
   private byte[] getFooterContent() throws IOException {
-    int footerSize =  Math.toIntExact(objectSize - footerStartOffsetInBytes);
+    int footerSize = Math.toIntExact(objectSize - footerStartOffsetInBytes);
     ByteBuffer buffer = ByteBuffer.allocate(footerSize);
 
     // snapshot these variables because readFromGCS clobbers them
@@ -358,8 +358,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   private int readBufferedContentInto(ByteBuffer byteBuffer) {
     // Handle skipping forward through the buffer for a seek.
     long bytesToSkip = positionForNextRead - positionInGrpcStream;
-    long bufferSkip =
-        min(bufferedContent.size() - bufferedContentReadOffset, bytesToSkip);
+    long bufferSkip = min(bufferedContent.size() - bufferedContentReadOffset, bytesToSkip);
     bufferSkip = max(0, bufferSkip);
     bufferedContentReadOffset += bufferSkip;
     positionInGrpcStream += bufferSkip;
@@ -435,7 +434,6 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       return bytesRead > 0 ? bytesRead : -1;
     }
 
-
     /* resIterator is null on the first read (position = 0) or when a seek is performed (and when
       there are exceptions). So if footerBuffer is null and we are trying to read into footer
       region, we may just cache the footer
@@ -443,8 +441,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     if ((resIterator == null)
         && (footerBuffer == null)
         && (positionForNextRead >= footerStartOffsetInBytes)) {
-      this.footerBuffer =
-          getFooterContent();
+      this.footerBuffer = getFooterContent();
     }
 
     if ((footerBuffer == null) || (positionForNextRead < footerStartOffsetInBytes)) {
@@ -735,11 +732,10 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     return this;
   }
 
-
   private void updateReadStrategy() {
     if (readStrategy == Fadvise.AUTO) {
-      if (positionForNextRead < positionInGrpcStream ||
-              positionForNextRead - positionInGrpcStream > readOptions.getInplaceSeekLimit()) {
+      if (positionForNextRead < positionInGrpcStream
+          || positionForNextRead - positionInGrpcStream > readOptions.getInplaceSeekLimit()) {
         readStrategy = Fadvise.RANDOM;
       }
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -105,10 +105,8 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   // Current position in the object.
   private long positionInGrpcStream;
 
-  // If a user seeks forwards by a configurably small amount, we continue reading from where
-  // we are instead of starting a new connection. The user's intended read position is
-  // position + bytesToSkipBeforeReading.
-  private long bytesToSkipBeforeReading;
+  // the position from which next read should happen
+  private long positionForNextRead;
 
   // The user may have read less data than we received from the server. If that's the case, we
   // keep
@@ -236,7 +234,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     StorageObject object;
     Sleeper sleeper = Sleeper.DEFAULT;
     BackOff backoff = backOffFactory.newBackOff();
-    IOException exception = null;
+    IOException exception;
     do {
       Stopwatch stopwatch = Stopwatch.createStarted();
       try {
@@ -309,21 +307,17 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     return getObject;
   }
 
-  private byte[] getFooterContent(long footerOffset, int footerSize) throws IOException {
+  private byte[] getFooterContent() throws IOException {
+    int footerSize =  Math.toIntExact(objectSize - footerStartOffsetInBytes);
     ByteBuffer buffer = ByteBuffer.allocate(footerSize);
 
     // snapshot these variables because readFromGCS clobbers them
-    long oldPositionInGrpcStream = this.positionInGrpcStream;
-    long oldBytesToSkipBeforeReading = bytesToSkipBeforeReading;
-    this.positionInGrpcStream = footerOffset;
-    this.bytesToSkipBeforeReading = 0;
-
+    long oldPositionForNextRead = positionForNextRead;
+    this.positionForNextRead = footerStartOffsetInBytes;
     readFromGCS(buffer, OptionalLong.empty());
 
     // restore the last know values of these variables
-    this.positionInGrpcStream = oldPositionInGrpcStream; // reset position to start
-    this.bytesToSkipBeforeReading = oldBytesToSkipBeforeReading;
-
+    this.positionForNextRead = oldPositionForNextRead; // reset position to start
     cancelCurrentRequest();
     return buffer.array();
   }
@@ -363,11 +357,11 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private int readBufferedContentInto(ByteBuffer byteBuffer) {
     // Handle skipping forward through the buffer for a seek.
+    long bytesToSkip = positionForNextRead - positionInGrpcStream;
     long bufferSkip =
-        min(bufferedContent.size() - bufferedContentReadOffset, bytesToSkipBeforeReading);
+        min(bufferedContent.size() - bufferedContentReadOffset, bytesToSkip);
     bufferSkip = max(0, bufferSkip);
     bufferedContentReadOffset += bufferSkip;
-    bytesToSkipBeforeReading -= bufferSkip;
     positionInGrpcStream += bufferSkip;
     int remainingBufferedBytes = bufferedContent.size() - bufferedContentReadOffset;
 
@@ -379,7 +373,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
             : remainingBufferedBytes;
     put(bufferedContent, bufferedContentReadOffset, bytesToWrite, byteBuffer);
     positionInGrpcStream += bytesToWrite;
-
+    positionForNextRead = positionInGrpcStream;
     if (remainingBufferedContentLargerThanByteBuffer) {
       bufferedContentReadOffset += bytesToWrite;
     } else {
@@ -387,6 +381,22 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     }
 
     return bytesToWrite;
+  }
+
+  private boolean canReadFromExistingRequest(ByteBuffer byteBuffer) {
+    if (resIterator == null) {
+      return false;
+    }
+
+    if (positionForNextRead < positionInGrpcStream) {
+      return false;
+    }
+
+    if (positionForNextRead - positionInGrpcStream > readOptions.getInplaceSeekLimit()) {
+      return false;
+    }
+
+    return isByteBufferWithinCurrentRequestRange(byteBuffer);
   }
 
   @Override
@@ -399,13 +409,14 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     if (!isOpen()) {
       throw new ClosedChannelException();
     }
-    int bytesRead = 0;
 
-    if (resIterator != null && isByteBufferBeyondCurrentRequestRange(byteBuffer)) {
-      positionInGrpcStream += bytesToSkipBeforeReading;
+    int bytesRead = 0;
+    updateReadStrategy();
+
+    if (!canReadFromExistingRequest(byteBuffer)) {
+      positionInGrpcStream = positionForNextRead;
       cancelCurrentRequest();
       invalidateBufferedContent();
-      bytesToSkipBeforeReading = 0;
     }
 
     // The server responds in 2MB chunks, but the client can ask for less than that. We
@@ -424,7 +435,6 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       return bytesRead > 0 ? bytesRead : -1;
     }
 
-    long effectivePosition = positionInGrpcStream + bytesToSkipBeforeReading;
 
     /* resIterator is null on the first read (position = 0) or when a seek is performed (and when
       there are exceptions). So if footerBuffer is null and we are trying to read into footer
@@ -432,13 +442,12 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     */
     if ((resIterator == null)
         && (footerBuffer == null)
-        && (effectivePosition >= footerStartOffsetInBytes)) {
+        && (positionForNextRead >= footerStartOffsetInBytes)) {
       this.footerBuffer =
-          getFooterContent(
-              footerStartOffsetInBytes, Math.toIntExact(objectSize - footerStartOffsetInBytes));
+          getFooterContent();
     }
 
-    if ((footerBuffer == null) || (effectivePosition < footerStartOffsetInBytes)) {
+    if ((footerBuffer == null) || (positionForNextRead < footerStartOffsetInBytes)) {
       OptionalLong bytesToRead = getBytesToRead(byteBuffer);
       bytesRead += readFromGCS(byteBuffer, bytesToRead);
       logger.atFinest().log(
@@ -471,8 +480,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       Stopwatch stopwatch = Stopwatch.createStarted();
       try {
         if (resIterator == null) {
-          positionInGrpcStream += bytesToSkipBeforeReading;
-          bytesToSkipBeforeReading = 0;
+          positionInGrpcStream = positionForNextRead;
           resIterator =
               requestObjectMedia(
                   resourceId.getObjectName(), objectGeneration, positionInGrpcStream, bytesToRead);
@@ -494,13 +502,12 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     throw convertError(statusRuntimeException, resourceId);
   }
 
-  private boolean isByteBufferBeyondCurrentRequestRange(ByteBuffer byteBuffer) {
-    long effectivePosition = positionInGrpcStream + bytesToSkipBeforeReading;
+  private boolean isByteBufferWithinCurrentRequestRange(ByteBuffer byteBuffer) {
     // current request does not have a range or this is the first request
     if (contentChannelEndOffset == -1) {
-      return false;
+      return true;
     }
-    return (effectivePosition + byteBuffer.remaining()) > (contentChannelEndOffset);
+    return ((positionForNextRead + byteBuffer.remaining()) <= contentChannelEndOffset);
   }
 
   private int readObjectContentFromGCS(ByteBuffer byteBuffer) throws IOException {
@@ -513,13 +520,13 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     InputStream stream = getObjectMediaResponseMarshaller.popStream(res);
     try {
       ByteString content = res.getChecksummedData().getContent();
-      if (bytesToSkipBeforeReading >= 0 && bytesToSkipBeforeReading < content.size()) {
-        content = content.substring((int) bytesToSkipBeforeReading);
-        positionInGrpcStream += bytesToSkipBeforeReading;
-        bytesToSkipBeforeReading = 0;
-      } else if (bytesToSkipBeforeReading >= content.size()) {
+      int skipBytes = Math.toIntExact(positionForNextRead - positionInGrpcStream);
+      if (skipBytes >= 0 && skipBytes < content.size()) {
+        content = content.substring(skipBytes);
+        positionInGrpcStream = positionForNextRead;
+      } else if (skipBytes >= content.size()) {
         positionInGrpcStream += content.size();
-        bytesToSkipBeforeReading -= content.size();
+        positionForNextRead = positionInGrpcStream;
         return bytesRead;
       }
 
@@ -533,7 +540,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       put(content, 0, bytesToWrite, byteBuffer);
       bytesRead += bytesToWrite;
       positionInGrpcStream += bytesToWrite;
-
+      positionForNextRead = positionInGrpcStream;
       if (responseSizeLargerThanRemainingBuffer) {
         invalidateBufferedContent();
         bufferedContent = content;
@@ -565,7 +572,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
 
   private boolean hasMoreFooterContentToRead(ByteBuffer byteBuffer) {
     return footerBuffer != null
-        && (positionInGrpcStream + bytesToSkipBeforeReading) >= footerStartOffsetInBytes
+        && (positionForNextRead) >= footerStartOffsetInBytes
         && byteBuffer.hasRemaining();
   }
 
@@ -589,13 +596,12 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   }
 
   private int readFooterContentIntoBuffer(ByteBuffer byteBuffer) {
-    positionInGrpcStream += bytesToSkipBeforeReading;
-    bytesToSkipBeforeReading = 0;
-    int bytesToSkipFromFooter = Math.toIntExact(positionInGrpcStream - footerStartOffsetInBytes);
+    int bytesToSkipFromFooter = Math.toIntExact(positionForNextRead - footerStartOffsetInBytes);
     int bytesToWriteFromFooter = footerBuffer.length - bytesToSkipFromFooter;
     int bytesToWrite = Math.toIntExact(min(byteBuffer.remaining(), bytesToWriteFromFooter));
     byteBuffer.put(footerBuffer, bytesToSkipFromFooter, bytesToWrite);
-    positionInGrpcStream += bytesToWrite;
+    positionInGrpcStream = positionForNextRead + bytesToWrite;
+    positionForNextRead = positionInGrpcStream;
     return bytesToWrite;
   }
 
@@ -710,7 +716,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
     }
     // Our real position is tracked in "positionInGrpcStream," but if the user is skipping
     // forwards a bit, we pretend we're at the new position already.
-    return positionInGrpcStream + bytesToSkipBeforeReading;
+    return positionForNextRead;
   }
 
   @Override
@@ -725,29 +731,17 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
         "Read position must be before end of file (%s), but was %s",
         size(),
         newPosition);
-    if (newPosition == positionInGrpcStream) {
-      return this;
-    }
+    positionForNextRead = newPosition;
+    return this;
+  }
 
-    long seekDistance = newPosition - positionInGrpcStream;
-
-    if (seekDistance >= 0 && seekDistance <= readOptions.getInplaceSeekLimit()) {
-      bytesToSkipBeforeReading = seekDistance;
-      return this;
-    }
-
+  private void updateReadStrategy() {
     if (readStrategy == Fadvise.AUTO) {
-      if (seekDistance < 0 || seekDistance > readOptions.getInplaceSeekLimit()) {
+      if (positionForNextRead < positionInGrpcStream ||
+              positionForNextRead - positionInGrpcStream > readOptions.getInplaceSeekLimit()) {
         readStrategy = Fadvise.RANDOM;
       }
     }
-
-    // Reset any ongoing read operations or local data caches.
-    cancelCurrentRequest();
-    invalidateBufferedContent();
-
-    positionInGrpcStream = newPosition;
-    return this;
   }
 
   @Override

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -1305,6 +1305,52 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   }
 
   @Test
+  public void testReadWithMultipleSeeks() throws Exception {
+    int objectSize = 16 * 1024;
+    fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
+    storageObject.setSize(BigInteger.valueOf(objectSize));
+    verify(fakeService, times(1)).setObject(any());
+    int minRangeRequestSize = 4 * 1024;
+    int inplaceSeekLimit = 6 * 1024;
+    GoogleCloudStorageReadOptions options =
+            GoogleCloudStorageReadOptions.builder()
+                    .setMinRangeRequestSize(minRangeRequestSize)
+                    .setFadvise(Fadvise.AUTO)
+                    .setInplaceSeekLimit(inplaceSeekLimit)
+                    .build();
+    GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
+    ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
+    readChannel.read(buffer);
+
+    verify(get).setFields(METADATA_FIELDS);
+    verify(get).execute();
+
+    verify(fakeService, times(1))
+            .readObject(
+                    eq(
+                            ReadObjectRequest.newBuilder()
+                                    .setBucket(BUCKET_NAME)
+                                    .setObject(OBJECT_NAME)
+                                    .setGeneration(OBJECT_GENERATION)
+                                    .build()),
+                    any());
+
+    buffer.clear();
+    readChannel.position(0);
+    int readOffset = 7 * 1024;
+    readChannel.position(readOffset);
+    int capacity = 4 * 1024;
+    buffer = ByteBuffer.allocate(capacity);
+    readChannel.read(buffer);
+
+    assertArrayEquals(
+            fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
+            buffer.array());
+
+    verifyNoMoreInteractions(fakeService);
+  }
+
+  @Test
   public void seekFailsOnNegative() throws Exception {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -1313,11 +1313,11 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     int minRangeRequestSize = 4 * 1024;
     int inplaceSeekLimit = 6 * 1024;
     GoogleCloudStorageReadOptions options =
-            GoogleCloudStorageReadOptions.builder()
-                    .setMinRangeRequestSize(minRangeRequestSize)
-                    .setFadvise(Fadvise.AUTO)
-                    .setInplaceSeekLimit(inplaceSeekLimit)
-                    .build();
+        GoogleCloudStorageReadOptions.builder()
+            .setMinRangeRequestSize(minRangeRequestSize)
+            .setFadvise(Fadvise.AUTO)
+            .setInplaceSeekLimit(inplaceSeekLimit)
+            .build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
@@ -1326,14 +1326,14 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     verify(get).execute();
 
     verify(fakeService, times(1))
-            .readObject(
-                    eq(
-                            ReadObjectRequest.newBuilder()
-                                    .setBucket(BUCKET_NAME)
-                                    .setObject(OBJECT_NAME)
-                                    .setGeneration(OBJECT_GENERATION)
-                                    .build()),
-                    any());
+        .readObject(
+            eq(
+                ReadObjectRequest.newBuilder()
+                    .setBucket(BUCKET_NAME)
+                    .setObject(OBJECT_NAME)
+                    .setGeneration(OBJECT_GENERATION)
+                    .build()),
+            any());
 
     buffer.clear();
     readChannel.position(0);
@@ -1344,8 +1344,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.read(buffer);
 
     assertArrayEquals(
-            fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
-            buffer.array());
+        fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
+        buffer.array());
 
     verifyNoMoreInteractions(fakeService);
   }


### PR DESCRIPTION
Hadoop FsDataInputStream exposes read APIs which will call seek back to original position after the read. Generally they are followed by another seek before actual read happens. We should only close the requests when we are actually reading rather than on seeks.