### PR TITLE
Always set the GoogleCredential JWT audience to the Google Cloud OAuth2 Token Server

### DIFF
--- a/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/CredentialFactory.java
@@ -103,6 +103,9 @@ public class CredentialFactory {
 
     private static final int DEFAULT_TOKEN_EXPIRATION_SECONDS = 3600;
 
+    private static final String GOOGLE_OAUTH2_TOKEN_AUDIENCE =
+        "https://oauth2.googleapis.com/token";
+
     private static final Joiner WHITESPACE_JOINER = Joiner.on(' ');
 
     /** Create a new GoogleCredentialWithRetry from a GoogleCredential. */
@@ -149,7 +152,7 @@ public class CredentialFactory {
       JsonWebToken.Payload payload =
           new JsonWebToken.Payload()
               .setIssuer(getServiceAccountId())
-              .setAudience(getTokenServerEncodedUrl())
+              .setAudience(GOOGLE_OAUTH2_TOKEN_AUDIENCE)
               .setIssuedAtTimeSeconds(currentTime / 1000)
               .setExpirationTimeSeconds(currentTime / 1000 + DEFAULT_TOKEN_EXPIRATION_SECONDS)
               .setSubject(getServiceAccountUser());


### PR DESCRIPTION
Ensure that we don't set the audience to the token server URI when the URI is overridden, such as when proxying the requests or using private service connect. This behavior causes requests to be rejected with the error:
```
400 Bad Request
POST
{
  "error" : "invalid_grant",
  "error_description" : "Invalid JWT: Failed audience check."
}
```

This corresponds to the this pull request in the [google-auth-java](https://github.com/googleapis/google-auth-library-java/pull/833) library.

Note that this is not required for 3.x branches which use [google-auth-java](https://github.com/googleapis/google-auth-library-java).