### PR TITLE
Clean up fail fast on not found logic

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
@@ -109,7 +109,11 @@ public class GoogleHadoopFileSystemNewIntegrationTest {
     CompletableFuture<FSDataInputStream> isFuture = ghfs.openFile(filePath).build();
 
     assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(getRequestString(testBucketName, name.getMethodName()));
+        .containsExactly(
+            getRequestString(
+                testBucketName,
+                name.getMethodName(),
+                /* fields= */ "contentEncoding,generation,size"));
 
     String fileContent;
     try (FSDataInputStream is = isFuture.get()) {
@@ -119,7 +123,10 @@ public class GoogleHadoopFileSystemNewIntegrationTest {
     assertThat(fileContent).isEqualTo(expectedContent);
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
-            getRequestString(testBucketName, name.getMethodName()),
+            getRequestString(
+                testBucketName,
+                name.getMethodName(),
+                /* fields= */ "contentEncoding,generation,size"),
             getMediaRequestString(
                 testBucketName, name.getMethodName(), itemInfo.getContentGeneration()))
         .inOrder();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -716,14 +716,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     checkArgument(
         resourceId.isStorageObject(), "Expected full StorageObject id, got %s", resourceId);
 
-    // The underlying channel doesn't initially read data, which means that we won't see a
-    // FileNotFoundException until read is called. As a result, in order to find out if the
-    // object exists, we'll need to do an RPC (metadata or data). A metadata check should be a less
-    // expensive operation than a read data operation.
-    GoogleCloudStorageItemInfo itemInfo =
-        readOptions.isFastFailOnNotFoundEnabled() ? getItemInfo(resourceId) : null;
-
-    return open(resourceId, itemInfo, readOptions);
+    return open(resourceId, /* itemInfo= */ null, readOptions);
   }
 
   /**
@@ -752,25 +745,16 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       throw createFileNotFoundException(
           resourceId.getBucketName(), resourceId.getObjectName(), /* cause= */ null);
     }
+
     if (storageOptions.isGrpcEnabled()) {
-      return itemInfo == null
-          ? new GoogleCloudStorageGrpcReadChannel(
-              storageStubProvider,
-              storage,
-              resourceId,
-              watchdog,
-              metricsRecorder,
-              readOptions,
-              BackOffFactory.DEFAULT,
-              this.storageOptions)
-          : new GoogleCloudStorageGrpcReadChannel(
-              storageStubProvider,
-              itemInfo,
-              watchdog,
-              metricsRecorder,
-              readOptions,
-              BackOffFactory.DEFAULT,
-              this.storageOptions);
+      return new GoogleCloudStorageGrpcReadChannel(
+          storageStubProvider,
+          itemInfo == null ? getItemInfo(resourceId) : itemInfo,
+          watchdog,
+          metricsRecorder,
+          storageOptions,
+          readOptions,
+          BackOffFactory.DEFAULT);
     }
 
     return new GoogleCloudStorageReadChannel(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -483,7 +483,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
    * and a new connection will be needed. Especially SSLExceptions since the there's a high
    * probability that SSL connections would be broken in a way that causes {@link Channel#close()}
    * itself to throw an exception, even though underlying sockets have already been cleaned up;
-   * close() on an SSLSocketImpl requires a shutdown handshake in order to shutdown cleanly, and if
+   * close() on an SSLSocketImpl requires a shutdown handshake in order to shut down cleanly, and if
    * the connection has been broken already, then this is not possible, and the SSLSocketImpl was
    * already responsible for performing local cleanup at the time the exception was raised.
    */
@@ -861,7 +861,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
    * Opens the underlying stream, sets its position to the {@link #currentPosition}.
    *
    * <p>If the file encoding in GCS is gzip (and therefore the HTTP client will decompress it), the
-   * entire file is always requested and we seek to the position requested. If the file encoding is
+   * entire file is always requested, and we seek to the position requested. If the file encoding is
    * not gzip, only the remaining bytes to be read are requested from GCS.
    *
    * @param bytesToRead number of bytes to read from new stream. Ignored if {@link
@@ -946,8 +946,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     } catch (IOException e) {
       if (!metadataInitialized && errorExtractor.rangeNotSatisfiable(e) && currentPosition == 0) {
         // We don't know the size yet (metadataInitialized == false) and we're seeking to
-        // byte 0,
-        // but got 'range not satisfiable'; the object must be empty.
+        // byte 0, but got 'range not satisfiable'; the object must be empty.
         logger.atInfo().log(
             "Got 'range not satisfiable' for reading '%s' at position 0; assuming empty.",
             resourceId);
@@ -966,11 +965,9 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         return new ByteArrayInputStream(new byte[0]);
       }
       if (gzipEncoded) {
-        // Initialize `contentChannelEnd` to `size` (initialized to Long.MAX_VALUE in
-        // `initMetadata`
-        // method for gzipped objetcs) because value of HTTP Content-Length header is
-        // usually
-        // smaller than decompressed object size.
+        // Initialize `contentChannelEnd` to `size` (initialized to Long.MAX_VALUE
+        // in `initMetadata` method for gzipped objects) because value of HTTP Content-Length
+        // header is usually smaller than decompressed object size.
         if (currentPosition == 0) {
           contentChannelEnd = size;
         } else {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -44,7 +44,7 @@ public abstract class GoogleCloudStorageReadOptions {
   public static final long DEFAULT_INPLACE_SEEK_LIMIT = 8 * 1024 * 1024;
   public static final Fadvise DEFAULT_FADVISE = Fadvise.SEQUENTIAL;
   public static final long DEFAULT_MIN_RANGE_REQUEST_SIZE = 2 * 1024 * 1024;
-  public static final boolean GRPC_CHECKSUMS_ENABLED_DEFAULT = false;
+  public static final boolean DEFAULT_GRPC_CHECKSUMS_ENABLED = false;
   public static final long DEFAULT_GRPC_READ_TIMEOUT_MILLIS = 20 * 60 * 1000;
   public static final long DEFAULT_GRPC_READ_METADATA_TIMEOUT_MILLIS = 60 * 1000;
   public static final boolean DEFAULT_GRPC_READ_ZEROCOPY_ENABLED = true;
@@ -66,7 +66,7 @@ public abstract class GoogleCloudStorageReadOptions {
         .setInplaceSeekLimit(DEFAULT_INPLACE_SEEK_LIMIT)
         .setFadvise(DEFAULT_FADVISE)
         .setMinRangeRequestSize(DEFAULT_MIN_RANGE_REQUEST_SIZE)
-        .setGrpcChecksumsEnabled(GRPC_CHECKSUMS_ENABLED_DEFAULT)
+        .setGrpcChecksumsEnabled(DEFAULT_GRPC_CHECKSUMS_ENABLED)
         .setGrpcReadTimeoutMillis(DEFAULT_GRPC_READ_TIMEOUT_MILLIS)
         .setGrpcReadMetadataTimeoutMillis(DEFAULT_GRPC_READ_METADATA_TIMEOUT_MILLIS)
         .setGrpcReadZeroCopyEnabled(DEFAULT_GRPC_READ_ZEROCOPY_ENABLED)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -831,9 +831,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void firstReadBeyondInPlaceSeekLimit() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int inplaceSeekLimit = 10;
     GoogleCloudStorageReadOptions options =
@@ -848,8 +847,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.position(inplaceSeekLimit * 2);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(
             eq(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -14,40 +14,19 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcReadChannel.METADATA_FIELDS;
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageTest.newStorageObject;
-import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.jsonDataResponse;
-import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.jsonErrorResponse;
-import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.mockTransport;
 import static com.google.common.truth.Truth.assertThat;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.json.gson.GsonFactory;
-import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.util.BackOff;
-import com.google.api.services.storage.Storage;
-import com.google.api.services.storage.Storage.Objects;
-import com.google.api.services.storage.Storage.Objects.Get;
-import com.google.api.services.storage.model.StorageObject;
-import com.google.auth.Credentials;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
-import com.google.cloud.hadoop.util.ApiErrorExtractor;
-import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.ByteString;
 import com.google.storage.v2.ChecksummedData;
@@ -68,12 +47,9 @@ import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import java.io.EOFException;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Before;
@@ -82,8 +58,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 @RunWith(JUnit4.class)
 public final class GoogleCloudStorageGrpcReadChannelTest {
@@ -113,18 +87,14 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
   private StorageBlockingStub stub;
   private FakeService fakeService;
-  @Mock private Credentials mockCredentials;
-  private Storage storage;
-  private ApiErrorExtractor errorExtractor;
-  private Get get;
-  private StorageObject storageObject;
   private static final Watchdog watchdog = Watchdog.create(Duration.ofMillis(100));
+  private long objectSize;
   private TestServerHeaderInterceptor headerInterceptor;
 
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
     fakeService = spy(new FakeService());
+    objectSize = OBJECT_SIZE;
     String serverName = InProcessServerBuilder.generateName();
     headerInterceptor = new TestServerHeaderInterceptor();
     grpcCleanup.register(
@@ -138,25 +108,12 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
         StorageGrpc.newBlockingStub(
             grpcCleanup.register(
                 InProcessChannelBuilder.forName(serverName).directExecutor().build()));
-    storage = mock(Storage.class);
-    get = mock(Get.class);
-    Objects objects = mock(Objects.class);
-    when(storage.objects()).thenReturn(objects);
-    when(objects.get(V1_BUCKET_NAME, OBJECT_NAME)).thenReturn(get);
-    storageObject = new StorageObject();
-    storageObject.setBucket(V1_BUCKET_NAME);
-    storageObject.setGeneration(OBJECT_GENERATION);
-    storageObject.setSize(BigInteger.valueOf(OBJECT_SIZE));
-    when(get.setFields(any())).thenCallRealMethod();
-    when(get.execute()).thenReturn(storageObject);
-    errorExtractor = ApiErrorExtractor.INSTANCE;
   }
 
   @Test
   public void readSingleChunkSucceeds() throws Exception {
-    int objectSize = FakeService.CHUNK_SIZE;
+    objectSize = FakeService.CHUNK_SIZE;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(4).build();
@@ -165,8 +122,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(100);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -176,7 +131,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setGeneration(OBJECT_GENERATION)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(0, 100).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(0, 100).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -185,19 +140,16 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   @Test
   public void readMultipleChunksSucceeds() throws Exception {
     // Enough to require multiple chunks.
-    int objectSize = FakeService.CHUNK_SIZE * 2;
+    objectSize = FakeService.CHUNK_SIZE * 2;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(4).build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
 
-    ByteBuffer buffer = ByteBuffer.allocate(objectSize);
+    ByteBuffer buffer = ByteBuffer.allocate(toIntExact(objectSize));
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -207,7 +159,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setGeneration(OBJECT_GENERATION)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(0, objectSize).toByteArray(), buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(0, toIntExact(objectSize)).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -215,8 +168,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void readAfterRepositioningAfterSkippingSucceeds() throws Exception {
-    int objectSize = toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10);
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
@@ -235,9 +187,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.position(1);
     readChannel.read(bufferFromReposition);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
-    assertArrayEquals(fakeService.data.substring(0, 20).toByteArray(), bufferAtBeginning.array());
+    assertThat(bufferAtBeginning.array())
+        .isEqualTo(fakeService.data.substring(0, 20).toByteArray());
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -257,12 +208,12 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setReadOffset(1)
                     .build()),
             any());
-    assertArrayEquals(
-        fakeService.data.substring(25, 30).toByteArray(), bufferFromSkippedSection1.array());
-    assertArrayEquals(
-        fakeService.data.substring(35, 45).toByteArray(), bufferFromSkippedSection2.array());
-    assertArrayEquals(
-        fakeService.data.substring(1, 11).toByteArray(), bufferFromReposition.array());
+    assertThat(bufferFromSkippedSection1.array())
+        .isEqualTo(fakeService.data.substring(25, 30).toByteArray());
+    assertThat(bufferFromSkippedSection2.array())
+        .isEqualTo(fakeService.data.substring(35, 45).toByteArray());
+    assertThat(bufferFromReposition.array())
+        .isEqualTo(fakeService.data.substring(1, 11).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
@@ -270,8 +221,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void multipleSequentialReads() throws Exception {
-    int objectSize = toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10);
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
@@ -283,10 +233,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.read(first_buffer);
     readChannel.read(second_buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
-    assertArrayEquals(fakeService.data.substring(0, 10).toByteArray(), first_buffer.array());
-    assertArrayEquals(fakeService.data.substring(10, 30).toByteArray(), second_buffer.array());
+    assertThat(first_buffer.array()).isEqualTo(fakeService.data.substring(0, 10).toByteArray());
+    assertThat(second_buffer.array()).isEqualTo(fakeService.data.substring(10, 30).toByteArray());
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -303,8 +251,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void randomReadRequestsExactBytes() throws Exception {
-    int objectSize = toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10);
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
@@ -319,8 +266,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.position(10);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     ReadObjectRequest expectedRequest =
         ReadObjectRequest.newBuilder()
             .setBucket(BUCKET_NAME)
@@ -330,7 +275,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
             .setReadOffset(10)
             .build();
     verify(fakeService, times(1)).readObject(eq(expectedRequest), any());
-    assertArrayEquals(fakeService.data.substring(10, 60).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(10, 60).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -338,8 +283,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void repeatedRandomReadsWorkAsExpected() throws Exception {
-    int objectSize = toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10);
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
@@ -353,12 +297,12 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(50);
     readChannel.position(10);
     readChannel.read(buffer);
-    assertArrayEquals(fakeService.data.substring(10, 60).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(10, 60).toByteArray());
 
     buffer = ByteBuffer.allocate(25);
     readChannel.position(20);
     readChannel.read(buffer);
-    assertArrayEquals(fakeService.data.substring(20, 45).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(20, 45).toByteArray());
 
     ReadObjectRequest firstExpectedRequest =
         ReadObjectRequest.newBuilder()
@@ -377,8 +321,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
             .setReadOffset(20)
             .build();
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1)).readObject(eq(firstExpectedRequest), any());
     verify(fakeService, times(1)).readObject(eq(secondExpectedRequest), any());
     verifyNoMoreInteractions(fakeService);
@@ -388,8 +330,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void randomReadRequestsExpectedBytes() throws Exception {
-    int objectSize = toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10);
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE * 10;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
@@ -404,14 +345,20 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(50);
     readChannel.position(10);
     readChannel.read(buffer);
-    assertArrayEquals(fakeService.data.substring(10, 60).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(10, 60).toByteArray());
 
     // Request bytes larger than minimum request size.
     int bufferSize = toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE + 1);
     buffer = ByteBuffer.allocate(bufferSize);
     readChannel.position(0);
     readChannel.read(buffer);
-    assertArrayEquals(fakeService.data.substring(0, bufferSize).toByteArray(), buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(
+            fakeService
+                .data
+                .substring(
+                    0, toIntExact(GoogleCloudStorageReadOptions.DEFAULT_MIN_RANGE_REQUEST_SIZE + 1))
+                .toByteArray());
 
     ReadObjectRequest firstExpectedRequest =
         ReadObjectRequest.newBuilder()
@@ -430,9 +377,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
             .setReadOffset(0)
             .build();
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
-
     verify(fakeService, times(1)).readObject(eq(firstExpectedRequest), any());
     verify(fakeService, times(1)).readObject(eq(secondExpectedRequest), any());
     verifyNoMoreInteractions(fakeService);
@@ -442,9 +386,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void readToBufferWithArrayOffset() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(4).build();
@@ -455,9 +398,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.wrap(array, 50, 150).slice();
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
-    byte[] expected = ByteString.copyFrom(array, 50, objectSize).toByteArray();
+    byte[] expected = ByteString.copyFrom(array, 50, toIntExact(objectSize)).toByteArray();
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -467,7 +408,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setGeneration(OBJECT_GENERATION)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(0, objectSize).toByteArray(), expected);
+    assertThat(fakeService.data.substring(0, toIntExact(objectSize)).toByteArray())
+        .isEqualTo(expected);
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -475,9 +417,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void readSucceedsAfterSeek() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder()
@@ -490,11 +431,9 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.position(50);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(eq(GET_OBJECT_MEDIA_REQUEST.toBuilder().setReadOffset(50).build()), any());
-    assertArrayEquals(fakeService.data.substring(50, 60).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(50, 60).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -513,7 +452,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(OBJECT_SIZE);
     readChannel.read(buffer);
 
-    assertArrayEquals(fakeService.data.toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.toByteArray());
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
   }
@@ -531,8 +470,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(OBJECT_SIZE - 10);
     readChannel.read(buffer);
 
-    assertArrayEquals(
-        fakeService.data.substring(0, OBJECT_SIZE - 10).toByteArray(), buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(0, OBJECT_SIZE - 10).toByteArray());
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
   }
@@ -552,8 +491,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.read(firstBuffer);
     readChannel.read(secondBuffer);
 
-    assertArrayEquals(fakeService.data.substring(0, 100).toByteArray(), firstBuffer.array());
-    assertArrayEquals(fakeService.data.substring(100).toByteArray(), secondBuffer.array());
+    assertThat(firstBuffer.array()).isEqualTo(fakeService.data.substring(0, 100).toByteArray());
+    assertThat(secondBuffer.array()).isEqualTo(fakeService.data.substring(100).toByteArray());
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
   }
@@ -585,7 +524,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.read(buffer);
 
     byte[] expected = ByteString.copyFrom(array, 50, OBJECT_SIZE).toByteArray();
-    assertArrayEquals(fakeService.data.toByteArray(), expected);
+    assertThat(fakeService.data.toByteArray()).isEqualTo(expected);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
   }
@@ -599,9 +538,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(10);
 
     IOException thrown = assertThrows(IOException.class, () -> readChannel.read(buffer));
-    assertTrue(
-        thrown.getMessage() + " should have contained 'checksum'",
-        thrown.getMessage().contains("checksum"));
+    assertThat(thrown).hasMessageThat().contains("checksum");
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
   }
@@ -621,45 +558,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.read(firstBuffer);
     readChannel.read(secondBuffer);
 
-    assertArrayEquals(fakeService.data.substring(0, 100).toByteArray(), firstBuffer.array());
-    assertArrayEquals(fakeService.data.substring(100).toByteArray(), secondBuffer.array());
-
-    headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
-  }
-
-  @Test
-  public void testOpenReadsMetadata() throws IOException {
-    int objectSize = 8 * 1024;
-    fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
-    GoogleCloudStorageReadOptions options = GoogleCloudStorageReadOptions.builder().build();
-    StorageResourceId storageResourceId =
-        new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME, OBJECT_GENERATION);
-    GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(storageResourceId, options);
-
-    assertTrue(readChannel.isOpen());
-    assertEquals(objectSize, readChannel.size());
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
-
-    headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 0);
-  }
-
-  @Test
-  public void testOpenThrowsIOExceptionOnGetError() throws IOException {
-    MockHttpTransport transport = mockTransport(jsonErrorResponse(ErrorResponses.SERVER_ERROR));
-
-    List<HttpRequest> requests = new ArrayList<>();
-
-    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
-
-    GoogleCloudStorageReadOptions options =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
-
-    IOException thrown = assertThrows(IOException.class, () -> newReadChannel(storage, options));
-    assertThat(thrown).hasCauseThat().hasMessageThat().contains("backendError");
-
-    headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 0);
+    assertThat(firstBuffer.array()).isEqualTo(fakeService.data.substring(0, 100).toByteArray());
+    assertThat(secondBuffer.array()).isEqualTo(fakeService.data.substring(100).toByteArray());
   }
 
   @Test
@@ -686,8 +586,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(10);
     IOException thrown = assertThrows(IOException.class, () -> readChannel.read(buffer));
     assertThat(thrown).hasCauseThat().hasMessageThat().contains("Custom error message.");
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService).readObject(any(), any());
     verifyNoMoreInteractions(fakeService);
 
@@ -707,27 +605,35 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
         .hasCauseThat()
         .hasMessageThat()
         .contains("Custom error message.");
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService).readObject(any(), any());
     verifyNoMoreInteractions(fakeService);
   }
 
   @Test
-  public void testOpenThrowsIOExceptionOnGzipContent() throws Exception {
-    MockHttpTransport transport =
-        mockTransport(
-            jsonDataResponse(
-                newStorageObject(BUCKET_NAME, OBJECT_NAME).setContentEncoding("gzip")));
+  public void testOpenThrowsIOExceptionOnGzipContent() {
+    GoogleCloudStorageItemInfo itemInfo =
+        GoogleCloudStorageItemInfo.createObject(
+            new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME),
+            /* creationTime= */ 10L,
+            /* modificationTime= */ 15L,
+            /* size= */ objectSize,
+            /* contentType= */ "text/plain",
+            /* contentEncoding= */ "gzip",
+            /* metadata= */ null,
+            /* contentGeneration= */ OBJECT_GENERATION,
+            /* metaGeneration= */ 2L,
+            /* verificationAttributes= */ null);
 
-    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), r -> {});
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () -> newReadChannel(itemInfo, GoogleCloudStorageReadOptions.DEFAULT));
 
-    GoogleCloudStorageReadOptions readOptions = GoogleCloudStorageReadOptions.builder().build();
-
-    IOException e = assertThrows(IOException.class, () -> newReadChannel(storage, readOptions));
     assertThat(e)
         .hasMessageThat()
-        .isEqualTo("Cannot read GZIP encoded files - content encoding support is disabled.");
+        .isEqualTo(
+            "Cannot read GZIP-encoded file (gzip) (not supported via gRPC API): "
+                + itemInfo.getResourceId());
   }
 
   @Test
@@ -756,8 +662,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void readWithStrictGenerationReadConsistencySucceeds() throws Exception {
-    int objectSize = 100;
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).setGeneration(1).build());
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(4).build();
@@ -772,8 +677,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
     ArgumentCaptor<ReadObjectRequest> requestCaptor =
         ArgumentCaptor.forClass(ReadObjectRequest.class);
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(2)).readObject(requestCaptor.capture(), any());
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
@@ -781,9 +684,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void readWithLatestGenerationReadConsistencySucceeds() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).setGeneration(1).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(4).build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
@@ -797,8 +699,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
     ArgumentCaptor<ReadObjectRequest> requestCaptor =
         ArgumentCaptor.forClass(ReadObjectRequest.class);
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(2)).readObject(requestCaptor.capture(), any());
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
@@ -806,9 +706,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void seekUnderInplaceSeekLimitReadsCorrectBufferedData() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 10;
     GoogleCloudStorageReadOptions options =
@@ -824,8 +723,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     buffer.clear();
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -835,7 +732,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setGeneration(OBJECT_GENERATION)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(25, 45).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(25, 45).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -843,9 +740,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void consecutiveSeekBackToSamePosition() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
 
     int minRangeRequestSize = 10;
@@ -855,13 +751,13 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
             .setInplaceSeekLimit(10)
             .build();
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
-    assertEquals(readChannel.position(), 0);
+    assertThat(readChannel.position()).isEqualTo(0);
 
     readChannel.position(5);
-    assertEquals(readChannel.position(), 5);
+    assertThat(readChannel.position()).isEqualTo(5);
 
     readChannel.position(0);
-    assertEquals(readChannel.position(), 0);
+    assertThat(readChannel.position()).isEqualTo(0);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 0);
   }
@@ -880,18 +776,17 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     buffer = ByteBuffer.allocate(FakeService.CHUNK_SIZE * 3 + 7);
     readChannel.read(buffer);
 
-    assertArrayEquals(
-        fakeService.data.substring(50, 50 + FakeService.CHUNK_SIZE * 3 + 7).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(
+            fakeService.data.substring(50, 50 + FakeService.CHUNK_SIZE * 3 + 7).toByteArray());
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
   }
 
   @Test
   public void seekBeyondInplaceSeekLimitReadsNoBufferedData() throws Exception {
-    int objectSize = 100;
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 10;
     GoogleCloudStorageReadOptions options =
@@ -908,8 +803,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     buffer.clear();
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -930,7 +823,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setReadLimit(20)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(35, 55).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(35, 55).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
@@ -975,8 +868,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testFooterSizeBiggerThanContent() throws Exception {
-    int objectSize = 100;
-    storageObject.setSize(BigInteger.valueOf(objectSize));
+    objectSize = 100;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 2 * 1024;
@@ -987,8 +879,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     readChannel.position(80);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     /* footerSize is bigger than object size, only the content is read */
     verify(fakeService, times(1))
         .readObject(
@@ -999,7 +889,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setGeneration(OBJECT_GENERATION)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(80).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(80).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
@@ -1007,9 +897,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadCachedFooter() throws Exception {
-    int objectSize = 8 * 1024;
+    objectSize = 8 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     // verify data setup on mock to ensure this interaction does not conflict with `verify`calls
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 2 * 1024;
@@ -1021,9 +910,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(1024);
     readChannel.read(buffer);
-
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
 
     int footerOffset = 7 * 1024;
     buffer.clear();
@@ -1050,14 +936,14 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .build()),
             any());
 
-    assertArrayEquals(fakeService.data.substring(footerOffset).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(footerOffset).toByteArray());
 
     // reading the footer twice to ensure there are no additional calls to GCS
     buffer.clear();
     readChannel.position(footerOffset);
     readChannel.read(buffer);
 
-    assertArrayEquals(fakeService.data.substring(footerOffset).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(footerOffset).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
@@ -1065,9 +951,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadCachedFooterPartially() throws Exception {
-    int objectSize = 16 * 1024;
+    objectSize = 16 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     GoogleCloudStorageReadOptions options =
@@ -1078,9 +963,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
-
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
 
     verify(fakeService, times(1))
         .readObject(
@@ -1107,9 +989,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setReadOffset(readOffset)
                     .build()),
             any());
-    assertArrayEquals(
-        fakeService.data.substring(readOffset, readOffset + (2 * 1024)).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(readOffset, readOffset + (2 * 1024)).toByteArray());
 
     // reading the footer twice to ensure there are no additional calls to GCS
     buffer.clear();
@@ -1127,7 +1008,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .build()),
             any());
 
-    assertArrayEquals(fakeService.data.substring(footerOffset).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(footerOffset).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 3);
@@ -1135,12 +1016,11 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testSeekBeforeFooterAndSequentialRead() throws Exception {
-    int objectSize = 4 * 1024;
+    objectSize = 4 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
-    int readOffset = 1 * 1024;
+    int readOffset = 1024;
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder()
             .setMinRangeRequestSize(minRangeRequestSize)
@@ -1170,9 +1050,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testFooterNotCachedInSequentialRead() throws Exception {
-    int objectSize = 4 * 1024;
+    objectSize = 4 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     GoogleCloudStorageReadOptions options =
@@ -1207,9 +1086,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadCachedFooterPartiallyWithInplaceSeek() throws Exception {
-    int objectSize = 16 * 1024;
+    objectSize = 16 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     GoogleCloudStorageReadOptions options =
@@ -1220,9 +1098,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
-
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
 
     // This should just issue a read from offset 0
     verify(fakeService, times(1))
@@ -1252,9 +1127,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setReadOffset(readOffset)
                     .build()),
             any());
-    assertArrayEquals(
-        fakeService.data.substring(readOffset, readOffset + (2 * 1024)).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(readOffset, readOffset + (2 * 1024)).toByteArray());
 
     int footerOffset = 14 * 1024;
     buffer.clear();
@@ -1272,7 +1146,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .build()),
             any());
 
-    assertArrayEquals(fakeService.data.substring(footerOffset).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(footerOffset).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 3);
@@ -1280,9 +1154,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadWithInplaceSeekAndFadviseRandom() throws Exception {
-    int objectSize = 16 * 1024;
+    objectSize = 16 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     int inplaceSeekLimit = 6 * 1024;
@@ -1295,9 +1168,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
-
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
 
     verify(fakeService, times(1))
         .readObject(
@@ -1328,9 +1198,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setReadLimit(inplaceSeekLimit)
                     .build()),
             any());
-    assertArrayEquals(
-        fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray());
 
     verifyNoMoreInteractions(fakeService);
 
@@ -1339,9 +1208,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadWithInplaceSeekAndFadviseAuto() throws Exception {
-    int objectSize = 16 * 1024;
+    objectSize = 16 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     int inplaceSeekLimit = 6 * 1024;
@@ -1354,9 +1222,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
-
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
 
     verify(fakeService, times(1))
         .readObject(
@@ -1375,9 +1240,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     buffer = ByteBuffer.allocate(capacity);
     readChannel.read(buffer);
 
-    assertArrayEquals(
-        fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray());
 
     verifyNoMoreInteractions(fakeService);
 
@@ -1386,9 +1250,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadWithInplaceSeekAndFadviseSequential() throws Exception {
-    int objectSize = 16 * 1024;
+    objectSize = 16 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     int inplaceSeekLimit = 6 * 1024;
@@ -1402,9 +1265,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
-
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -1422,9 +1282,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     buffer = ByteBuffer.allocate(capacity);
     readChannel.read(buffer);
 
-    assertArrayEquals(
-        fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray());
 
     verifyNoMoreInteractions(fakeService);
 
@@ -1433,9 +1292,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void testReadWithMultipleSeeks() throws Exception {
-    int objectSize = 16 * 1024;
+    objectSize = 16 * 1024;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     int minRangeRequestSize = 4 * 1024;
     int inplaceSeekLimit = 6 * 1024;
@@ -1448,9 +1306,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel(options);
     ByteBuffer buffer = ByteBuffer.allocate(2 * 1024);
     readChannel.read(buffer);
-
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
 
     verify(fakeService, times(1))
         .readObject(
@@ -1470,9 +1325,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     buffer = ByteBuffer.allocate(capacity);
     readChannel.read(buffer);
 
-    assertArrayEquals(
-        fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray(),
-        buffer.array());
+    assertThat(buffer.array())
+        .isEqualTo(fakeService.data.substring(readOffset, readOffset + (capacity)).toByteArray());
 
     verifyNoMoreInteractions(fakeService);
 
@@ -1502,7 +1356,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(50);
     readChannel.read(buffer);
 
-    assertEquals(50, readChannel.position());
+    assertThat(readChannel.position()).isEqualTo(50);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
   }
@@ -1513,7 +1367,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
     readChannel.position(50);
 
-    assertEquals(50, readChannel.position());
+    assertThat(readChannel.position()).isEqualTo(50);
   }
 
   @Test
@@ -1525,66 +1379,36 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   }
 
   @Test
-  public void fastFailOnNotFoundFailsOnCreateWhenEnabled() throws IOException {
-    MockHttpTransport transport = mockTransport(jsonErrorResponse(ErrorResponses.NOT_FOUND));
-
-    List<HttpRequest> requests = new ArrayList<>();
-
-    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
-
+  public void fastFailOnNotFoundFailsOnCreateWhenEnabled() {
+    StorageResourceId resourceId = new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME);
+    GoogleCloudStorageItemInfo itemInfo = GoogleCloudStorageItemInfo.createNotFound(resourceId);
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(true).build();
 
-    Throwable throwable = assertThrows(IOException.class, () -> newReadChannel(storage, options));
-    assertThat(throwable).hasMessageThat().contains("Item not found");
-  }
-
-  @Test
-  public void fastFailOnNotFoundFailsByReadWhenDisabled() throws IOException {
-    MockHttpTransport transport = mockTransport(jsonErrorResponse(ErrorResponses.NOT_FOUND));
-
-    List<HttpRequest> requests = new ArrayList<>();
-
-    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
-
-    GoogleCloudStorageReadOptions options =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
-
-    // If the user hasn't mandated fail fast, it is permissible for either open() or read() to
-    // raise this exception.
-    IOException thrown = assertThrows(IOException.class, () -> newReadChannel(storage, options));
-    assertThat(thrown).hasMessageThat().contains("Item not found");
-  }
-
-  @Test
-  public void fastFailOnNotFoundFailsByReadWhenDisabledItemInfo() throws IOException {
-    MockHttpTransport transport = mockTransport(jsonErrorResponse(ErrorResponses.NOT_FOUND));
-
-    List<HttpRequest> requests = new ArrayList<>();
-
-    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
-
-    GoogleCloudStorageReadOptions options =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
-    StorageResourceId resourceId =
-        StorageResourceId.fromStringPath("gs://" + BUCKET_NAME + "/" + OBJECT_NAME);
-    GoogleCloudStorageItemInfo itemInfo = GoogleCloudStorageItemInfo.createNotFound(resourceId);
-    // If the user hasn't mandated fail fast, it is permissible for either open() or read() to
-    // raise this exception.
     IOException thrown = assertThrows(IOException.class, () -> newReadChannel(itemInfo, options));
-    assertThat(thrown).hasMessageThat().contains("File not found");
+
+    assertThat(thrown).hasMessageThat().isEqualTo("File not found: " + resourceId);
+  }
+
+  @Test
+  public void fastFailOnNotFoundFailsOnCreateWhenDisabled() {
+    StorageResourceId resourceId = new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME);
+    GoogleCloudStorageItemInfo itemInfo = GoogleCloudStorageItemInfo.createNotFound(resourceId);
+    GoogleCloudStorageReadOptions options =
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
+
+    IOException thrown = assertThrows(IOException.class, () -> newReadChannel(itemInfo, options));
+
+    assertThat(thrown).hasMessageThat().isEqualTo("File not found: " + resourceId);
   }
 
   @Test
   public void sizeReturnsObjectSize() throws Exception {
-    int objectSize = 1234;
+    objectSize = 1234;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
 
-    assertEquals(1234L, readChannel.size());
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
+    assertThat(readChannel.size()).isEqualTo(1234);
   }
 
   @Test
@@ -1597,22 +1421,19 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
 
   @Test
   public void sizeIsCached() throws Exception {
-    int objectSize = 1234;
+    objectSize = 1234;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
 
-    assertEquals(1234L, readChannel.size());
-    assertEquals(1234L, readChannel.size());
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
+    assertThat(readChannel.size()).isEqualTo(1234);
+    assertThat(readChannel.size()).isEqualTo(1234);
   }
 
   @Test
   public void isOpenReturnsTrueOnCreate() throws Exception {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
 
-    assertTrue(readChannel.isOpen());
+    assertThat(readChannel.isOpen()).isTrue();
   }
 
   @Test
@@ -1620,7 +1441,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
 
     readChannel.close();
-    assertFalse(readChannel.isOpen());
+
+    assertThat(readChannel.isOpen()).isFalse();
   }
 
   @Test
@@ -1637,16 +1459,16 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
       assertingHandler.assertLogCount(7);
       assertingHandler.verifyCommonTraceFields();
 
-      verifyMethodsName(0, "streamCreated", assertingHandler);
-      verifyMethodsName(1, "outboundMessage", assertingHandler);
+      assertThat(assertingHandler.getMethodAtIndex(0)).isEqualTo("streamCreated");
+      assertThat(assertingHandler.getMethodAtIndex(1)).isEqualTo("outboundMessage");
       // InProcessTransport is not reporting the correct size
       // (https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/inprocess/InProcessTransport.java#L519).
       // Hence only validating that the relevant methods are called.
-      verifyMethodsName(2, "outboundMessageSent", assertingHandler);
-      verifyMethodsName(3, "inboundMessage", assertingHandler);
-      verifyMethodsName(4, "inboundMessageRead", assertingHandler);
-      verifyMethodsName(5, "inboundTrailers", assertingHandler);
-      verifyMethodsName(6, "streamClosed", assertingHandler);
+      assertThat(assertingHandler.getMethodAtIndex(2)).isEqualTo("outboundMessageSent");
+      assertThat(assertingHandler.getMethodAtIndex(3)).isEqualTo("inboundMessage");
+      assertThat(assertingHandler.getMethodAtIndex(4)).isEqualTo("inboundMessageRead");
+      assertThat(assertingHandler.getMethodAtIndex(5)).isEqualTo("inboundTrailers");
+      assertThat(assertingHandler.getMethodAtIndex(6)).isEqualTo("streamClosed");
     } finally {
       grpcTracingLogger.removeHandler(assertingHandler);
     }
@@ -1670,9 +1492,8 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   }
 
   private void readObjectAndVerify(GoogleCloudStorageOptions storageOptions) throws IOException {
-    int objectSize = FakeService.CHUNK_SIZE;
+    objectSize = FakeService.CHUNK_SIZE;
     fakeService.setObject(DEFAULT_OBJECT.toBuilder().setSize(objectSize).build());
-    storageObject.setSize(BigInteger.valueOf(objectSize));
     verify(fakeService, times(1)).setObject(any());
     GoogleCloudStorageReadOptions options =
         GoogleCloudStorageReadOptions.builder().setMinRangeRequestSize(4).build();
@@ -1681,8 +1502,6 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
     ByteBuffer buffer = ByteBuffer.allocate(100);
     readChannel.read(buffer);
 
-    verify(get).setFields(METADATA_FIELDS);
-    verify(get).execute();
     verify(fakeService, times(1))
         .readObject(
             eq(
@@ -1692,29 +1511,10 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
                     .setGeneration(OBJECT_GENERATION)
                     .build()),
             any());
-    assertArrayEquals(fakeService.data.substring(0, 100).toByteArray(), buffer.array());
+    assertThat(buffer.array()).isEqualTo(fakeService.data.substring(0, 100).toByteArray());
     verifyNoMoreInteractions(fakeService);
 
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 1);
-  }
-
-  private void verifyMethodsName(
-      int index, String methodName, AssertingLogHandler assertingHandler) {
-    assertEquals(assertingHandler.getMethodAtIndex(index), methodName);
-  }
-
-  private GoogleCloudStorageGrpcReadChannel newReadChannel(
-      GoogleCloudStorageReadOptions options, GoogleCloudStorageOptions storageOptions)
-      throws IOException {
-    return new GoogleCloudStorageGrpcReadChannel(
-        new FakeStubProvider(mockCredentials),
-        storage,
-        new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME),
-        watchdog,
-        new NoOpMetricsRecorder(),
-        options,
-        () -> BackOff.STOP_BACKOFF,
-        storageOptions);
   }
 
   private GoogleCloudStorageGrpcReadChannel newReadChannel() throws IOException {
@@ -1722,56 +1522,48 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   }
 
   private GoogleCloudStorageGrpcReadChannel newReadChannel(
-      Storage storage, GoogleCloudStorageReadOptions options) throws IOException {
-    return new GoogleCloudStorageGrpcReadChannel(
-        new FakeStubProvider(mockCredentials),
-        storage,
-        new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
-        watchdog,
-        new NoOpMetricsRecorder(),
-        options,
-        () -> BackOff.STOP_BACKOFF,
-        GoogleCloudStorageOptions.DEFAULT);
-  }
-
-  private GoogleCloudStorageGrpcReadChannel newReadChannel(GoogleCloudStorageReadOptions options)
-      throws IOException {
-    return new GoogleCloudStorageGrpcReadChannel(
-        new FakeStubProvider(mockCredentials),
-        storage,
-        new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME),
-        watchdog,
-        new NoOpMetricsRecorder(),
-        options,
-        () -> BackOff.STOP_BACKOFF,
-        GoogleCloudStorageOptions.DEFAULT);
+      GoogleCloudStorageReadOptions readOptions) throws IOException {
+    return newReadChannel(readOptions, GoogleCloudStorageOptions.DEFAULT);
   }
 
   private GoogleCloudStorageGrpcReadChannel newReadChannel(
-      StorageResourceId storageResourceId, GoogleCloudStorageReadOptions options)
+      GoogleCloudStorageReadOptions readOptions, GoogleCloudStorageOptions storageOptions)
       throws IOException {
-    return new GoogleCloudStorageGrpcReadChannel(
-        new FakeStubProvider(mockCredentials),
-        storage,
-        storageResourceId,
-        watchdog,
-        new NoOpMetricsRecorder(),
-        options,
-        () -> BackOff.STOP_BACKOFF,
-        GoogleCloudStorageOptions.DEFAULT);
+    return newReadChannel(
+        GoogleCloudStorageItemInfo.createObject(
+            new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME),
+            /* creationTime= */ 10L,
+            /* modificationTime= */ 15L,
+            /* size= */ objectSize,
+            /* contentType= */ "text/plain",
+            /* contentEncoding= */ "lzma",
+            /* metadata= */ null,
+            /* contentGeneration= */ OBJECT_GENERATION,
+            /* metaGeneration= */ 2L,
+            /* verificationAttributes= */ null),
+        readOptions,
+        storageOptions);
   }
 
   private GoogleCloudStorageGrpcReadChannel newReadChannel(
-      GoogleCloudStorageItemInfo itemInfo, GoogleCloudStorageReadOptions options)
+      GoogleCloudStorageItemInfo itemInfo, GoogleCloudStorageReadOptions readOptions)
+      throws IOException {
+    return newReadChannel(itemInfo, readOptions, GoogleCloudStorageOptions.DEFAULT);
+  }
+
+  private GoogleCloudStorageGrpcReadChannel newReadChannel(
+      GoogleCloudStorageItemInfo itemInfo,
+      GoogleCloudStorageReadOptions readOptions,
+      GoogleCloudStorageOptions storageOptions)
       throws IOException {
     return new GoogleCloudStorageGrpcReadChannel(
-        new FakeStubProvider(mockCredentials),
+        new FakeStubProvider(),
         itemInfo,
         watchdog,
         new NoOpMetricsRecorder(),
-        options,
-        () -> BackOff.STOP_BACKOFF,
-        GoogleCloudStorageOptions.DEFAULT);
+        storageOptions,
+        readOptions,
+        () -> BackOff.STOP_BACKOFF);
   }
 
   private static class FakeGrpcDecorator implements StorageStubProvider.GrpcDecorator {
@@ -1788,7 +1580,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   }
 
   private class FakeStubProvider extends StorageStubProvider {
-    FakeStubProvider(Credentials credentials) {
+    FakeStubProvider() {
       super(GoogleCloudStorageOptions.DEFAULT, null, new FakeGrpcDecorator());
     }
 
@@ -1825,15 +1617,14 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
       if (readObjectException != null) {
         responseObserver.onError(readObjectException);
       } else {
-        int readStart = (int) request.getReadOffset();
-        int readEnd =
+        long readStart = request.getReadOffset();
+        long readEnd =
             request.getReadLimit() > 0
-                ? (int) min(object.getSize(), readStart + request.getReadLimit())
-                : (int) object.getSize();
-        for (int position = readStart; position < readEnd; position += CHUNK_SIZE) {
-          int endIndex = min((int) object.getSize(), position + CHUNK_SIZE);
-          endIndex = min(endIndex, readEnd);
-          ByteString messageData = data.substring(position, endIndex);
+                ? min(object.getSize(), readStart + request.getReadLimit())
+                : object.getSize();
+        for (long position = readStart; position < readEnd; position += CHUNK_SIZE) {
+          long endIndex = min(min(object.getSize(), position + CHUNK_SIZE), readEnd);
+          ByteString messageData = data.substring(toIntExact(position), toIntExact(endIndex));
           int crc32c = Hashing.crc32c().hashBytes(messageData.toByteArray()).asInt();
           if (alterMessageChecksum) {
             crc32c += 1;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
@@ -1274,7 +1274,10 @@ public class GoogleCloudStorageNewIntegrationTest {
 
     assertThat(gcsRequestsTracker.getAllRequestStrings())
         .containsExactly(
-            getRequestString(testBucket, testFile.getObjectName()),
+            getRequestString(
+                testBucket,
+                testFile.getObjectName(),
+                /* fields= */ "contentEncoding,generation,size"),
             getMediaRequestString(testBucket, testFile.getObjectName(), generationId))
         .inOrder();
   }
@@ -1333,7 +1336,11 @@ public class GoogleCloudStorageNewIntegrationTest {
         .isEqualTo("Cannot read GZIP encoded files - content encoding support is disabled.");
 
     assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(getRequestString(testBucket, testFile.getObjectName()));
+        .containsExactly(
+            getRequestString(
+                testBucket,
+                testFile.getObjectName(),
+                /* fields= */ "contentEncoding,generation,size"));
   }
 
   @Test
@@ -1377,6 +1384,8 @@ public class GoogleCloudStorageNewIntegrationTest {
         assertThrows(FileNotFoundException.class, () -> gcs.open(itemInfo, readOptions));
 
     assertThat(e).hasMessageThat().startsWith("Item not found");
+
+    assertThat(gcsRequestsTracker.getAllRequestStrings()).isEmpty();
   }
 
   private static List<String> getObjectNames(List<GoogleCloudStorageItemInfo> listedObjects) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -189,9 +189,9 @@ public class GoogleCloudStorageReadChannelTest {
 
   @Test
   public void footerPrefetch_reused() throws IOException {
-    int footeSize = 2;
+    int footerSize = 2;
     byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
-    int footerStart = testData.length - footeSize;
+    int footerStart = testData.length - footerSize;
     byte[] footer = Arrays.copyOfRange(testData, footerStart, testData.length);
 
     MockHttpTransport transport =
@@ -208,7 +208,7 @@ public class GoogleCloudStorageReadChannelTest {
     GoogleCloudStorageReadOptions options =
         newLazyReadOptionsBuilder()
             .setFadvise(Fadvise.RANDOM)
-            .setMinRangeRequestSize(footeSize)
+            .setMinRangeRequestSize(footerSize)
             .build();
 
     GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -290,10 +290,11 @@ public class GoogleCloudStorageGrpcIntegrationTest {
     }
   }
 
-  // The wiresize is usually greater than the content size by a few bytes. Hence, checking that the
-  // actual wire
-  // size is within the range. Also checking the difference b/w wireSize b/w two calls is within a
-  // bound of few bytes of the expected value.
+  /**
+   * The wire size is usually greater than the content size by a few bytes. Hence, checking that the
+   * actual wire size is within the range. Also checking the difference b/w wireSize b/w two calls
+   * is within a bound of few bytes of the expected value.
+   */
   private void verifyWireSizeDifferenceWithinRange(
       Map<String, Object> event1, Map<String, Object> event2, int sizeDifference, int range) {
     double wireSize1 = (double) event1.get("optionalWireSize");
@@ -330,7 +331,7 @@ public class GoogleCloudStorageGrpcIntegrationTest {
     StorageResourceId resourceId =
         new StorageResourceId(BUCKET_NAME, "testOpenNonExistentItem_Object");
     IOException exception = assertThrows(IOException.class, () -> rawStorage.open(resourceId));
-    assertThat(exception).hasMessageThat().contains("Item not found");
+    assertThat(exception).hasMessageThat().contains("File not found");
   }
 
   @Test


### PR DESCRIPTION
This change also removes extra `getItemInfo` call in gRPC read channel