### PR TITLE
fAdvise should be updated in second read.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -104,7 +104,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   private boolean channelIsOpen = true;
 
   // Current position in the object.
-  private long positionInGrpcStream;
+  private long positionInGrpcStream = -1;
 
   // the position from which next read should happen
   private long positionForNextRead;
@@ -765,7 +765,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
   }
 
   private void updateReadStrategy() {
-    if (readStrategy == Fadvise.AUTO) {
+    if (readStrategy == Fadvise.AUTO && positionInGrpcStream != -1) {
       if (positionForNextRead < positionInGrpcStream
           || positionForNextRead - positionInGrpcStream > readOptions.getInplaceSeekLimit()) {
         readStrategy = Fadvise.RANDOM;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannel.java
@@ -423,6 +423,7 @@ public class GoogleCloudStorageGrpcReadChannel implements SeekableByteChannel {
       invalidateBufferedContent();
     }
 
+    checkArgument(positionInGrpcStream >= 0, "Read should always happen from positive offset");
     // The server responds in 2MB chunks, but the client can ask for less than that. We
     // store the remainder in bufferedContent and return pieces of that on the next read call (and
     // flush that buffer if there is a seek).

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcReadChannelTest.java
@@ -66,6 +66,7 @@ import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
+import java.io.EOFException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -1445,7 +1446,7 @@ public final class GoogleCloudStorageGrpcReadChannelTest {
   public void seekFailsOnNegative() throws Exception {
     GoogleCloudStorageGrpcReadChannel readChannel = newReadChannel();
 
-    assertThrows(IllegalArgumentException.class, () -> readChannel.position(-1));
+    assertThrows(EOFException.class, () -> readChannel.position(-1));
   }
 
   @Test


### PR DESCRIPTION
CSV files can be opened at different offsets. gRPC flow updates fAdvise to Random even when first read is beyond InPlaceSeekLimit.