### PR TITLE
Enforce early socket read timeout setting.

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -1,5 +1,10 @@
 ### 2.2.8 - 2022-XX-XX
 
+1.  Set socket read timeout (`fs.gs.http.read-timeout`) as early as possible on
+    new sockets returned from the custom `SSLSocketFactory`. This guarantees the
+    timeout is enforced during TLS handshakes when using Conscrypt as the
+    security provider.
+
 ### 2.2.7 - 2022-06-01
 
 1. Fix: Prevent clobbering of SSL trustCertificates

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -1418,7 +1418,8 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
               options.getTransportType(),
               options.getProxyAddress(),
               options.getProxyUsername(),
-              options.getProxyPassword());
+              options.getProxyPassword(),
+              Duration.ofMillis(options.getHttpRequestReadTimeout()));
       GoogleCredential impersonatedCredential =
           new GoogleCredentialWithIamAccessToken(
               httpTransport,

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -450,7 +450,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
             options.getTransportType(),
             options.getProxyAddress(),
             options.getProxyUsername(),
-            options.getProxyPassword());
+            options.getProxyPassword(),
+            Duration.ofMillis(options.getHttpRequestReadTimeout()));
 
     HttpRequestInitializer requestInitializer = httpRequestInitializer;
     if (options.isTraceLogEnabled()) {

--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -35,6 +35,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
 import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
@@ -93,8 +94,37 @@ public class HttpTransportFactory {
       @Nullable RedactedString proxyUsername,
       @Nullable RedactedString proxyPassword)
       throws IOException {
+    return createHttpTransport(
+        type, proxyAddress, proxyUsername, proxyPassword, /* readTimeout= */ null);
+  }
+
+  /**
+   * Create an {@link HttpTransport} based on a type class, optional HTTP proxy and optional socket
+   * read timeout.
+   *
+   * @param type The type of HttpTransport to use.
+   * @param proxyAddress The HTTP proxy to use with the transport. Of the form hostname:port. If
+   *     empty no proxy will be used.
+   * @param proxyUsername The HTTP proxy username to use with the transport. If empty no proxy
+   *     username will be used.
+   * @param proxyPassword The HTTP proxy password to use with the transport. If empty no proxy
+   *     password will be used.
+   * @param readTimeout The socket read timeout to apply immediately on all HTTP requests. If empty,
+   *     no socket read timeout will be applied.
+   * @return The resulting HttpTransport.
+   * @throws IllegalArgumentException If the proxy address is invalid.
+   * @throws IOException If there is an issue connecting to Google's Certification server.
+   */
+  public static HttpTransport createHttpTransport(
+      HttpTransportType type,
+      @Nullable String proxyAddress,
+      @Nullable RedactedString proxyUsername,
+      @Nullable RedactedString proxyPassword,
+      @Nullable Duration readTimeout)
+      throws IOException {
     logger.atFiner().log(
-        "createHttpTransport(%s, %s, %s, %s)", type, proxyAddress, proxyUsername, proxyPassword);
+        "createHttpTransport(%s, %s, %s, %s, %s)",
+        type, proxyAddress, proxyUsername, proxyPassword, readTimeout);
     checkArgument(
         proxyAddress != null || (proxyUsername == null && proxyPassword == null),
         "if proxyAddress is null then proxyUsername and proxyPassword should be null too");
@@ -116,7 +146,7 @@ public class HttpTransportFactory {
                   ? new PasswordAuthentication(
                       proxyUsername.value(), proxyPassword.value().toCharArray())
                   : null;
-          return createNetHttpTransport(proxyUri, proxyAuth);
+          return createNetHttpTransport(proxyUri, proxyAuth, readTimeout);
         default:
           throw new IllegalArgumentException(
               String.format("Invalid HttpTransport type '%s'", type.name()));
@@ -170,12 +200,15 @@ public class HttpTransportFactory {
    *
    * @param proxyUri Optional HTTP proxy URI to use with the transport.
    * @param proxyAuth Optional HTTP proxy credentials to authenticate with the transport proxy.
+   * @param readTimeout Optional socket read timeout to apply immediately on all HTTP requests.
    * @return The resulting HttpTransport.
    * @throws IOException If there is an issue connecting to Google's certification server.
    * @throws GeneralSecurityException If there is a security issue with the keystore.
    */
   public static NetHttpTransport createNetHttpTransport(
-      @Nullable URI proxyUri, @Nullable PasswordAuthentication proxyAuth)
+      @Nullable URI proxyUri,
+      @Nullable PasswordAuthentication proxyAuth,
+      @Nullable Duration readTimeout)
       throws IOException, GeneralSecurityException {
     checkArgument(
         proxyUri != null || proxyAuth == null,
@@ -197,20 +230,21 @@ public class HttpTransportFactory {
             }
           });
     }
-    return createNetHttpTransportBuilder(proxyUri).build();
+    return createNetHttpTransportBuilder(proxyUri, readTimeout).build();
   }
 
   @VisibleForTesting
-  static NetHttpTransport.Builder createNetHttpTransportBuilder(@Nullable URI proxyUri)
+  static NetHttpTransport.Builder createNetHttpTransportBuilder(
+      @Nullable URI proxyUri, @Nullable Duration readTimeout)
       throws IOException, GeneralSecurityException {
     NetHttpTransport.Builder builder =
         new NetHttpTransport.Builder().trustCertificates(GoogleUtils.getCertificateTrustStore());
+    SSLSocketFactory wrappedSslSocketFactory =
+        builder.getSslSocketFactory() != null
+            ? builder.getSslSocketFactory()
+            : HttpsURLConnection.getDefaultSSLSocketFactory();
     return builder
-        .setSslSocketFactory(
-            new SslKeepAliveSocketFactory(
-                builder.getSslSocketFactory() != null
-                    ? builder.getSslSocketFactory()
-                    : HttpsURLConnection.getDefaultSSLSocketFactory()))
+        .setSslSocketFactory(new CustomSslSocketFactory(wrappedSslSocketFactory, readTimeout))
         .setProxy(
             proxyUri == null
                 ? null
@@ -257,12 +291,14 @@ public class HttpTransportFactory {
 
   /** Wrapper class to have socketKeepAlive property while creating the socket */
   @VisibleForTesting
-  static class SslKeepAliveSocketFactory extends SSLSocketFactory {
+  static final class CustomSslSocketFactory extends SSLSocketFactory {
 
     private final SSLSocketFactory wrappedSockedFactory;
+    private final Integer readTimeoutMillis;
 
-    public SslKeepAliveSocketFactory(SSLSocketFactory wrappedSocketFactory) {
+    public CustomSslSocketFactory(SSLSocketFactory wrappedSocketFactory, Duration readTimeout) {
       this.wrappedSockedFactory = wrappedSocketFactory;
+      this.readTimeoutMillis = readTimeout != null ? Math.toIntExact(readTimeout.toMillis()) : null;
     }
 
     @Override
@@ -277,44 +313,55 @@ public class HttpTransportFactory {
 
     @Override
     public Socket createSocket() throws IOException {
-      return setSocketKeepAlive(wrappedSockedFactory.createSocket());
+      return customizeSocket(wrappedSockedFactory.createSocket());
     }
 
     @Override
     public Socket createSocket(Socket s, InputStream consumed, boolean autoClose)
         throws IOException {
-      return setSocketKeepAlive(wrappedSockedFactory.createSocket(s, consumed, autoClose));
+      return customizeSocket(wrappedSockedFactory.createSocket(s, consumed, autoClose));
     }
 
     @Override
     public Socket createSocket(Socket s, String host, int port, boolean autoClose)
         throws IOException {
-      return setSocketKeepAlive(wrappedSockedFactory.createSocket(s, host, port, autoClose));
+      return customizeSocket(wrappedSockedFactory.createSocket(s, host, port, autoClose));
     }
 
     public Socket createSocket(String host, int port) throws IOException {
-      return setSocketKeepAlive(wrappedSockedFactory.createSocket(host, port));
+      return customizeSocket(wrappedSockedFactory.createSocket(host, port));
     }
 
     public Socket createSocket(InetAddress address, int port) throws IOException {
-      return setSocketKeepAlive(wrappedSockedFactory.createSocket(address, port));
+      return customizeSocket(wrappedSockedFactory.createSocket(address, port));
     }
 
     public Socket createSocket(String host, int port, InetAddress clientAddress, int clientPort)
         throws IOException {
-      return setSocketKeepAlive(
+      return customizeSocket(
           wrappedSockedFactory.createSocket(host, port, clientAddress, clientPort));
     }
 
     public Socket createSocket(
         InetAddress address, int port, InetAddress clientAddress, int clientPort)
         throws IOException {
-      return setSocketKeepAlive(
+      return customizeSocket(
           wrappedSockedFactory.createSocket(address, port, clientAddress, clientPort));
     }
 
-    private static Socket setSocketKeepAlive(Socket socket) throws SocketException {
+    private Socket customizeSocket(Socket socket) throws SocketException {
+      // Enable TCP keep-alive.
       socket.setKeepAlive(true);
+
+      // Set socket read timeout. This shouldn't be necessary, because we generally set the timeout
+      // through other layers, such as com.google.api.client.http.HttpRequest#setReadTimeout(int).
+      // However, setting it here guarantees that the timeout is enforced during TLS handshake when
+      // using Conscrypt as the security provider. (See discussion in
+      // https://github.com/google/conscrypt/issues/864 .)
+      if (readTimeoutMillis != null) {
+        socket.setSoTimeout(readTimeoutMillis);
+      }
+
       return socket;
     }
   }

--- a/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.cloud.hadoop.util.HttpTransportFactory.SslKeepAliveSocketFactory;
+import com.google.cloud.hadoop.util.HttpTransportFactory.CustomSslSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +37,7 @@ import org.junit.runners.JUnit4;
 public class HttpTransportFactoryTest {
 
   private static final FakeSslSocketFactory FAKE_SOCKET_FACTORY = new FakeSslSocketFactory();
-  private static final String[] SUPPORTED_TEST_SUITES = {"testSuite"};
+  private static final String[] SUPPORTED_CIPHER_SUITES = {"testSuite"};
   private static final String[] DEFAULT_CIPHER_SUITES = {"testDefaultCipherSuite"};
 
   @Test
@@ -120,52 +121,58 @@ public class HttpTransportFactoryTest {
   }
 
   @Test
-  public void testKeepAliveSocketFactoryDefaultCipherSuites() {
-    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
-        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+  public void testCustomSslSocketFactoryDefaultCipherSuites() {
+    CustomSslSocketFactory customSslSocketFactory =
+        new CustomSslSocketFactory(FAKE_SOCKET_FACTORY, null);
 
-    assertThat(sslKeepAliveSocketFactory.getDefaultCipherSuites()).isEqualTo(DEFAULT_CIPHER_SUITES);
+    assertThat(customSslSocketFactory.getDefaultCipherSuites()).isEqualTo(DEFAULT_CIPHER_SUITES);
   }
 
   @Test
-  public void testKeepAliveSocketFactorySupportedCipherSuites() {
-    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
-        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+  public void testCustomSslSocketFactorySupportedCipherSuites() {
+    CustomSslSocketFactory customSslSocketFactory =
+        new CustomSslSocketFactory(FAKE_SOCKET_FACTORY, null);
 
-    assertThat(sslKeepAliveSocketFactory.getSupportedCipherSuites())
-        .isEqualTo(SUPPORTED_TEST_SUITES);
+    assertThat(customSslSocketFactory.getSupportedCipherSuites())
+        .isEqualTo(SUPPORTED_CIPHER_SUITES);
   }
 
   @Test
-  public void testKeepAliveSettingIsNotCorrupted() throws GeneralSecurityException, IOException {
+  public void testCustomSslSocketFactoryIsNotCorrupted()
+      throws GeneralSecurityException, IOException {
     NetHttpTransport.Builder builder =
-        HttpTransportFactory.createNetHttpTransportBuilder(/* proxyUri= */ null);
+        HttpTransportFactory.createNetHttpTransportBuilder(
+            /* proxyUri= */ null, /* readTimeout= */ null);
 
-    assertThat(builder.getSslSocketFactory()).isInstanceOf(SslKeepAliveSocketFactory.class);
+    assertThat(builder.getSslSocketFactory()).isInstanceOf(CustomSslSocketFactory.class);
   }
 
   @Test
-  public void testKeepAliveSocketFactoryKeepAliveTrue() throws IOException {
-    SslKeepAliveSocketFactory sslKeepAliveSocketFactory =
-        new SslKeepAliveSocketFactory(FAKE_SOCKET_FACTORY);
+  public void testCustomSslSocketFactoryKeepAliveTrue() throws IOException {
+    CustomSslSocketFactory customSslSocketFactory =
+        new CustomSslSocketFactory(FAKE_SOCKET_FACTORY, null);
 
-    assertThat(sslKeepAliveSocketFactory.createSocket().getKeepAlive()).isTrue();
+    checkSocket(customSslSocketFactory, socket -> assertThat(socket.getKeepAlive()).isTrue());
+  }
 
-    assertThat(sslKeepAliveSocketFactory.createSocket(null, "localhost", 80, false).getKeepAlive())
-        .isTrue();
+  @Test
+  public void testCustomSslSocketFactoryNoReadTimeout() throws IOException {
+    CustomSslSocketFactory customSslSocketFactory =
+        new CustomSslSocketFactory(FAKE_SOCKET_FACTORY, null);
 
-    assertThat(sslKeepAliveSocketFactory.createSocket(null, null, false).getKeepAlive()).isTrue();
+    checkSocket(customSslSocketFactory, socket -> assertThat(socket.getSoTimeout()).isEqualTo(0));
+  }
 
-    assertThat(sslKeepAliveSocketFactory.createSocket("localhost", 80).getKeepAlive()).isTrue();
+  @Test
+  public void testCustomSslSocketFactorySetReadTimeout() throws IOException {
+    Duration readTimeout = Duration.ofMillis(20 * 1000);
+    CustomSslSocketFactory customSslSocketFactory =
+        new CustomSslSocketFactory(FAKE_SOCKET_FACTORY, readTimeout);
 
-    assertThat(sslKeepAliveSocketFactory.createSocket("localhost", 80, null, 443).getKeepAlive())
-        .isTrue();
-
-    InetAddress fakeInet = InetAddress.getByName("10.0.0.0");
-    assertThat(sslKeepAliveSocketFactory.createSocket(fakeInet, 443).getKeepAlive()).isTrue();
-
-    assertThat(sslKeepAliveSocketFactory.createSocket(fakeInet, 443, fakeInet, 80).getKeepAlive())
-        .isTrue();
+    checkSocket(
+        customSslSocketFactory,
+        socket ->
+            assertThat(socket.getSoTimeout()).isEqualTo(Math.toIntExact(readTimeout.toMillis())));
   }
 
   private static class FakeSslSocketFactory extends SSLSocketFactory {
@@ -177,7 +184,7 @@ public class HttpTransportFactoryTest {
 
     @Override
     public String[] getSupportedCipherSuites() {
-      return SUPPORTED_TEST_SUITES;
+      return SUPPORTED_CIPHER_SUITES;
     }
 
     @Override
@@ -217,6 +224,42 @@ public class HttpTransportFactoryTest {
         throws IOException {
       return createSocket();
     }
+  }
+
+  /**
+   * Similar to {@link java.util.function.Consumer}, but supports calling {@link Socket} methods
+   * that declare a checked {@link IOException}.
+   */
+  @FunctionalInterface
+  private interface SocketAssertion {
+
+    void accept(Socket socket) throws IOException;
+  }
+
+  /**
+   * Performs an assertion on sockets returned from an {@link SSLSocketFactory}, making sure to
+   * check the assertion against all overloads of the {@code createSocket} method.
+   *
+   * @param sslSocketFactory the socket factory to check
+   * @param assertion the assertion to perform on created sockets
+   * @throws IOException for any socket error
+   */
+  private static void checkSocket(SSLSocketFactory sslSocketFactory, SocketAssertion assertion)
+      throws IOException {
+    assertion.accept(sslSocketFactory.createSocket());
+
+    assertion.accept(sslSocketFactory.createSocket(null, "localhost", 80, false));
+
+    assertion.accept(sslSocketFactory.createSocket(null, null, false));
+
+    assertion.accept(sslSocketFactory.createSocket("localhost", 80));
+
+    assertion.accept(sslSocketFactory.createSocket("localhost", 80, null, 443));
+
+    InetAddress fakeInet = InetAddress.getByName("10.0.0.0");
+    assertion.accept(sslSocketFactory.createSocket(fakeInet, 443));
+
+    assertion.accept(sslSocketFactory.createSocket(fakeInet, 443, fakeInet, 80));
   }
 
   private static URI getURI(String scheme, String host, int port) throws URISyntaxException {


### PR DESCRIPTION
Set socket read timeout (`fs.gs.http.read-timeout`) as early as possible
on new sockets returned from the custom `SSLSocketFactory`. This
guarantees the timeout is enforced during TLS handshakes when using
Conscrypt as the security provider.

See also https://github.com/google/conscrypt/issues/864 .

(cherry picked from commit 61f8629ed3aa0c19629e072e3ff6445df6e211e0)