### PR TITLE
Enforce early socket read timeout setting.

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -1,3 +1,10 @@
+### 2.1.9 - 2022-XX-XX
+
+1.  Set socket read timeout (`fs.gs.http.read-timeout`) as early as possible on
+    new sockets returned from the custom `SSLSocketFactory`. This guarantees the
+    timeout is enforced during TLS handshakes when using Conscrypt as the
+    security provider.
+
 ### 2.1.8 - 2022-05-30
 
 1.  prevent clobbering of SSL trustCertificates

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -1544,7 +1544,8 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
               options.getTransportType(),
               options.getProxyAddress(),
               options.getProxyUsername(),
-              options.getProxyPassword());
+              options.getProxyPassword(),
+              Duration.ofMillis(options.getHttpRequestReadTimeout()));
       GoogleCredential impersonatedCredential =
           new GoogleCredentialWithIamAccessToken(
               httpTransport,

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -235,7 +235,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
             options.getTransportType(),
             options.getProxyAddress(),
             options.getProxyUsername(),
-            options.getProxyPassword());
+            options.getProxyPassword(),
+            Duration.ofMillis(options.getHttpRequestReadTimeout()));
 
     // Create GCS instance.
     this.gcs =


### PR DESCRIPTION
Set socket read timeout (`fs.gs.http.read-timeout`) as early as possible
on new sockets returned from the custom `SSLSocketFactory`. This
guarantees the timeout is enforced during TLS handshakes when using
Conscrypt as the security provider.

See also https://github.com/google/conscrypt/issues/864 .

(cherry picked from commit 61f8629ed3aa0c19629e072e3ff6445df6e211e0)
(cherry picked from commit 667836b98df89b2c645466d6790b3e32470b1e55)