### PR TITLE
Support existing access token when using UserCredentials auth type

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -62,6 +62,8 @@
     fs.gs.auth.client.id
     fs.gs.auth.client.secret
     fs.gs.auth.refresh.token
+    fs.gs.auth.access.token
+    fs.gs.auth.access.token.expiration.time
     ```
 
 1.  Merge all output stream types functionality in the default output stream
@@ -78,6 +80,7 @@
     new sockets returned from the custom `SSLSocketFactory`. This guarantees the
     timeout is enforced during TLS handshakes when using Conscrypt as the
     security provider.
+
 
 ### 2.2.2 - 2021-06-25
 

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -199,17 +199,28 @@ refresh token using the
 [authorization code grant flow](https://oauth.net/2/grant-types/authorization-code)
 and pass it to the connector with OAuth client ID and secret:
 
-*   `fs.gs.auth.client.id` (not set by default)
+* `fs.gs.auth.client.id` (not set by default)
 
     The OAuth2 client ID.
 
-*   `fs.gs.auth.client.secret` (not set by default)
+* `fs.gs.auth.client.secret` (not set by default)
 
     The OAuth2 client secret.
 
-*   `fs.gs.auth.refresh.token` (not set by default)
+* `fs.gs.auth.refresh.token` (not set by default)
 
     The refresh token.
+
+During the authorisation code grant flow, you also retrieved an access token and its expiration time.
+If the token is not expired, you can also provide it.
+
+* `fs.gs.auth.access.token`
+
+    The access token.
+
+* `fs.gs.auth.access.token.expiration.time` 
+
+    The access token expiration time in milliseconds since epoch.
 
 ### Service account impersonation
 


### PR DESCRIPTION
In Dataiku, we found a small optimisation of the UserCredentials auth type that we thought we could share with you guys.

Saving a bit of network calls to Google OAuth2 provider.

Fixes #869 