### PR TITLE
Support GCS Connector usage as a Hadoop Credential Provider. (#882)

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -1,5 +1,8 @@
 ### 2.2.9 - 2022-XX-XX
 
+1.  The Google Cloud Storage Connector now can be used as a
+    [Hadoop Credential Provider](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
+
 ### 2.2.8 - 2022-09-12
 
 1.  Set socket read timeout (`fs.gs.http.read-timeout`) as early as possible on

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.ProviderUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
@@ -452,6 +453,8 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
     checkArgument(path.getScheme() != null, "scheme of path must not be null");
     checkArgument(path.getScheme().equals(getScheme()), "URI scheme not supported: %s", path);
 
+    config =
+        ProviderUtils.excludeIncompatibleCredentialProviders(config, GoogleHadoopFileSystem.class);
     super.initialize(path, config);
 
     initUri = path;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -25,6 +25,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.GcsFileChecksumType;
@@ -67,6 +68,8 @@ import org.junit.runners.JUnit4;
 /** Integration tests for GoogleHadoopFileSystem class. */
 @RunWith(JUnit4.class)
 public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSystemTestBase {
+
+  private static final String PUBLIC_BUCKET = "gs://gcp-public-data-landsat";
 
   @ClassRule
   public static NotInheritableExternalResource storageResource =
@@ -1165,31 +1168,38 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
 
   @Test
   public void unauthenticatedAccessToPublicBuckets_fsGsProperties() throws Exception {
-    String publicBucket = "gs://gcp-public-data-landsat";
-
     Configuration config = new Configuration();
     config.setBoolean("fs.gs.auth.service.account.enable", false);
     config.setBoolean("fs.gs.auth.null.enable", true);
 
-    FileSystem fs = FileSystem.get(new URI(publicBucket), config);
+    FileSystem fs = FileSystem.get(new URI(PUBLIC_BUCKET), config);
 
-    FileStatus[] fileStatuses = fs.listStatus(new Path(publicBucket));
+    FileStatus[] fileStatuses = fs.listStatus(new Path(PUBLIC_BUCKET));
 
     assertThat(fileStatuses).isNotEmpty();
   }
 
   @Test
   public void unauthenticatedAccessToPublicBuckets_googleCloudProperties() throws Exception {
-    String publicBucket = "gs://gcp-public-data-landsat";
-
     Configuration config = new Configuration();
     config.setBoolean("google.cloud.auth.service.account.enable", false);
     config.setBoolean("google.cloud.auth.null.enable", true);
 
-    FileSystem fs = FileSystem.get(new URI(publicBucket), config);
+    FileSystem fs = FileSystem.get(new URI(PUBLIC_BUCKET), config);
 
-    FileStatus[] fileStatuses = fs.listStatus(new Path(publicBucket));
+    FileStatus[] fileStatuses = fs.listStatus(new Path(PUBLIC_BUCKET));
 
     assertThat(fileStatuses).isNotEmpty();
+  }
+
+  @Test
+  public void testInitializeCompatibleWithHadoopCredentialProvider() throws Exception {
+    Configuration config = loadConfig();
+
+    // This does not need to refer to a real bucket/path for the test.
+    config.set(HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH, "jceks://gs@foobar/test.jceks");
+
+    FileSystem.get(new URI(PUBLIC_BUCKET), config);
+    // Initialization successful with no exception thrown.
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -376,4 +376,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
 
   @Override
   public void testConcurrentCreationWithoutOverwrite_onlyOneSucceeds() {}
+
+  @Override
+  public void testInitializeCompatibleWithHadoopCredentialProvider() {}
 }


### PR DESCRIPTION
For additional context, see
https://issues.apache.org/jira/browse/HADOOP-12846.

Closes #219.

(cherry picked from commit 9ba13a6d303e8abc23c431283101d96fd148af44)