### PR TITLE
Support GCS Connector usage as a Hadoop Credential Provider. (#882) (…

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -5,6 +5,9 @@
     timeout is enforced during TLS handshakes when using Conscrypt as the
     security provider.
 
+1.  The Google Cloud Storage Connector now can be used as a
+    [Hadoop Credential Provider](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
+
 ### 2.1.8 - 2022-05-30
 
 1.  prevent clobbering of SSL trustCertificates

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -125,6 +125,7 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.ProviderUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
@@ -538,6 +539,8 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
     logger.atFine().log(
         "initialize(path: %s, config: %s, initSuperclass: %b)", path, config, initSuperclass);
 
+    config =
+        ProviderUtils.excludeIncompatibleCredentialProviders(config, GoogleHadoopFileSystem.class);
     if (initSuperclass) {
       super.initialize(path, config);
     } else {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -26,6 +26,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.GcsFileChecksumType;
@@ -66,6 +67,8 @@ import org.junit.runners.JUnit4;
 /** Integration tests for GoogleHadoopFileSystem class. */
 @RunWith(JUnit4.class)
 public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSystemTestBase {
+
+  private static final String PUBLIC_BUCKET = "gs://gcp-public-data-landsat";
 
   @ClassRule
   public static NotInheritableExternalResource storageResource =
@@ -1141,5 +1144,16 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
     // Validate that authorities can't be crazy:
     assertThrows(
         IllegalArgumentException.class, () -> myghfs.getGcsPath(new Path("gs://buck^et/object")));
+  }
+
+  @Test
+  public void testInitializeCompatibleWithHadoopCredentialProvider() throws Exception {
+    Configuration config = loadConfig();
+
+    // This does not need to refer to a real bucket/path for the test.
+    config.set(HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH, "jceks://gs@foobar/test.jceks");
+
+    FileSystem.get(new URI(PUBLIC_BUCKET), config);
+    // Initialization successful with no exception thrown.
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -374,4 +374,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
 
   @Override
   public void testConcurrentCreationWithoutOverwrite_onlyOneSucceeds() {}
+
+  @Override
+  public void testInitializeCompatibleWithHadoopCredentialProvider() {}
 }


### PR DESCRIPTION
…#883)

For additional context, see
https://issues.apache.org/jira/browse/HADOOP-12846.

Closes #219.

(cherry picked from commit 9ba13a6d303e8abc23c431283101d96fd148af44) (cherry picked from commit 793cfa8d05517ae0b4092370992171fea42024d6)