### PR TITLE
remove use of CommonRequestParams

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannel.java
@@ -33,7 +33,6 @@ import com.google.common.io.ByteStreams;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Timestamps;
 import com.google.storage.v2.ChecksummedData;
-import com.google.storage.v2.CommonRequestParams;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.ObjectChecksums;
 import com.google.storage.v2.QueryWriteStatusRequest;
@@ -511,17 +510,8 @@ public final class GoogleCloudStorageGrpcWriteChannel
               writeConditions.getMetaGenerationMatch());
         }
 
-        CommonRequestParams.Builder commonRequestParamsBuilder = null;
-        if (requesterPaysProject != null) {
-          commonRequestParamsBuilder =
-              CommonRequestParams.newBuilder().setUserProject(requesterPaysProject);
-        }
-
         StartResumableWriteRequest.Builder startResumableWriteRequestBuilder =
             StartResumableWriteRequest.newBuilder().setWriteObjectSpec(insertObjectSpecBuilder);
-        if (commonRequestParamsBuilder != null) {
-          startResumableWriteRequestBuilder.setCommonRequestParams(commonRequestParamsBuilder);
-        }
         StartResumableWriteRequest request = startResumableWriteRequestBuilder.build();
         return ResilientOperation.retry(
             () -> startResumableUpload(request),

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcWriteChannelTest.java
@@ -314,7 +314,6 @@ public final class GoogleCloudStorageGrpcWriteChannelTest {
     writeChannel.close();
 
     StartResumableWriteRequest.Builder expectedRequestBuilder = START_REQUEST.toBuilder();
-    expectedRequestBuilder.getCommonRequestParamsBuilder().setUserProject("project-id");
     verify(fakeService, times(1)).startResumableWrite(eq(expectedRequestBuilder.build()), any());
     headerInterceptor.verifyAllRequestsHasGoogRequestParamsHeader(V1_BUCKET_NAME, 2);
   }


### PR DESCRIPTION
Removing the use of `CommonRequestParams` to pass in the `requesterPaysProject` Info. Will use the recommended way of passing on this information using: https://cloud.google.com/apis/docs/system-parameters#definitions