### PR TITLE
dependencies for Veneer Client

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -82,6 +82,8 @@
 1.  The Google Cloud Storage Connector now can be used as a
     [Hadoop Credential Provider](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
 
+1.  Added dependency on new storage client library: [google-cloud-storage](https://github.com/googleapis/java-storage/tree/main/google-cloud-storage).
+
 ### 2.2.2 - 2021-06-25
 
 1.  Support footer prefetch in gRPC read channel.

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -239,6 +239,7 @@
                     <include>com.google.api.gax.**</include>
                     <include>com.google.auth.**</include>
                     <include>com.google.cloud.audit.**</include>
+                    <include>com.google.cloud.storage.**</include>
                     <include>com.google.cloud.hadoop.gcsio.**</include>
                     <include>com.google.cloud.hadoop.util.**</include>
                     <include>com.google.common.**</include>

--- a/gcsio/pom.xml
+++ b/gcsio/pom.xml
@@ -98,6 +98,10 @@
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-storage-v2</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage-bom</artifactId>
-        <version>2.14.0</version>
+        <version>${google.cloud-storage.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <google.auto-value.version>1.9</google.auto-value.version>
     <google.cloud-bigquerystorage.version>2.7.0</google.cloud-bigquerystorage.version>
     <google.cloud-core.verion>2.5.4</google.cloud-core.verion>
-    <google.cloud-storage.grpc.version>2.2.2-alpha</google.cloud-storage.grpc.version>
+    <google.cloud-storage.bom.version>2.14.0</google.cloud-storage.bom.version>
     <google.error-prone.version>2.10.0</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
     <google.gax.version>2.7.1</google.gax.version>
@@ -102,7 +102,7 @@
     <google.http-client.version>1.40.1</google.http-client.version>
     <google.oauth-client.version>1.33.3</google.oauth-client.version>
     <google.protobuf.version>3.19.2</google.protobuf.version>
-    <grpc.version>1.43.1</grpc.version>
+    <grpc.version>1.50.1</grpc.version>
     <hadoop.version>3.3.1</hadoop.version>
     <opencensus.version>0.31.0</opencensus.version>
 
@@ -272,6 +272,13 @@
         <version>${google.http-client.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-storage-bom</artifactId>
+        <version>2.14.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
         <version>${google.api-client.version}</version>
@@ -369,11 +376,6 @@
         <artifactId>flogger-system-backend</artifactId>
         <version>${google.flogger.version}</version>
         <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>grpc-google-cloud-storage-v2</artifactId>
-        <version>${google.cloud-storage.grpc.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Also upgraded `io.grpc` version from `1.43.1` to `1.50.1` because `com.google.cloud` is introducing [`io.grpc:grpc-googleapis`](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-storage/2.14.0) dependency with `1.50.1` and does make sense to have all `io.grpc` to be consistent. Btw we already have `requireSameVersions` plugin against `io.grpc`.