### PR TITLE
added support to use new Storage Client

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -1060,7 +1060,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
     createFile(new Path("/directory1/subdirectory2/file1"), data);
     createFile(new Path("/directory1/subdirectory2/file2"), data);
 
-    FileStatus[] rootDirectories = ghfs.globStatus(new Path("/d*"));
+    FileStatus[] rootDirectories = ghfs.globStatus(new Path("/directory1*"));
     assertThat(stream(rootDirectories).map(d -> d.getPath().getName()).collect(toImmutableList()))
         .containsExactly("directory1");
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -1480,7 +1480,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
     ghfs.mkdirs(new Path("/directory1/subdirectory1"));
     createFile(new Path("/directory1/subdirectory1/file1"), "data".getBytes(UTF_8));
 
-    FileStatus[] rootDirStatuses = ghfs.globStatus(new Path("/d*"));
+    FileStatus[] rootDirStatuses = ghfs.globStatus(new Path("/directory1*"));
     List<String> rootDirs =
         stream(rootDirStatuses).map(d -> d.getPath().toString()).collect(toImmutableList());
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -63,7 +63,6 @@ import com.google.cloud.hadoop.util.ApiErrorExtractor;
 import com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.AuthenticationType;
 import com.google.cloud.hadoop.util.testing.TestingAccessTokenProvider;
 import com.google.common.collect.ImmutableList;
-import com.google.common.flogger.GoogleLogger;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.Ints;
 import java.io.File;
@@ -92,13 +91,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.runners.JUnit4;
 
 /** Integration tests for GoogleHadoopFileSystem class. */
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSystemTestBase {
-
-  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private static final String PUBLIC_BUCKET = "gs://gcp-public-data-landsat";
 
@@ -110,7 +107,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
 
     // loadConfig needs ghfsHelper, which is normally created in
     // postCreateInit. Create one here for it to use.
-    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl);
+    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs);
 
     URI initUri = new URI("gs://" + ghfsHelper.getUniqueBucketName("init"));
     ghfs.initialize(initUri, loadConfig());
@@ -955,7 +952,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
     assertThat(thrown).hasMessageThat().isEqualTo("No bucket specified in GCS URI: gs:/");
   }
 
-  private static Configuration getConfigurationWithImplementation() {
+  private Configuration getConfigurationWithImplementation() {
     Configuration conf = loadConfig();
     conf.set("fs.gs.impl", GoogleHadoopFileSystem.class.getCanonicalName());
     return conf;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -110,7 +110,7 @@ public class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoopFileSyste
 
     // loadConfig needs ghfsHelper, which is normally created in
     // postCreateInit. Create one here for it to use.
-    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs);
+    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl);
 
     URI initUri = new URI("gs://" + ghfsHelper.getUniqueBucketName("init"));
     ghfs.initialize(initUri, loadConfig());

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemNewIntegrationTest.java
@@ -38,7 +38,6 @@ import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -50,19 +49,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.JUnit4;
 
 /** Integration tests for GoogleHadoopFileSystem class. */
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public class GoogleHadoopFileSystemNewIntegrationTest {
-
-  @Parameterized.Parameter public boolean testStorageClientImpl;
-
-  @Parameters
-  public static Iterable<Boolean> getTesStorageClientImplParameter() {
-    return List.of(false, true);
-  }
 
   private static GoogleCloudStorageOptions gcsOptions;
   private static RetryHttpInitializer httpRequestsInitializer;
@@ -83,7 +74,7 @@ public class GoogleHadoopFileSystemNewIntegrationTest {
         new RetryHttpInitializer(credentials, gcsOptions.toRetryHttpInitializerOptions());
 
     GoogleHadoopFileSystem ghfs = new GoogleHadoopFileSystem();
-    ghfsIHelper = new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl);
+    ghfsIHelper = new HadoopFileSystemIntegrationHelper(ghfs);
 
     testBucketName = ghfsIHelper.getUniqueBucketName("new-it");
     URI testBucketUri = new URI("gs://" + testBucketName);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -32,35 +32,26 @@ import java.util.logging.Logger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
 /** Unit tests for {@link GoogleHadoopFileSystem} class. */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegrationTest {
 
-  @ClassRule
-  public static NotInheritableExternalResource storageResource =
-      new NotInheritableExternalResource(GoogleHadoopFileSystemTest.class) {
-        @Override
-        public void before() throws Throwable {
-          // Disable logging.
-          // Normally you would need to keep a strong reference to any logger used for
-          // configuration, but the "root" logger is always present.
-          Logger.getLogger("").setLevel(Level.OFF);
+  @Before
+  public void before() throws IOException {
+    // Disable logging.
+    // Normally you would need to keep a strong reference to any logger used for
+    // configuration, but the "root" logger is always present.
+    Logger.getLogger("").setLevel(Level.OFF);
 
-          ghfs = GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem();
+    super.ghfs = GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem();
 
-          GoogleHadoopFileSystemIntegrationTest.postCreateInit();
-        }
-
-        @Override
-        public void after() {
-          GoogleHadoopFileSystemIntegrationTest.storageResource.after();
-        }
-      };
+    postCreateInit();
+  }
 
   @Test
   public void testVersionString() {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTestBase.java
@@ -23,7 +23,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationTest;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
@@ -40,7 +39,6 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 /**
@@ -75,16 +73,6 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     config.setBoolean("fs.gs.bucket.delete.enable", true);
     return config;
   }
-
-  @ClassRule
-  public static NotInheritableExternalResource storageResource =
-      new NotInheritableExternalResource(GoogleHadoopFileSystemTestBase.class) {
-        /** Perform clean-up once after all tests are turn. */
-        @Override
-        public void after() {
-          HadoopFileSystemTestBase.storageResource.after();
-        }
-      };
 
   // -----------------------------------------------------------------------------------------
   // Tests that vary according to the GHFS variant, but which we want to make sure get tested.
@@ -154,7 +142,7 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     String bucketName = sharedBucketName1;
     GoogleHadoopFileSystem myghfs = (GoogleHadoopFileSystem) ghfs;
     GoogleCloudStorageFileSystem gcsfs = myghfs.getGcsFs();
-    URI seedUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI seedUri = getTempFilePath();
     Path parentPath = ghfsHelper.castAsHadoopPath(seedUri);
     URI parentUri = myghfs.getGcsPath(parentPath);
 
@@ -179,7 +167,7 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     GoogleHadoopFileSystem myghfs = (GoogleHadoopFileSystem) ghfs;
     GoogleCloudStorageFileSystem gcsfs = myghfs.getGcsFs();
     GoogleCloudStorage gcs = gcsfs.getGcs();
-    URI seedUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI seedUri = getTempFilePath();
     Path dirPath = ghfsHelper.castAsHadoopPath(seedUri);
     URI dirUri = myghfs.getGcsPath(dirPath);
 
@@ -209,7 +197,7 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     GoogleCloudStorageFileSystem gcsfs = myghfs.getGcsFs();
     GoogleCloudStorage gcs = gcsfs.getGcs();
 
-    URI seedUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI seedUri = getTempFilePath();
     Path dirPath = ghfsHelper.castAsHadoopPath(seedUri);
     URI dirUri = myghfs.getGcsPath(dirPath);
     Path subDir = new Path(dirPath, "subdir");
@@ -242,7 +230,7 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     GoogleCloudStorageFileSystem gcsfs = myghfs.getGcsFs();
     GoogleCloudStorage gcs = gcsfs.getGcs();
 
-    URI seedUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI seedUri = getTempFilePath();
     Path dirPath = ghfsHelper.castAsHadoopPath(seedUri);
     URI dirUri = myghfs.getGcsPath(dirPath);
 
@@ -273,8 +261,7 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     GoogleCloudStorageFileSystem gcsfs = myghfs.getGcsFs();
     GoogleCloudStorage gcs = gcsfs.getGcs();
 
-    Path dirPath =
-        ghfsHelper.castAsHadoopPath(GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath());
+    Path dirPath = ghfsHelper.castAsHadoopPath(getTempFilePath());
     URI dirUri = myghfs.getGcsPath(dirPath);
     Path subDir = new Path(dirPath, "subdir");
     URI subdirUri = myghfs.getGcsPath(subDir);
@@ -441,7 +428,7 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
   @Test
   public void CopyFromLocalFileIOStatisticsTest() throws IOException {
     // Temporary file in GHFS.
-    URI tempFileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI tempFileUri = getTempFilePath();
     Path tempFilePath = ghfsHelper.castAsHadoopPath(tempFileUri);
     Path tempDirPath = tempFilePath.getParent();
     String text = "Hello World!";
@@ -490,14 +477,14 @@ public abstract class GoogleHadoopFileSystemTestBase extends HadoopFileSystemTes
     // Create test data.
 
     // Temporary file in GHFS.
-    URI tempFileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI tempFileUri = getTempFilePath();
     Path tempFilePath = ghfsHelper.castAsHadoopPath(tempFileUri);
     Path tempDirPath = tempFilePath.getParent();
     String text = "Hello World!";
     ghfsHelper.writeFile(tempFilePath, text, 1, /* overwrite= */ false);
 
     // Another temporary file in GHFS.
-    URI tempFileUri2 = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI tempFileUri2 = getTempFilePath();
     Path tempFilePath2 = ghfsHelper.castAsHadoopPath(tempFileUri2);
 
     // Temporary file in local FS.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemXAttrsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemXAttrsIntegrationTest.java
@@ -38,9 +38,9 @@ import org.apache.hadoop.fs.XAttrSetFlag;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.runners.JUnit4;
 
-@RunWith(Parameterized.class)
+@RunWith(JUnit4.class)
 public final class GoogleHadoopFileSystemXAttrsIntegrationTest extends HadoopFileSystemTestBase {
 
   @Before
@@ -51,7 +51,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest extends HadoopFil
 
     // loadConfig needs ghfsHelper, which is normally created in
     // postCreateInit. Create one here for it to use.
-    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl);
+    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs);
 
     URI initUri = new URI("gs://" + ghfsHelper.getUniqueBucketName("init"));
     ghfs.initialize(initUri, GoogleHadoopFileSystemTestBase.loadConfig());
@@ -61,22 +61,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest extends HadoopFil
       testInstance.getGcsFs();
     }
 
-    super.postCreateInit();
-  }
-
-  /*  @Override
-  public void postCreateInit() throws IOException {
-    postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs));
-  }*/
-
-  /** Perform initialization after creating test instances. */
-  public void postCreateInit(HadoopFileSystemIntegrationHelper helper) throws IOException {
-    ghfsHelper = helper;
-    ghfsHelper.ghfs.mkdirs(new Path(ghfsHelper.ghfs.getUri()));
-    super.postCreateInit(ghfsHelper);
-
-    // Ensures that we do not accidentally end up testing wrong functionality.
-    gcsfs = null;
+    postCreateInit();
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemXAttrsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemXAttrsIntegrationTest.java
@@ -51,7 +51,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest extends HadoopFil
 
     // loadConfig needs ghfsHelper, which is normally created in
     // postCreateInit. Create one here for it to use.
-    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs);
+    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl);
 
     URI initUri = new URI("gs://" + ghfsHelper.getUniqueBucketName("init"));
     ghfs.initialize(initUri, GoogleHadoopFileSystemTestBase.loadConfig());
@@ -64,10 +64,10 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest extends HadoopFil
     super.postCreateInit();
   }
 
-  @Override
+  /*  @Override
   public void postCreateInit() throws IOException {
     postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs));
-  }
+  }*/
 
   /** Perform initialization after creating test instances. */
   public void postCreateInit(HadoopFileSystemIntegrationHelper helper) throws IOException {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemXAttrsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemXAttrsIntegrationTest.java
@@ -21,7 +21,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationTest;
+import com.google.cloud.hadoop.gcsio.MethodOutcome;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.UpdatableItemInfo;
 import com.google.common.collect.ImmutableList;
@@ -33,38 +33,55 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.XAttrSetFlag;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
-@RunWith(JUnit4.class)
-public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
+@RunWith(Parameterized.class)
+public final class GoogleHadoopFileSystemXAttrsIntegrationTest extends HadoopFileSystemTestBase {
 
-  private static HadoopFileSystemIntegrationHelper ghfsHelper;
-  private static FileSystem ghfs;
+  @Before
+  public void before() throws Exception {
 
-  @BeforeClass
-  public static void setup() throws Throwable {
-    GoogleHadoopFileSystemIntegrationTest.storageResource.before();
-    ghfsHelper = GoogleHadoopFileSystemIntegrationTest.ghfsHelper;
-    ghfs = GoogleHadoopFileSystemIntegrationTest.ghfs;
+    GoogleHadoopFileSystem testInstance = new GoogleHadoopFileSystem();
+    ghfs = testInstance;
+
+    // loadConfig needs ghfsHelper, which is normally created in
+    // postCreateInit. Create one here for it to use.
+    ghfsHelper = new HadoopFileSystemIntegrationHelper(ghfs);
+
+    URI initUri = new URI("gs://" + ghfsHelper.getUniqueBucketName("init"));
+    ghfs.initialize(initUri, GoogleHadoopFileSystemTestBase.loadConfig());
+
+    if (GoogleHadoopFileSystemConfiguration.GCS_LAZY_INITIALIZATION_ENABLE.get(
+        ghfs.getConf(), ghfs.getConf()::getBoolean)) {
+      testInstance.getGcsFs();
+    }
+
+    super.postCreateInit();
   }
 
-  @AfterClass
-  public static void cleanup() {
-    ghfs = null;
-    ghfsHelper = null;
-    GoogleHadoopFileSystemIntegrationTest.storageResource.after();
+  @Override
+  public void postCreateInit() throws IOException {
+    postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs));
+  }
+
+  /** Perform initialization after creating test instances. */
+  public void postCreateInit(HadoopFileSystemIntegrationHelper helper) throws IOException {
+    ghfsHelper = helper;
+    ghfsHelper.ghfs.mkdirs(new Path(ghfsHelper.ghfs.getUri()));
+    super.postCreateInit(ghfsHelper);
+
+    // Ensures that we do not accidentally end up testing wrong functionality.
+    gcsfs = null;
   }
 
   @Test
   public void getXAttr_nonExistentAttr() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-get-xattr", 1, /* overwrite= */ false);
 
@@ -79,7 +96,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void getXAttr_returnEmptyMapOnEmptyNames() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-get-xattr", 1, /* overwrite= */ false);
 
@@ -94,7 +111,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
   @Test
   public void getXAttr_nonGhfsMetadata() throws Exception {
     GoogleCloudStorageFileSystem gcsFs = ((GoogleHadoopFileSystem) ghfs).getGcsFs();
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
 
     ghfsHelper.writeFile(filePath, "obj-test-get-xattr-extra", 1, /* overwrite= */ false);
@@ -120,7 +137,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-set-xattr", 1, /* overwrite= */ false);
 
@@ -155,7 +172,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr_throwsExceptionOnNullFlags() {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     Throwable exception =
         assertThrows(
@@ -166,7 +183,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr_throwsExceptionOnEmptyFlags() {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     EnumSet<XAttrSetFlag> emptyFlags = EnumSet.noneOf(XAttrSetFlag.class);
     Throwable exception =
@@ -178,7 +195,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr_replace() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-set-xattr-replace", 1, /* overwrite= */ false);
 
@@ -198,7 +215,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr_create_fail() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-set-xattr-create-fail", 1, /* overwrite= */ false);
 
@@ -217,7 +234,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr_replace_fail() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-set-xattr-replace-fail", 1, /* overwrite= */ false);
 
@@ -237,7 +254,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void setXAttr_throwsExceptionOnFlagsNull() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-set-xattr-create-fail", 1, /* overwrite= */ false);
     Throwable e =
@@ -253,7 +270,7 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
   @Test
   public void removeXAttr() throws Exception {
-    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    URI fileUri = getTempFilePath();
     Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
     ghfsHelper.writeFile(filePath, "obj-test-remove-xattr", 1, /* overwrite= */ false);
 
@@ -273,6 +290,21 @@ public final class GoogleHadoopFileSystemXAttrsIntegrationTest {
 
     // Cleanup.
     assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  @Override
+  public void testRename() throws Exception {
+    renameHelper(
+        new HdfsBehavior() {
+          /**
+           * Returns the MethodOutcome of trying to rename an existing file into the root directory.
+           */
+          @Override
+          public MethodOutcome renameFileIntoRootOutcome() {
+            return new MethodOutcome(MethodOutcome.Type.RETURNS_TRUE);
+          }
+        });
   }
 
   private static Map<String, String> toStringValuesMap(Map<String, byte[]> map) {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationHelper.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationHelper.java
@@ -27,7 +27,6 @@ import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationHelper;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions.ClientType;
 import com.google.cloud.hadoop.gcsio.UriPaths;
 import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
 import java.io.FileNotFoundException;
@@ -67,14 +66,11 @@ public class HadoopFileSystemIntegrationHelper
   // FS statistics mode of the FS tested by this class.
   FileSystemStatistics statistics = FileSystemStatistics.IGNORE;
 
-  public HadoopFileSystemIntegrationHelper(FileSystem hfs, boolean testStorageClientImpl)
-      throws IOException {
+  public HadoopFileSystemIntegrationHelper(FileSystem hfs) throws IOException {
     super(
         new GoogleCloudStorageFileSystemImpl(
             InMemoryGoogleCloudStorage::new,
             GoogleCloudStorageFileSystemOptions.builder()
-                .setClientType(
-                    testStorageClientImpl ? ClientType.STORAGE_CLIENT : ClientType.HTTP_API_CLIENT)
                 .setCloudStorageOptions(getInMemoryGoogleCloudStorageOptions())
                 .build()));
     this.ghfs = hfs;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationHelper.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationHelper.java
@@ -27,6 +27,7 @@ import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationHelper;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions.ClientType;
 import com.google.cloud.hadoop.gcsio.UriPaths;
 import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
 import java.io.FileNotFoundException;
@@ -66,11 +67,14 @@ public class HadoopFileSystemIntegrationHelper
   // FS statistics mode of the FS tested by this class.
   FileSystemStatistics statistics = FileSystemStatistics.IGNORE;
 
-  public HadoopFileSystemIntegrationHelper(FileSystem hfs) throws IOException {
+  public HadoopFileSystemIntegrationHelper(FileSystem hfs, boolean testStorageClientImpl)
+      throws IOException {
     super(
         new GoogleCloudStorageFileSystemImpl(
             InMemoryGoogleCloudStorage::new,
             GoogleCloudStorageFileSystemOptions.builder()
+                .setClientType(
+                    testStorageClientImpl ? ClientType.STORAGE_CLIENT : ClientType.HTTP_API_CLIENT)
                 .setCloudStorageOptions(getInMemoryGoogleCloudStorageOptions())
                 .build()));
     this.ghfs = hfs;

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemIntegrationTest.java
@@ -60,44 +60,34 @@ public class HadoopFileSystemIntegrationTest extends HadoopFileSystemTestBase {
 
   @ClassRule public static TemporaryFolder folder = new TemporaryFolder();
 
-  @ClassRule
-  public static NotInheritableExternalResource storageResource =
-      new NotInheritableExternalResource(HadoopFileSystemIntegrationTest.class) {
-        /** Performs initialization once before tests are run. */
-        @Override
-        public void before() throws Throwable {
-          // Get info about the HDFS instance against which we run tests.
-          hdfsRoot = System.getenv(HDFS_ROOT);
+  @Override
+  public void before() throws IOException, URISyntaxException {
+    // Get info about the HDFS instance against which we run tests.
+    hdfsRoot = System.getenv(HDFS_ROOT);
 
-          if (isNullOrEmpty(hdfsRoot)) {
-            hdfsRoot = "file://" + folder.newFolder("hdfs_root").getAbsolutePath();
-          }
+    if (isNullOrEmpty(hdfsRoot)) {
+      hdfsRoot = "file://" + folder.newFolder("hdfs_root").getAbsolutePath();
+    }
 
-          // Create a FileSystem instance to access the given HDFS.
-          URI hdfsUri;
-          try {
-            hdfsUri = new URI(hdfsRoot);
-          } catch (URISyntaxException e) {
-            throw new AssertionError("Invalid HDFS path: " + hdfsRoot, e);
-          }
-          Configuration config = new Configuration();
-          config.set("fs.default.name", hdfsRoot);
-          ghfs = FileSystem.get(hdfsUri, config);
+    // Create a FileSystem instance to access the given HDFS.
+    URI hdfsUri;
+    try {
+      hdfsUri = new URI(hdfsRoot);
+    } catch (URISyntaxException e) {
+      throw new AssertionError("Invalid HDFS path: " + hdfsRoot, e);
+    }
+    Configuration config = new Configuration();
+    config.set("fs.default.name", hdfsRoot);
+    ghfs = FileSystem.get(hdfsUri, config);
 
-          postCreateInit();
-          ghfsHelper.setIgnoreStatistics(); // Multi-threaded code screws us up.
-        }
-
-        /** Perform clean-up once after all tests are turn. */
-        @Override
-        public void after() {
-          HadoopFileSystemTestBase.storageResource.after();
-        }
-      };
+    postCreateInit();
+    ghfsHelper.setIgnoreStatistics(); // Multi-threaded code screws us up.
+  }
 
   /** Perform initialization after creating test instances. */
-  public static void postCreateInit() throws IOException {
-    HadoopFileSystemTestBase.postCreateInit();
+  @Override
+  public void postCreateInit() throws IOException {
+    super.postCreateInit();
   }
 
   // -----------------------------------------------------------------

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
@@ -74,7 +74,7 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
 
   @Override
   public void postCreateInit() throws IOException {
-    postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs));
+    postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl));
   }
 
   /** Perform initialization after creating test instances. */

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
@@ -74,7 +74,7 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
 
   @Override
   public void postCreateInit() throws IOException {
-    postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs, testStorageClientImpl));
+    postCreateInit(new HadoopFileSystemIntegrationHelper(ghfs));
   }
 
   /** Perform initialization after creating test instances. */

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/WebHdfsIntegrationTest.java
@@ -23,12 +23,12 @@ import static org.junit.Assert.assertThrows;
 import com.google.cloud.hadoop.gcsio.MethodOutcome;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
 /**
  * Integration tests for HDFS.
@@ -44,7 +44,7 @@ import org.junit.runners.JUnit4;
  * the behavior of HDFS. The FileSystemDescriptor thus reroutes all the test methods through the
  * proper HDFS instance using webhdfs:/ paths.
  */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
 
   // Environment variable from which to get HDFS access info.
@@ -53,36 +53,26 @@ public class WebHdfsIntegrationTest extends HadoopFileSystemTestBase {
   // HDFS path (passed to the test through environment var).
   static String hdfsRoot;
 
-  @ClassRule
-  public static NotInheritableExternalResource storageResource =
-      new NotInheritableExternalResource(WebHdfsIntegrationTest.class) {
-        /** Performs initialization once before tests are run. */
-        @Override
-        public void before() throws Throwable {
-          // Get info about the HDFS instance against which we run tests.
-          hdfsRoot = System.getenv(WEBHDFS_ROOT);
-          assertThat(hdfsRoot).isNotNull();
+  @Override
+  public void before() throws IOException, URISyntaxException {
+    // Get info about the HDFS instance against which we run tests.
+    hdfsRoot = System.getenv(WEBHDFS_ROOT);
+    assertThat(hdfsRoot).isNotNull();
 
-          // Create a FileSystem instance to access the given HDFS.
-          URI hdfsUri = new URI(hdfsRoot);
-          Configuration config = new Configuration();
-          config.set("fs.default.name", hdfsRoot);
-          ghfs = FileSystem.get(hdfsUri, config);
+    // Create a FileSystem instance to access the given HDFS.
+    URI hdfsUri = new URI(hdfsRoot);
+    Configuration config = new Configuration();
+    config.set("fs.default.name", hdfsRoot);
+    ghfs = FileSystem.get(hdfsUri, config);
 
-          postCreateInit();
-          ghfsHelper.setIgnoreStatistics();
-        }
+    postCreateInit();
+    ghfsHelper.setIgnoreStatistics();
+  }
 
-        /** Perform clean-up once after all tests are turn. */
-        @Override
-        public void after() {
-          HadoopFileSystemTestBase.storageResource.after();
-        }
-      };
-
+  @Override
   /** Perform initialization after creating test instances. */
-  public static void postCreateInit() throws IOException {
-    HadoopFileSystemTestBase.postCreateInit();
+  public void postCreateInit() throws IOException {
+    super.postCreateInit();
   }
 
   // -----------------------------------------------------------------

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -25,6 +25,8 @@ import com.google.api.client.http.HttpTransport;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoBuilder;
 import com.google.cloud.hadoop.util.AccessBoundary;
+import com.google.cloud.hadoop.util.ErrorTypeExtractor;
+import com.google.cloud.hadoop.util.GRPCErrorTypeExtractor;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
@@ -51,6 +53,8 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
 
   private final GoogleCloudStorageOptions storageOptions;
   private final Storage storage;
+
+  private final ErrorTypeExtractor errorExtractor;
 
   // Thread-pool used for background tasks.
   private ExecutorService backgroundTasksThreadPool =
@@ -80,6 +84,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
             .setDownscopedAccessTokenFn(downscopedAccessTokenFn)
             .build());
     this.storageOptions = options;
+    this.errorExtractor = GRPCErrorTypeExtractor.INSTANCE;
     this.storage =
         clientLibraryStorage == null ? createStorage(credentials, options) : clientLibraryStorage;
   }
@@ -134,7 +139,10 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
       GoogleCloudStorageReadOptions readOptions)
       throws IOException {
     return new GoogleCloudStorageClientReadChannel(
-        storage, itemInfo == null ? getItemInfo(resourceId) : itemInfo, readOptions);
+        storage,
+        itemInfo == null ? getItemInfo(resourceId) : itemInfo,
+        readOptions,
+        errorExtractor);
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -26,7 +26,7 @@ import com.google.auth.Credentials;
 import com.google.auto.value.AutoBuilder;
 import com.google.cloud.hadoop.util.AccessBoundary;
 import com.google.cloud.hadoop.util.ErrorTypeExtractor;
-import com.google.cloud.hadoop.util.GRPCErrorTypeExtractor;
+import com.google.cloud.hadoop.util.GrpcErrorTypeExtractor;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
@@ -84,7 +84,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
             .setDownscopedAccessTokenFn(downscopedAccessTokenFn)
             .build());
     this.storageOptions = options;
-    this.errorExtractor = GRPCErrorTypeExtractor.INSTANCE;
+    this.errorExtractor = GrpcErrorTypeExtractor.INSTANCE;
     this.storage =
         clientLibraryStorage == null ? createStorage(credentials, options) : clientLibraryStorage;
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -32,6 +32,7 @@ import com.google.cloud.ReadChannel;
 import com.google.cloud.hadoop.gcsio.FakeReadChannel.REQUEST_TYPE;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
+import com.google.cloud.hadoop.util.GRPCErrorTypeExtractor;
 import com.google.cloud.storage.Storage;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
@@ -529,6 +530,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     if (itemInfo == null) {
       objectInfo = DEFAULT_ITEM_INFO;
     }
-    return new GoogleCloudStorageClientReadChannel(mockedStorage, objectInfo, readOptions);
+    return new GoogleCloudStorageClientReadChannel(
+        mockedStorage, objectInfo, readOptions, GRPCErrorTypeExtractor.INSTANCE);
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -32,7 +32,7 @@ import com.google.cloud.ReadChannel;
 import com.google.cloud.hadoop.gcsio.FakeReadChannel.REQUEST_TYPE;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
-import com.google.cloud.hadoop.util.GRPCErrorTypeExtractor;
+import com.google.cloud.hadoop.util.GrpcErrorTypeExtractor;
 import com.google.cloud.storage.Storage;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
@@ -531,6 +531,6 @@ public class GoogleCloudStorageClientReadChannelTest {
       objectInfo = DEFAULT_ITEM_INFO;
     }
     return new GoogleCloudStorageClientReadChannel(
-        mockedStorage, objectInfo, readOptions, GRPCErrorTypeExtractor.INSTANCE);
+        mockedStorage, objectInfo, readOptions, GrpcErrorTypeExtractor.INSTANCE);
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationHelper.java
@@ -18,6 +18,7 @@ package com.google.cloud.hadoop.gcsio;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions.ClientType;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
 import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import java.io.IOException;
@@ -43,6 +44,10 @@ public class GoogleCloudStorageFileSystemIntegrationHelper
             .setBucketDeleteEnabled(true)
             .setCloudStorageOptions(gcsOptions)
             .build());
+  }
+
+  public static ClientType getClientType(boolean testStorageClient) {
+    return testStorageClient ? ClientType.STORAGE_CLIENT : ClientType.HTTP_API_CLIENT;
   }
 
   public static GoogleCloudStorageFileSystemIntegrationHelper create() throws IOException {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -188,7 +188,6 @@ public abstract class GoogleCloudStorageFileSystemIntegrationTest {
       assertWithMessage(
               "getModificationTime for bucketName '%s' objectName '%s'", bucketName, objectName)
           .that(fileModificationTime)
-              //.isAtLeast(testStartTime);
           .isAtLeast(Instant.ofEpochMilli(testStartTime.toEpochMilli()));
       assertWithMessage(
               "getModificationTime for bucketName '%s' objectName '%s'", bucketName, objectName)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -188,7 +188,8 @@ public abstract class GoogleCloudStorageFileSystemIntegrationTest {
       assertWithMessage(
               "getModificationTime for bucketName '%s' objectName '%s'", bucketName, objectName)
           .that(fileModificationTime)
-          .isAtLeast(testStartTime);
+              //.isAtLeast(testStartTime);
+          .isAtLeast(Instant.ofEpochMilli(testStartTime.toEpochMilli()));
       assertWithMessage(
               "getModificationTime for bucketName '%s' objectName '%s'", bucketName, objectName)
           .that(fileModificationTime)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -24,7 +24,6 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertThrows;
 
 import com.google.auth.Credentials;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions.ClientType;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper;
 import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
@@ -61,7 +60,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 /** Integration tests for GoogleCloudStorageFileSystem class. */
 @RunWith(Parameterized.class)
-public abstract class GoogleCloudStorageFileSystemIntegrationTest {
+public class GoogleCloudStorageFileSystemIntegrationTest {
 
   @Parameterized.Parameter public boolean testStorageClientImpl;
 
@@ -102,8 +101,8 @@ public abstract class GoogleCloudStorageFileSystemIntegrationTest {
 
       optionsBuilder
           .setClientType(
-              testStorageClientImpl ? ClientType.STORAGE_CLIENT : ClientType.HTTP_API_CLIENT)
-          .setBucketDeleteEnabled(testStorageClientImpl)
+              GoogleCloudStorageFileSystemIntegrationHelper.getClientType(testStorageClientImpl))
+          .setBucketDeleteEnabled(true)
           .setCloudStorageOptions(
               GoogleCloudStorageOptions.builder()
                   .setAppName(GoogleCloudStorageTestHelper.APP_NAME)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage.getInMemoryGoogleCloudStorageOptions;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.RequesterPaysOptions;
 import java.io.IOException;
@@ -29,6 +31,9 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -40,6 +45,26 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class GoogleCloudStorageFileSystemTest extends GoogleCloudStorageFileSystemIntegrationTest {
+
+  @Before
+  @Override
+  public void before() throws Exception {
+    // Disable logging.
+    // Normally you would need to keep a strong reference to any logger used for
+    // configuration, but the "root" logger is always present.
+    Logger.getLogger("").setLevel(Level.OFF);
+    if (gcsfs == null) {
+      gcsfs =
+          new GoogleCloudStorageFileSystemImpl(
+              InMemoryGoogleCloudStorage::new,
+              GoogleCloudStorageFileSystemOptions.builder()
+                  .setCloudStorageOptions(getInMemoryGoogleCloudStorageOptions())
+                  .setMarkerFilePattern("_(FAILURE|SUCCESS)")
+                  .build());
+      gcs = gcsfs.getGcs();
+      postCreateInit();
+    }
+  }
 
   /**
    * Helper to fill out some default valid options after which the caller may want to reset a few

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
@@ -35,15 +35,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * The unittest version of {@code GoogleCloudStorageFileSystemIntegrationTest}; the external
  * GoogleCloudStorage dependency is replaced by an in-memory version which mimics the same
  * bucket/object semantics.
  */
-@RunWith(Parameterized.class)
 public class GoogleCloudStorageFileSystemTest extends GoogleCloudStorageFileSystemIntegrationTest {
 
   @Before

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTest.java
@@ -16,13 +16,11 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage.getInMemoryGoogleCloudStorageOptions;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.RequesterPaysOptions;
 import java.io.IOException;
@@ -31,49 +29,17 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
 
 /**
  * The unittest version of {@code GoogleCloudStorageFileSystemIntegrationTest}; the external
  * GoogleCloudStorage dependency is replaced by an in-memory version which mimics the same
  * bucket/object semantics.
  */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class GoogleCloudStorageFileSystemTest extends GoogleCloudStorageFileSystemIntegrationTest {
-
-  @ClassRule
-  public static NotInheritableExternalResource storageResource =
-      new NotInheritableExternalResource(GoogleCloudStorageFileSystemTest.class) {
-        @Override
-        public void before() throws IOException {
-          // Disable logging.
-          // Normally you would need to keep a strong reference to any logger used for
-          // configuration, but the "root" logger is always present.
-          Logger.getLogger("").setLevel(Level.OFF);
-
-          if (gcsfs == null) {
-            gcsfs =
-                new GoogleCloudStorageFileSystemImpl(
-                    InMemoryGoogleCloudStorage::new,
-                    GoogleCloudStorageFileSystemOptions.builder()
-                        .setCloudStorageOptions(getInMemoryGoogleCloudStorageOptions())
-                        .setMarkerFilePattern("_(FAILURE|SUCCESS)")
-                        .build());
-            gcs = gcsfs.getGcs();
-            GoogleCloudStorageFileSystemIntegrationTest.postCreateInit();
-          }
-        }
-
-        @Override
-        public void after() {
-          GoogleCloudStorageFileSystemIntegrationTest.storageResource.after();
-        }
-      };
 
   /**
    * Helper to fill out some default valid options after which the caller may want to reset a few

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class GoogleCloudStorageIntegrationHelper {
 
   // Prefix used for naming test buckets.
-  private static final String TEST_BUCKET_NAME_PREFIX = "gcsio-test";
+  private static final String TEST_BUCKET_NAME_PREFIX = "gcs-grpc-team_gcsio";
 
   private final TestBucketHelper bucketHelper = new TestBucketHelper(TEST_BUCKET_NAME_PREFIX);
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageIntegrationHelper.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class GoogleCloudStorageIntegrationHelper {
 
   // Prefix used for naming test buckets.
-  private static final String TEST_BUCKET_NAME_PREFIX = "gcs-grpc-team_gcsio";
+  private static final String TEST_BUCKET_NAME_PREFIX = "dataproc-gcs-gcsio";
 
   private final TestBucketHelper bucketHelper = new TestBucketHelper(TEST_BUCKET_NAME_PREFIX);
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTest.java
@@ -692,7 +692,9 @@ public class GoogleCloudStorageNewIntegrationTest {
   public void listObjectInfo_includePrefix_implicitDirInBucket() throws Exception {
     GoogleCloudStorage gcs = createGoogleCloudStorage(gcsOptions);
 
-    String testBucket = gcsfsIHelper.createUniqueBucket("lst-objs_incl-pfx_impl-dir-in-bckt");
+    String testBucket =
+        gcsfsIHelper.createUniqueBucket(
+            UUID.randomUUID().toString().replaceAll("-", "").substring(0, 10));
     gcsfsIHelper.createObjects(testBucket, "implDir/obj");
 
     List<GoogleCloudStorageItemInfo> listedObjects =

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -83,5 +83,9 @@
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/util/src/main/java/com/google/cloud/hadoop/util/ErrorType.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/ErrorType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+public enum ErrorType {
+  NON_FOUND,
+  OUT_OF_RANGE,
+  UNKNOWN
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/ErrorTypeExtractor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/ErrorTypeExtractor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+public interface ErrorTypeExtractor {
+  public ErrorType getErrorType(Exception exception);
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GRPCErrorTypeExtractor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GRPCErrorTypeExtractor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import io.grpc.Status;
+
+public class GRPCErrorTypeExtractor implements ErrorTypeExtractor {
+
+  public static final GRPCErrorTypeExtractor INSTANCE = new GRPCErrorTypeExtractor();
+
+  @Override
+  public ErrorType getErrorType(Exception error) {
+    switch (Status.fromThrowable(error).getCode()) {
+      case NOT_FOUND:
+        return ErrorType.NON_FOUND;
+      case OUT_OF_RANGE:
+        return ErrorType.OUT_OF_RANGE;
+      default:
+        return ErrorType.UNKNOWN;
+    }
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GrpcErrorTypeExtractor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GrpcErrorTypeExtractor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import io.grpc.Status;
+
+public class GrpcErrorTypeExtractor implements ErrorTypeExtractor {
+
+  public static final GrpcErrorTypeExtractor INSTANCE = new GrpcErrorTypeExtractor();
+
+  private GrpcErrorTypeExtractor() {}
+
+  @Override
+  public ErrorType getErrorType(Exception error) {
+    switch (Status.fromThrowable(error).getCode()) {
+      case NOT_FOUND:
+        return ErrorType.NON_FOUND;
+      case OUT_OF_RANGE:
+        return ErrorType.OUT_OF_RANGE;
+      default:
+        return ErrorType.UNKNOWN;
+    }
+  }
+}

--- a/util/src/test/java/com/google/cloud/hadoop/util/GrpcErrorTypeExtractorTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/GrpcErrorTypeExtractorTest.java
@@ -16,21 +16,25 @@
 
 package com.google.cloud.hadoop.util;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.Test;
 
-public class GRPCErrorTypeExtractor implements ErrorTypeExtractor {
+public class GrpcErrorTypeExtractorTest {
 
-  public static final GRPCErrorTypeExtractor INSTANCE = new GRPCErrorTypeExtractor();
+  private static final GrpcErrorTypeExtractor typeExtractor = GrpcErrorTypeExtractor.INSTANCE;
 
-  @Override
-  public ErrorType getErrorType(Exception error) {
-    switch (Status.fromThrowable(error).getCode()) {
-      case NOT_FOUND:
-        return ErrorType.NON_FOUND;
-      case OUT_OF_RANGE:
-        return ErrorType.OUT_OF_RANGE;
-      default:
-        return ErrorType.UNKNOWN;
-    }
+  @Test
+  public void testNotFound() {
+    Exception ex = new StatusRuntimeException(Status.NOT_FOUND);
+    assertThat(typeExtractor.getErrorType(ex)).isEqualTo(ErrorType.NON_FOUND);
+  }
+
+  @Test
+  public void testOutOfRange() {
+    Exception ex = new StatusRuntimeException(Status.OUT_OF_RANGE);
+    assertThat(typeExtractor.getErrorType(ex)).isEqualTo(ErrorType.OUT_OF_RANGE);
   }
 }


### PR DESCRIPTION
1. Added support to use new StorageCLient library using flag `fs.gs.client.type`.
2. Also updated the tests fro GCSFS and GHFS as https://github.com/junit-team/junit4/issues/1509 is resolved now.