### PR TITLE
Shade re2j dependency (used by gRPC)

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -251,10 +251,10 @@
                     <include>com.google.longrunning.**</include>
                     <include>com.google.protobuf.**</include>
                     <include>com.google.rpc.**</include>
+                    <include>com.google.re2j.**</include>
                     <include>com.google.storage.**</include>
                     <include>com.google.thirdparty.**</include>
                     <include>com.google.type.**</include>
-                    <include>com.google.re2j.**</include>
                     <include>com.lmax.disruptor.**</include>
                   </includes>
                   <excludes>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -250,8 +250,8 @@
                     <include>com.google.logging.**</include>
                     <include>com.google.longrunning.**</include>
                     <include>com.google.protobuf.**</include>
-                    <include>com.google.rpc.**</include>
                     <include>com.google.re2j.**</include>
+                    <include>com.google.rpc.**</include>
                     <include>com.google.storage.**</include>
                     <include>com.google.thirdparty.**</include>
                     <include>com.google.type.**</include>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -220,6 +220,7 @@
                   <include>com.google.http-client</include>
                   <include>com.google.oauth-client</include>
                   <include>com.google.protobuf</include>
+                  <include>com.google.re2j</include>
                   <include>com.google.storage.v2</include>
                   <include>com.lmax</include>
                   <include>io.grpc</include>
@@ -253,6 +254,7 @@
                     <include>com.google.storage.**</include>
                     <include>com.google.thirdparty.**</include>
                     <include>com.google.type.**</include>
+                    <include>com.google.re2j.**</include>
                     <include>com.lmax.disruptor.**</include>
                   </includes>
                   <excludes>


### PR DESCRIPTION
For debian11 re2j seems to me missing as it's a required jar for connector shading it.

```
 23/02/15 19:05:02 ERROR ManagedChannelImpl: [Channel<1>: (google-c2p-experimental:///storage.googleapis.com)] Uncaught exception in the SynchronizationContext. Panic!
 java.lang.NoClassDefFoundError: com/google/re2j/PatternSyntaxException
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.xds.ClientXdsClient.<init>(ClientXdsClient.java:102) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.xds.SharedXdsClientPoolProvider$RefCountedXdsClientObjectPool.getObject(SharedXdsClientPoolProvider.java:126) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.xds.SharedXdsClientPoolProvider$RefCountedXdsClientObjectPool.getObject(SharedXdsClientPoolProvider.java:103) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.xds.XdsNameResolver.start(XdsNameResolver.java:186) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.googleapis.GoogleCloudToProdNameResolver$1Resolve$1.run(GoogleCloudToProdNameResolver.java:162) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.SynchronizationContext.drain(SynchronizationContext.java:95) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.SynchronizationContext.execute(SynchronizationContext.java:127) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at com.google.cloud.hadoop.repackaged.gcs.io.grpc.googleapis.GoogleCloudToProdNameResolver$1Resolve.run(GoogleCloudToProdNameResolver.java:157) ~[gcs-connector-hadoop3-2.2.11.jar:?]
 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
 	at java.lang.Thread.run(Thread.java:829) ~[?:?]
 Caused by: java.lang.ClassNotFoundException: com.google.re2j.PatternSyntaxException
 	at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581) ~[?:?]
 	at jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178) ~[?:?]
 	at java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
 	... 11 more
```