### PR TITLE
disabled TD only for CloudBuild

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -43,6 +43,7 @@ steps:
       - 'VCS_COMMIT_ID=$COMMIT_SHA'
       - 'VCS_TAG=$TAG_NAME'
       - 'CI_BUILD_ID=$BUILD_ID'
+      - 'TRAFFIC_DIRECTOR_ENABLED=false'
 
   # 5. Run Hadoop 3 integration tests concurrently with Hadoop 2 integration tests
   - name: 'gcr.io/$PROJECT_ID/dataproc-hadoop-connectors-presubmit'
@@ -57,6 +58,7 @@ steps:
       - 'VCS_COMMIT_ID=$COMMIT_SHA'
       - 'VCS_TAG=$TAG_NAME'
       - 'CI_BUILD_ID=$BUILD_ID'
+      - 'TRAFFIC_DIRECTOR_ENABLED=false'
 
 # Tests take on average 25 minutes to run
 timeout: 2400s

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
@@ -22,6 +22,8 @@ public abstract class TestConfiguration {
 
   public static final String GCS_TEST_JSON_KEYFILE = "GCS_TEST_JSON_KEYFILE";
 
+  public static final String TRAFFIC_DIRECTOR_ENABLED = "TRAFFIC_DIRECTOR_ENABLED";
+
   /** Environment-based test configuration. */
   public static class EnvironmentBasedTestConfiguration extends TestConfiguration {
     @Override
@@ -43,6 +45,16 @@ public abstract class TestConfiguration {
     public String getServiceAccountJsonKeyFile() {
       return System.getenv(GCS_TEST_JSON_KEYFILE);
     }
+
+    /** By default, TD is enabled unless specified specifically. */
+    @Override
+    public boolean isTrafficDirector() {
+      String td = System.getenv(TRAFFIC_DIRECTOR_ENABLED);
+      if (td != null && td.equalsIgnoreCase("false")) {
+        return false;
+      }
+      return true;
+    }
   }
 
   public static TestConfiguration getInstance() {
@@ -60,4 +72,6 @@ public abstract class TestConfiguration {
   public abstract String getPrivateKeyFile();
 
   public abstract String getServiceAccountJsonKeyFile();
+
+  public abstract boolean isTrafficDirector();
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -79,7 +79,7 @@ public class GoogleCloudStorageGrpcIntegrationTest {
   private final boolean tdEnabled;
 
   @Parameters
-  // TODO: Disabled TD for cloud-build b/274371396 enable once resolved.
+  // TODO: Disabled TD for cloud-build issues/956 enable once resolved.
   public static Iterable<Boolean> tdEnabled() {
     return ImmutableList.of(TEST_CONFIGURATION.isTrafficDirector());
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageGrpcIntegrationTest.java
@@ -41,6 +41,7 @@ import com.google.cloud.hadoop.gcsio.GoogleCloudStorageTestUtils;
 import com.google.cloud.hadoop.gcsio.GrpcRequestTracingInfo;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
+import com.google.cloud.hadoop.gcsio.testing.TestConfiguration;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.GoogleLogger;
@@ -65,6 +66,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class GoogleCloudStorageGrpcIntegrationTest {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  public static final TestConfiguration TEST_CONFIGURATION = TestConfiguration.getInstance();
 
   // Prefix this name with the prefix used in other gcs io integrate tests once it's whitelisted by
   // GCS to access gRPC API.
@@ -77,10 +79,9 @@ public class GoogleCloudStorageGrpcIntegrationTest {
   private final boolean tdEnabled;
 
   @Parameters
-  // Falling back to gRPC-LB for now as TD has issue with CloudBuild
-  // TODO: issues/956 Enabled TD once resolved.
+  // TODO: Disabled TD for cloud-build b/274371396 enable once resolved.
   public static Iterable<Boolean> tdEnabled() {
-    return ImmutableList.of(false);
+    return ImmutableList.of(TEST_CONFIGURATION.isTrafficDirector());
   }
 
   public GoogleCloudStorageGrpcIntegrationTest(boolean tdEnabled) {


### PR DESCRIPTION
Enabled traffic director by default and disabled it just for cloud-builds.