### PR TITLE
Add ability to set request reason

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -2196,6 +2196,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   <RequestT extends StorageRequest<?>> RequestT configureRequest(
       RequestT request, String bucketName) {
     setRequesterPaysProject(request, bucketName);
+    setRequestReason(request);
+
 
     if (request instanceof Storage.Objects.Get || request instanceof Storage.Objects.Insert) {
       setEncryptionHeaders(request);
@@ -2207,6 +2209,10 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     }
 
     return request;
+  }
+
+  private <RequestT extends StorageRequest<?>> void setRequestReason(RequestT request) {
+    request.getRequestHeaders().set("x-goog-request-reason", storageOptions.getRequestReason());
   }
 
   private <RequestT extends StorageRequest<?>> void setEncryptionHeaders(RequestT request) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -119,6 +119,9 @@ public abstract class GoogleCloudStorageOptions {
   @Nullable
   public abstract RedactedString getProxyPassword();
 
+  @Nullable
+  public abstract String getRequestReason();
+
   public abstract boolean isCopyWithRewriteEnabled();
 
   public abstract long getMaxRewriteChunkSize();
@@ -221,6 +224,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setEncryptionKey(RedactedString encryptionKey);
 
     public abstract Builder setEncryptionKeyHash(RedactedString encryptionKeyHash);
+
+    public abstract Builder setRequestReason(String reason);
 
     public abstract Builder setGrpcMessageTimeoutCheckInterval(
         Duration grpcMessageTimeoutInMillisCheckInterval);


### PR DESCRIPTION
Request reason is a very powerful tool for clients to  add custom information into the audit logs. https://cloud.google.com/apis/docs/system-parameters
This PR provides a base to clients to build upon