### PR TITLE
fixed write inconsistency in gRPC implementation

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageContentWriteStream.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageContentWriteStream.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.flogger.GoogleLogger;
+import com.google.storage.v2.StorageGrpc;
+import com.google.storage.v2.StorageGrpc.StorageStub;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import io.grpc.ClientCall;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Manages WriteObject rpc stream. Provide operation for opening, writing and closing the stream.
+ */
+@VisibleForTesting
+public class GoogleCloudStorageContentWriteStream {
+
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+  // A set that defines all transient errors on which retry can be attempted.
+  protected static final ImmutableSet<Code> TRANSIENT_ERRORS =
+      ImmutableSet.of(
+          Status.Code.DEADLINE_EXCEEDED,
+          Status.Code.INTERNAL,
+          Status.Code.RESOURCE_EXHAUSTED,
+          Status.Code.UNAVAILABLE);
+
+  private final StorageResourceId resourceId;
+  private final StorageStub stub;
+  private final GoogleCloudStorageOptions storageOptions;
+  private final AsyncWriteChannelOptions channelOptions;
+  private final String uploadId;
+  private final long writeOffset;
+  private final Watchdog watchdog;
+
+  private InsertChunkResponseObserver responseObserver;
+  private InsertChunkRequestObserver requestStreamObserver;
+  // Keeps track of number of request sent over stream.
+  private int inflightRequests = 0;
+
+  public GoogleCloudStorageContentWriteStream(
+      StorageResourceId resourceId,
+      GoogleCloudStorageOptions storageOptions,
+      StorageStub stub,
+      String uploadId,
+      long writeOffset,
+      Watchdog watchdog) {
+    this.resourceId = resourceId;
+    this.stub = stub;
+    this.uploadId = uploadId;
+    this.writeOffset = writeOffset;
+    this.responseObserver = new InsertChunkResponseObserver(uploadId, writeOffset);
+    this.storageOptions = storageOptions;
+    this.channelOptions = storageOptions.getWriteChannelOptions();
+    this.watchdog = watchdog;
+  }
+
+  public void openStream() throws IOException {
+    if (isOpen()) {
+      throw new IOException(
+          String.format(
+              "Stream is already open for resourceId %s with uploadId %s and writeOffset %d",
+              resourceId, uploadId, writeOffset));
+    }
+    try {
+      StorageStub storageStub = getStorageStubWithTracking(channelOptions.getGrpcWriteTimeout());
+      ClientCall clientCall =
+          storageStub
+              .getChannel()
+              .newCall(StorageGrpc.getWriteObjectMethod(), stub.getCallOptions());
+      StreamObserver<WriteObjectRequest> writeObjectRequestStreamObserver =
+          ClientCalls.asyncClientStreamingCall(clientCall, responseObserver);
+
+      // Wait for streaming RPC to become ready for upload.
+      // wait for 1 min for the channel to be ready. Else bail out
+      if (!responseObserver.ready.await(60 * 1000, MILLISECONDS)) {
+        throw new IOException(
+            String.format(
+                "Timed out while awaiting ready on responseObserver for '%s' with UploadID '%s' and writeOffset %d",
+                resourceId, responseObserver.uploadId, writeOffset));
+      }
+
+      this.requestStreamObserver =
+          new InsertChunkRequestObserver(
+              watchdog.watch(
+                  clientCall,
+                  writeObjectRequestStreamObserver,
+                  channelOptions.getGrpcWriteMessageTimeout()));
+
+    } catch (IOException e) {
+      throw e;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(
+          String.format(
+              "Interrupted while awaiting ready on responseObserver for '%s' with UploadID '%s' and writeOffset %d",
+              resourceId, responseObserver.uploadId, writeOffset));
+    } catch (Exception e) {
+      throw new IOException(
+          String.format(
+              "Exception while awaiting ready on responseObserver for '%s' with UploadID '%s' and writeOffset %d",
+              resourceId, responseObserver.uploadId, writeOffset),
+          e);
+    }
+  }
+
+  private StorageStub getStorageStubWithTracking(Duration grpcWriteTimeout) {
+    StorageStub stubWithDeadline =
+        stub.withDeadlineAfter(grpcWriteTimeout.toMillis(), MILLISECONDS);
+
+    if (!this.storageOptions.isTraceLogEnabled()) {
+      return stubWithDeadline;
+    }
+
+    return stubWithDeadline.withInterceptors(
+        new GoogleCloudStorageGrpcTracingInterceptor(
+            GrpcRequestTracingInfo.getWriteRequestTraceInfo(this.resourceId.getObjectName())));
+  }
+
+  public void writeChunk(WriteObjectRequest request) throws IOException {
+    if (!isOpen()) {
+      throw new IOException(
+          String.format(
+              "Can't write without stream being open for '%s' with UploadID '%s' and writeOffset %d",
+              resourceId, uploadId, writeOffset));
+    }
+    try {
+      requestStreamObserver.onNext(request);
+      inflightRequests += 1;
+      if (responseObserver.hasTransientError() || responseObserver.hasNonTransientError()) {
+        Throwable error =
+            responseObserver.hasTransientError()
+                ? responseObserver.transientError
+                : responseObserver.nonTransientError;
+        requestStreamObserver.onError(error);
+        throw new IOException(
+            String.format(
+                "Got transient error for '%s' with UploadID '%s' and writeOffset %d",
+                resourceId, responseObserver.uploadId, writeOffset),
+            error);
+      }
+    } catch (Exception e) {
+      throw new IOException(
+          String.format(
+              "Exception while writing chunk with offset %d for '%s' with UploadID '%s' and streams writeOffset %d",
+              request.getWriteOffset(), resourceId, responseObserver.uploadId, writeOffset),
+          e);
+    }
+  }
+
+  public int getInflightRequestCount() {
+    return inflightRequests;
+  }
+
+  public boolean isOpen() {
+    return (responseObserver != null
+            && responseObserver.isReady()
+            && !responseObserver.isComplete())
+        ? true
+        : false;
+  }
+
+  public WriteObjectResponse closeStream() throws IOException {
+    try {
+      // RequestStreamObserver might already be completed either
+      // 1. Error was encountered during writing chunks nad eventually onError was called
+      // 2. closeStream was called again.
+      // It safeguards us from calling onCompleted on an already closed stream.
+      if (!requestStreamObserver.isComplete()) {
+        requestStreamObserver.onCompleted();
+      }
+      responseObserver.done.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException(
+          String.format(
+              "Interrupted while awaiting response during upload of '%s' with UploadID '%s' and writeOffset %d",
+              resourceId, responseObserver.uploadId, writeOffset));
+    } catch (Exception e) {
+      throw new IOException(
+          String.format(
+              "Exception while marking response and requestObservers complete for '%s' with UploadID '%s' and writeOffset %d",
+              resourceId, responseObserver.uploadId, writeOffset),
+          e);
+    }
+    if (responseObserver.hasTransientError()) {
+      throw new IOException(
+          // pattern matching in unit-test GoogleCloudStorageContentWriteStreamTest
+          String.format(
+              "TRANSIENT-ERROR for '%s' with UploadID '%s' and writeOffset %d",
+              resourceId, responseObserver.uploadId, writeOffset),
+          responseObserver.transientError);
+    }
+    return responseObserver.getResponseOrThrow();
+  }
+
+  /** Handler for responses from the Insert streaming RPC. */
+  private class InsertChunkResponseObserver
+      implements ClientResponseObserver<WriteObjectRequest, WriteObjectResponse> {
+
+    private final long writeOffset;
+    private final String uploadId;
+
+    // The response from the server, populated at the end of a successful streaming RPC.
+    private WriteObjectResponse response;
+    // The last transient error to occur during the streaming RPC.
+    public Throwable transientError = null;
+    // The last non-transient error to occur during the streaming RPC.
+    public Throwable nonTransientError = null;
+    // CountDownLatch tracking completion of the streaming RPC. Set on error, or once the
+    // request stream is closed.
+    final CountDownLatch done = new CountDownLatch(1);
+    // CountDownLatch tracking readiness of the streaming RPC.
+    final CountDownLatch ready = new CountDownLatch(1);
+
+    InsertChunkResponseObserver(String uploadId, long writeOffset) {
+      this.uploadId = uploadId;
+      this.writeOffset = writeOffset;
+    }
+
+    public WriteObjectResponse getResponseOrThrow() throws IOException {
+      // TODO: throw only for nonTransient Error
+      if (hasNonTransientError()) {
+        throw new IOException(
+            // pattern matching in unit-test GoogleCloudStorageContentWriteStreamTest
+            String.format(
+                "NON-TRANSIENT-ERROR, resumable upload failed for '%s' , uploadId : %s, writeOffset : %d ",
+                resourceId, uploadId, writeOffset),
+            nonTransientError);
+      }
+      return checkNotNull(response, "Response not present for '%s'", resourceId);
+    }
+
+    boolean hasTransientError() {
+      return transientError != null;
+    }
+
+    boolean hasNonTransientError() {
+      return response == null && nonTransientError != null;
+    }
+
+    @Override
+    public void onNext(WriteObjectResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      Status status = Status.fromThrowable(t);
+      Status.Code statusCode = status.getCode();
+      if (TRANSIENT_ERRORS.contains(statusCode)) {
+        transientError = t;
+      }
+      if (transientError == null) {
+        nonTransientError =
+            new IOException(
+                String.format(
+                    "Caught exception for '%s', while uploading to uploadId %s at writeOffset %d."
+                        + " Status: %s",
+                    resourceId, uploadId, writeOffset, status.getDescription()),
+                t);
+      }
+      done.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+      done.countDown();
+    }
+
+    @Override
+    public void beforeStart(ClientCallStreamObserver<WriteObjectRequest> clientCallStreamObserver) {
+      clientCallStreamObserver.setOnReadyHandler(ready::countDown);
+    }
+
+    public boolean isComplete() {
+      return done.getCount() == 0 ? true : false;
+    }
+
+    public boolean isReady() {
+      return ready.getCount() == 0 ? true : false;
+    }
+  }
+
+  /**
+   * Wrapper around the requestStreamObserver to track the completeness of requestObserver. It does
+   * it by keeping track of count down latch and set it if Errored or Completed.
+   */
+  private class InsertChunkRequestObserver implements StreamObserver<WriteObjectRequest> {
+    private final StreamObserver<WriteObjectRequest> innerStreamObserver;
+    // CountDownLatch tracking completion of the streaming RPC. Set on error, or once the
+    // request stream is closed.
+    final CountDownLatch done = new CountDownLatch(1);
+
+    private InsertChunkRequestObserver(StreamObserver<WriteObjectRequest> innerStreamObserver) {
+      this.innerStreamObserver = innerStreamObserver;
+    }
+
+    @Override
+    public void onNext(WriteObjectRequest value) {
+      innerStreamObserver.onNext(value);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      done.countDown();
+      innerStreamObserver.onError(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      done.countDown();
+      innerStreamObserver.onCompleted();
+    }
+
+    public boolean isComplete() {
+      return done.getCount() < 1 ? true : false;
+    }
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageContentWriteStreamTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageContentWriteStreamTest.java
@@ -1,0 +1,540 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.auth.Credentials;
+import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.common.base.Throwables;
+import com.google.protobuf.ByteString;
+import com.google.storage.v2.ChecksummedData;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.StorageGrpc;
+import com.google.storage.v2.StorageGrpc.StorageImplBase;
+import com.google.storage.v2.StorageGrpc.StorageStub;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import com.google.storage.v2.WriteObjectResponse.WriteStatusCase;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.AbstractStub;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class GoogleCloudStorageContentWriteStreamTest {
+
+  private static final String V1_BUCKET_NAME = "bucket-name";
+  private static final String BUCKET_NAME = GrpcChannelUtils.toV2BucketName(V1_BUCKET_NAME);
+  private static final String OBJECT_NAME = "object-name";
+  private static final Status TRANSIENT_ERROR_STATUS = Status.INTERNAL;
+  private static final Status NON_TRANSIENT_ERROR_STATUS = Status.ALREADY_EXISTS;
+  private static final StorageResourceId RESOURCE_ID =
+      new StorageResourceId(V1_BUCKET_NAME, OBJECT_NAME);
+  private StorageStub stub;
+  private static final String UPLOAD_ID = "upload-id";
+  private static final AsyncWriteChannelOptions DEFAULT_OPTIONS =
+      AsyncWriteChannelOptions.builder().build();
+  @Mock private Credentials mockCredentials;
+  private Watchdog watchdog = Watchdog.create(Duration.ofMillis(100));
+
+  private FakeService fakeService;
+
+  private static final Object DEFAULT_OBJECT =
+      Object.newBuilder()
+          .setBucket(BUCKET_NAME)
+          .setName(OBJECT_NAME)
+          .setGeneration(1)
+          .setMetageneration(2)
+          .build();
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    fakeService = spy(new GoogleCloudStorageContentWriteStreamTest.FakeService());
+    String serverName = InProcessServerBuilder.generateName();
+    InProcessServerBuilder.forName(serverName)
+        .directExecutor()
+        .addService(fakeService)
+        .build()
+        .start();
+    stub =
+        StorageGrpc.newStub(
+            InProcessChannelBuilder.forName(serverName)
+                .propagateCauseWithStatus(true)
+                .directExecutor()
+                .build());
+  }
+
+  @Test
+  public void openStreamTest() throws IOException {
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(1);
+    contentWriteStream.closeStream();
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void streamNotOpenThrows() {
+    // Trying to write without opening stream
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest));
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void streamAlreadyOpenThrows() throws IOException {
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(1);
+    assertThrows(IOException.class, () -> contentWriteStream.openStream());
+  }
+
+  @Test
+  public void inflightRequestTest() throws IOException {
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    int chunksToWrite = 4;
+    int writeOffset = 0;
+    for (int i = 0; i < chunksToWrite; i++) {
+      ByteString data = ByteString.copyFromUtf8("test data");
+      WriteObjectRequest insertRequest = getInsertRequest(data, writeOffset);
+      contentWriteStream.writeChunk(insertRequest);
+      writeOffset += data.size();
+    }
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(1);
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(chunksToWrite);
+    contentWriteStream.closeStream();
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void writeChunkResponseThrows() throws IOException {
+    fakeService.setInsertRequestException(new IOException("ERROR!"));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest));
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void closeStreamWithFinalize() throws IOException {
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, /* writeOffset */ 0, true);
+    contentWriteStream.writeChunk(insertRequest);
+
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+
+    WriteObjectResponse response = contentWriteStream.closeStream();
+    assertThat(response.getWriteStatusCase()).isEqualTo(WriteStatusCase.RESOURCE);
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void closingAlreadyClosedStream() throws IOException {
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, /* writeOffset */ 0, true);
+    contentWriteStream.writeChunk(insertRequest);
+
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+
+    WriteObjectResponse response = contentWriteStream.closeStream();
+    assertThat(response.getWriteStatusCase()).isEqualTo(WriteStatusCase.RESOURCE);
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+    WriteObjectResponse duplicateResponse = contentWriteStream.closeStream();
+    assertThat(duplicateResponse).isEqualTo(response);
+  }
+
+  @Test
+  public void writingOnClosedStream() throws IOException {
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, /* writeOffset */ 0, false);
+    contentWriteStream.writeChunk(insertRequest);
+
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+
+    contentWriteStream.closeStream();
+
+    WriteObjectRequest insertRequest2 =
+        getInsertRequest(data, /* writeOffset */ data.size(), false);
+    IOException ioe =
+        assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest2));
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(Can't write without stream being open).*");
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void closeStreamWithoutFinalize() throws IOException {
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    contentWriteStream.writeChunk(insertRequest);
+    // Inserted chunk is not final
+    assertThat(insertRequest.getFinishWrite()).isFalse();
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+
+    WriteObjectResponse response = contentWriteStream.closeStream();
+    // Returned response in case of non-final chunk is of type PERSISTED_SIZE
+    assertThat(response.getWriteStatusCase()).isEqualTo(WriteStatusCase.PERSISTED_SIZE);
+    assertThat(response.getPersistedSize()).isEqualTo(data.size());
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void streamErroredOnCompleteNotCalled() throws IOException {
+    fakeService.setInsertRequestException(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest));
+
+    assertThrows(IOException.class, () -> contentWriteStream.closeStream());
+    verify(fakeService.insertRequestObserver, times(0)).onCompleted();
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void writeChunkErroredStreamCloses() throws IOException {
+    fakeService.setInsertRequestException(new StatusRuntimeException(Status.DEADLINE_EXCEEDED));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest));
+
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void transientErrorWriteChunk() throws IOException {
+    fakeService.setInsertRequestException(new StatusRuntimeException(TRANSIENT_ERROR_STATUS));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    IOException ioe =
+        assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest));
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(Exception while writing chunk).*");
+
+    ioe = assertThrows(IOException.class, () -> contentWriteStream.closeStream());
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(TRANSIENT-ERROR).*");
+    verify(fakeService.insertRequestObserver, times(0)).onCompleted();
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void nonTransientErrorWriteChunk() throws IOException {
+    fakeService.setInsertRequestException(new StatusRuntimeException(NON_TRANSIENT_ERROR_STATUS));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    IOException ioe =
+        assertThrows(IOException.class, () -> contentWriteStream.writeChunk(insertRequest));
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(Exception while writing chunk).*");
+
+    ioe = assertThrows(IOException.class, () -> contentWriteStream.closeStream());
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(NON-TRANSIENT-ERROR).*");
+    verify(fakeService.insertRequestObserver, times(0)).onCompleted();
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void transientErrorCloseStream() throws IOException {
+    fakeService.setOnCompletedException(new StatusRuntimeException(TRANSIENT_ERROR_STATUS));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    contentWriteStream.writeChunk(insertRequest);
+
+    IOException ioe = assertThrows(IOException.class, () -> contentWriteStream.closeStream());
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(TRANSIENT-ERROR).*");
+    verify(fakeService.insertRequestObserver, times(1)).onCompleted();
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void nonTransientErrorCloseStream() throws IOException {
+    fakeService.setOnCompletedException(new StatusRuntimeException(NON_TRANSIENT_ERROR_STATUS));
+
+    GoogleCloudStorageContentWriteStream contentWriteStream = getContentWriteStream();
+    contentWriteStream.openStream();
+    ByteString data = ByteString.copyFromUtf8("test data");
+    WriteObjectRequest insertRequest = getInsertRequest(data, 0);
+    contentWriteStream.writeChunk(insertRequest);
+
+    IOException ioe = assertThrows(IOException.class, () -> contentWriteStream.closeStream());
+    assertWithMessage("unexpected exception:%n%s", Throwables.getStackTraceAsString(ioe))
+        .that(ioe)
+        .hasMessageThat()
+        .matches("^(NON-TRANSIENT-ERROR).*");
+    verify(fakeService.insertRequestObserver, times(1)).onCompleted();
+    assertThat(contentWriteStream.getInflightRequestCount()).isEqualTo(1);
+    // Stream gets closed whenever there is an error in writing chunk.
+    assertThat(contentWriteStream.isOpen()).isFalse();
+    // Exception is thrown from responseObserver which resulted in closer of stream as well
+    assertThat(watchdog.getOpenStreams().size()).isEqualTo(0);
+  }
+
+  private GoogleCloudStorageContentWriteStream getContentWriteStream() {
+
+    return new GoogleCloudStorageContentWriteStream(
+        RESOURCE_ID,
+        GoogleCloudStorageOptions.builder().setWriteChannelOptions(DEFAULT_OPTIONS).build(),
+        new FakeStubProvider(mockCredentials).newAsyncStub(BUCKET_NAME),
+        UPLOAD_ID,
+        /* writeOffset */ 0,
+        watchdog);
+  }
+
+  private WriteObjectRequest getInsertRequest(ByteString data, long writeOffset) {
+    return getInsertRequest(data, writeOffset, false);
+  }
+
+  private WriteObjectRequest getInsertRequest(
+      ByteString data, long writeOffset, boolean finalizeObject) {
+    return WriteObjectRequest.newBuilder()
+        .setUploadId(UPLOAD_ID)
+        .setChecksummedData(ChecksummedData.newBuilder().setContent(data))
+        .setWriteOffset(writeOffset)
+        .setFinishWrite(finalizeObject)
+        .build();
+  }
+
+  private static class FakeGrpcDecorator implements StorageStubProvider.GrpcDecorator {
+
+    @Override
+    public ManagedChannelBuilder<?> createChannelBuilder(String target) {
+      return null;
+    }
+
+    @Override
+    public AbstractStub<?> applyCallOption(AbstractStub<?> stub) {
+      return stub;
+    }
+  }
+
+  private class FakeStubProvider extends StorageStubProvider {
+
+    FakeStubProvider(Credentials credentials) {
+      super(GoogleCloudStorageOptions.DEFAULT, null, new FakeGrpcDecorator());
+    }
+
+    @Override
+    protected StorageStub newAsyncStubInternal() {
+      return stub;
+    }
+  }
+
+  private class FakeService extends StorageImplBase {
+
+    private Throwable insertRequestException = null;
+
+    private Throwable onCompletedException = null;
+
+    InsertRequestObserver insertRequestObserver = null;
+
+    @Override
+    public StreamObserver<WriteObjectRequest> writeObject(
+        StreamObserver<WriteObjectResponse> responseObserver) {
+      long committedWriteOffset = 0;
+      insertRequestObserver =
+          spy(new InsertRequestObserver(committedWriteOffset, insertRequestException));
+      if (insertRequestException != null) {
+        Throwable throwable = insertRequestException;
+        if (!throwable.getClass().isAssignableFrom(Throwable.class)
+            || throwable.getCause() != null) {
+          insertRequestObserver.insertRequestException = throwable;
+        }
+      }
+      insertRequestObserver.onCompletedException = onCompletedException;
+      insertRequestObserver.responseObserver = responseObserver;
+      return insertRequestObserver;
+    }
+
+    void setInsertRequestException(Throwable t) {
+      insertRequestException = t;
+    }
+
+    void setOnCompletedException(Throwable t) {
+      onCompletedException = t;
+    }
+  }
+
+  private class InsertRequestObserver implements StreamObserver<WriteObjectRequest> {
+
+    public volatile int number = 0;
+    private StreamObserver<WriteObjectResponse> responseObserver;
+    private Object object = DEFAULT_OBJECT;
+
+    // tracks the writeOffset of next chunk
+    private long expectedWriteOffset = 0;
+    // tracks the committed writeOffset of a stream and will only be updated during onCompleted
+    private long committedWriteOffset = 0;
+    WriteObjectResponse writeObjectResponse =
+        WriteObjectResponse.newBuilder().setResource(object).build();
+    Throwable insertRequestException;
+    Throwable onCompletedException;
+
+    boolean objectFinalized = false;
+
+    public InsertRequestObserver(long startingWriteOffset, Throwable throwable) {
+      if (throwable != null) {
+        this.insertRequestException = throwable;
+      }
+      this.committedWriteOffset = startingWriteOffset;
+      this.expectedWriteOffset = startingWriteOffset;
+    }
+
+    @Override
+    public void onNext(WriteObjectRequest request) {
+      // Handle error cases
+      if (insertRequestException != null) {
+        responseObserver.onError(insertRequestException);
+        return;
+      }
+
+      if (request.getWriteOffset() != expectedWriteOffset) {
+        onError(
+            new IOException(
+                String.format(
+                    "Out of order writes encountered. Expecting offset %d, got %d",
+                    expectedWriteOffset, request.getWriteOffset())));
+        return;
+      }
+
+      expectedWriteOffset += request.getChecksummedData().getContent().size();
+
+      if (request.getFinishWrite() == true) {
+        objectFinalized = true;
+        onCompleted();
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      responseObserver.onError(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      if (onCompletedException != null) {
+        onError(onCompletedException);
+        return;
+      }
+      committedWriteOffset = expectedWriteOffset;
+      WriteObjectResponse response = createWriteObjectResponse();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+
+    private WriteObjectResponse createWriteObjectResponse() {
+      if (objectFinalized) {
+        return WriteObjectResponse.newBuilder()
+            .setPersistedSize(committedWriteOffset)
+            .setResource(
+                writeObjectResponse.getResource().toBuilder().setSize(committedWriteOffset).build())
+            .build();
+      }
+
+      return WriteObjectResponse.newBuilder().setPersistedSize(committedWriteOffset).build();
+    }
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageContentWriteStreamTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageContentWriteStreamTest.java
@@ -51,6 +51,12 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+/**
+ * Integration test for {@code GoogleCloudStorageContentWriteStream}; Be careful while using
+ * debugger as default values of grpc message timeout {@code AsyncWriteChannelOptions} are very low
+ * and could cause deviation form behaviour tested using unit tests. One can set higher values for
+ * these timeouts while using debugger option.
+ */
 @RunWith(JUnit4.class)
 public class GoogleCloudStorageContentWriteStreamTest {
 
@@ -423,7 +429,7 @@ public class GoogleCloudStorageContentWriteStreamTest {
     }
   }
 
-  private class FakeService extends StorageImplBase {
+  private static class FakeService extends StorageImplBase {
 
     private Throwable insertRequestException = null;
 
@@ -458,7 +464,7 @@ public class GoogleCloudStorageContentWriteStreamTest {
     }
   }
 
-  private class InsertRequestObserver implements StreamObserver<WriteObjectRequest> {
+  private static class InsertRequestObserver implements StreamObserver<WriteObjectRequest> {
 
     public volatile int number = 0;
     private StreamObserver<WriteObjectResponse> responseObserver;
@@ -487,7 +493,7 @@ public class GoogleCloudStorageContentWriteStreamTest {
     public void onNext(WriteObjectRequest request) {
       // Handle error cases
       if (insertRequestException != null) {
-        responseObserver.onError(insertRequestException);
+        onError(insertRequestException);
         return;
       }
 


### PR DESCRIPTION
Refactored gRPC write channel. Major changes 
1. Created `GoogleCloudStorageContentWriteStream` which manages a single writeObject stream.
2. Refactored FakeService(gcs) in `GoogleCloudStorageContentWriteStreamTest` to support more usecases like
    *   Exception during onCompleted.
    *   WriteObjectResponse being prepared based on object is in finialized state or not.
    *   Added test case to verify the retry logic of stream faiure during commit.
    *   WriteStatus API call no longer needs overriden with static value instead fetched state maintained in fakeService.
    *  etc.
3. Added unit test class `GoogleCloudStorageContentWriteStream` to test the various behaviour of resumable writeObject stream. 