### PR TITLE
upgrade java-storage

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -44,6 +44,7 @@ steps:
       - 'VCS_COMMIT_ID=$COMMIT_SHA'
       - 'VCS_TAG=$TAG_NAME'
       - 'CI_BUILD_ID=$BUILD_ID'
+      - 'GCS_TEST_DIRECT_PATH_PREFERRED=false'
 
 # Tests take on average 25 minutes to run
 timeout: 2400s

--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -120,7 +120,7 @@
 
 1.  Upgrade Hadoop to 3.3.5.
 
-1. Upgrade java-storage to 2.22.2
+1.  Upgrade java-storage to 2.22.2
 
 ### 2.2.2 - 2021-06-25
 

--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -120,6 +120,8 @@
 
 1.  Upgrade Hadoop to 3.3.5.
 
+1. Upgrade java-storage to 2.22.2
+
 ### 2.2.2 - 2021-06-25
 
 1.  Support footer prefetch in gRPC read channel.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationHelper.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationHelper.java
@@ -54,6 +54,8 @@ public final class GoogleHadoopFileSystemIntegrationHelper {
           "fs.gs.auth.service.account.json.keyfile", testConf.getServiceAccountJsonKeyFile());
     }
 
+    config.setBoolean("fs.gs.grpc.directpath.enable", testConf.isDirectPathPreferred());
+
     return config;
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
@@ -21,6 +21,8 @@ public abstract class TestConfiguration {
   public static final String GCS_TEST_PROJECT_ID = "GCS_TEST_PROJECT_ID";
   public static final String GCS_TEST_JSON_KEYFILE = "GCS_TEST_JSON_KEYFILE";
 
+  public static final String GCS_TEST_DIRECT_PATH_PREFERRED = "GCS_TEST_DIRECT_PATH_PREFERRED";
+
   /** Environment-based test configuration. */
   public static class EnvironmentBasedTestConfiguration extends TestConfiguration {
     @Override
@@ -31,6 +33,16 @@ public abstract class TestConfiguration {
     @Override
     public String getServiceAccountJsonKeyFile() {
       return System.getenv(GCS_TEST_JSON_KEYFILE);
+    }
+
+    @Override
+    public boolean isDirectPathPreferred() {
+      String envVar = System.getProperty(GCS_TEST_DIRECT_PATH_PREFERRED);
+      // if env variable is not configured default behaviour is to attempt directPath
+      if (envVar == null) {
+        return true;
+      }
+      return Boolean.parseBoolean(envVar);
     }
   }
 
@@ -45,4 +57,6 @@ public abstract class TestConfiguration {
   public abstract String getProjectId();
 
   public abstract String getServiceAccountJsonKeyFile();
+
+  public abstract boolean isDirectPathPreferred();
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
@@ -37,7 +37,7 @@ public abstract class TestConfiguration {
 
     @Override
     public boolean isDirectPathPreferred() {
-      String envVar = System.getProperty(GCS_TEST_DIRECT_PATH_PREFERRED);
+      String envVar = System.getenv(GCS_TEST_DIRECT_PATH_PREFERRED);
       // if env variable is not configured default behaviour is to attempt directPath
       if (envVar == null) {
         return true;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -107,6 +107,7 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
               GoogleCloudStorageOptions.builder()
                   .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
                   .setProjectId(projectId)
+                  .setDirectPathPreferred(isDirectPathAllowed())
                   .setWriteChannelOptions(
                       AsyncWriteChannelOptions.builder()
                           .setUploadChunkSize(64 * 1024 * 1024)
@@ -131,6 +132,15 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
       gcsfs.close();
       gcsfs = null;
     }
+  }
+
+  public boolean isDirectPathAllowed() {
+    String envVar = System.getProperty("GCS_TEST_DIRECT_PATH_PREFERRED");
+    // if env variable is not configured default behaviour is to attempt directPath
+    if (envVar == null) {
+      return true;
+    }
+    return Boolean.parseBoolean(envVar);
   }
 
   public void postCreateInit() throws IOException {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -107,7 +107,7 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
               GoogleCloudStorageOptions.builder()
                   .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
                   .setProjectId(projectId)
-                  .setDirectPathPreferred(isDirectPathAllowed())
+                  .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
                   .setWriteChannelOptions(
                       AsyncWriteChannelOptions.builder()
                           .setUploadChunkSize(64 * 1024 * 1024)
@@ -132,15 +132,6 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
       gcsfs.close();
       gcsfs = null;
     }
-  }
-
-  public boolean isDirectPathAllowed() {
-    String envVar = System.getProperty("GCS_TEST_DIRECT_PATH_PREFERRED");
-    // if env variable is not configured default behaviour is to attempt directPath
-    if (envVar == null) {
-      return true;
-    }
-    return Boolean.parseBoolean(envVar);
   }
 
   public void postCreateInit() throws IOException {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -110,6 +110,7 @@ public class GoogleCloudStorageTestHelper {
   public static GoogleCloudStorageOptions.Builder getStandardOptionBuilder() {
     return GoogleCloudStorageOptions.builder()
         .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
+        .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
         .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId()));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <google.cloud-storage.bom.version>2.22.2</google.cloud-storage.bom.version>
     <google.error-prone.version>2.16</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
-    <google.gax.version>2.20.1</google.gax.version>
+    <google.gax.version>2.27.0</google.gax.version>
     <google.gson.version>2.10</google.gson.version>
     <google.guava.version>31.1-jre</google.guava.version>
     <google.http-client.version>1.42.3</google.http-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <google.auth.version>1.14.0</google.auth.version>
     <google.auto-value.version>1.10.1</google.auto-value.version>
     <google.cloud-core.verion>2.9.0</google.cloud-core.verion>
-    <google.cloud-storage.bom.version>2.22.1</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.22.2</google.cloud-storage.bom.version>
     <google.error-prone.version>2.16</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
     <google.gax.version>2.20.1</google.gax.version>

--- a/tools/run_integration_tests.sh
+++ b/tools/run_integration_tests.sh
@@ -71,7 +71,5 @@ fi
 export GCS_TEST_JSON_KEYFILE
 export HDFS_ROOT=file:///tmp
 export RUN_INTEGRATION_TESTS=true
-# Env variable to enable direct path over gRPC
-export GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS=true
 
 ./mvnw -B -e -T1C -Pintegration-test clean verify "${@:3}"


### PR DESCRIPTION
In relation to directPath support issue in cloudBuild https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/956, added an ENV variable to control it.

Currently in cloudBuild gRPC calls generated via java-storage were going GFE silently as directPath wasn't supported. With new version of the java-storage v2.22.2 it will fail if DirectPath is opted.
With `GCS_TEST_DIRECT_PATH_PREFERRED` we will be able to control the integration test cases.