### PR TITLE
Fix x-goog-request-params bucket prefix

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageStubProvider.java
@@ -94,7 +94,7 @@ class StorageStubProvider {
 
   private static Metadata getRequestHeaderMetadata(String bucketName) {
     Metadata metadata = new Metadata();
-    metadata.put(GOOG_REQUEST_PARAMS, String.format("bucket=%s", bucketName));
+    metadata.put(GOOG_REQUEST_PARAMS, String.format("bucket=projects/_/buckets/%s", bucketName));
     return metadata;
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TestServerHeaderInterceptor.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TestServerHeaderInterceptor.java
@@ -43,7 +43,7 @@ class TestServerHeaderInterceptor implements ServerInterceptor {
     assertThat(allMeta).hasSize(expectedCallCount);
     for (Metadata metadata : allMeta) {
       assertThat(metadata.get(StorageStubProvider.GOOG_REQUEST_PARAMS))
-          .isEqualTo("bucket=" + bucket);
+          .isEqualTo("bucket=projects/_/buckets/" + bucket);
     }
   }
 }


### PR DESCRIPTION
gRPC backend introduced a specifc format for bucket name filed for `x-goog-request-params` headers.