### PR TITLE
Refactor GoogleCloudStorageClientImpl to add support for java-storage GCS client for both HTTP and gRPC transport.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -126,7 +126,7 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
 
     switch (options.getClientType()) {
       case STORAGE_CLIENT:
-        return GoogleCloudStorageClientImpl.builder()
+        return GoogleCloudStorageGrpcClientImpl.builder()
             .setOptions(options.getCloudStorageOptions())
             .setCredentials(credentials)
             .setDownscopedAccessTokenFn(downscopedAccessTokenFn)

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageGrpcClientImpl.java
@@ -1,0 +1,116 @@
+package com.google.cloud.hadoop.gcsio;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.auth.Credentials;
+import com.google.auto.value.AutoBuilder;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.hadoop.util.AccessBoundary;
+import com.google.cloud.hadoop.util.GcsClientStatisticInterface;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.grpc.ClientInterceptor;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Provides read/write access to Google Cloud Storage (GCS), using Java nio channel semantics. Uses
+ * java-storage client to interact with GCS APIs via the gRPC transport.
+ */
+public class GoogleCloudStorageGrpcClientImpl extends GoogleCloudStorageClientImpl {
+
+  GoogleCloudStorageGrpcClientImpl(
+      GoogleCloudStorageOptions options,
+      @Nullable Storage clientLibraryStorage,
+      @Nullable Credentials credentials,
+      @Nullable HttpTransport httpTransport,
+      @Nullable HttpRequestInitializer httpRequestInitializer,
+      @Nullable Function<List<AccessBoundary>, String> downscopedAccessTokenFn,
+      @Nullable ExecutorService pCUExecutorService,
+      @Nullable ImmutableList<ClientInterceptor> gRPCInterceptors,
+      @Nullable GcsClientStatisticInterface gcsClientStatisticInterface)
+      throws IOException {
+    super(
+        options,
+        clientLibraryStorage,
+        credentials,
+        httpTransport,
+        httpRequestInitializer,
+        gRPCInterceptors,
+        downscopedAccessTokenFn,
+        pCUExecutorService,
+        gcsClientStatisticInterface);
+  }
+
+  @Override
+  Storage createStorage(
+      Credentials credentials,
+      GoogleCloudStorageOptions storageOptions,
+      List<ClientInterceptor> interceptors,
+      ExecutorService pCUExecutorService)
+      throws IOException {
+    return StorageOptions.grpc()
+        .setAttemptDirectPath(storageOptions.isDirectPathPreferred())
+        .setHeaderProvider(storageOptions::getHttpRequestHeaders)
+        .setGrpcInterceptorProvider(
+            () -> {
+              List<ClientInterceptor> list = new ArrayList<>();
+              if (interceptors != null && !interceptors.isEmpty()) {
+                list.addAll(
+                    interceptors.stream().filter(Objects::nonNull).collect(Collectors.toList()));
+              }
+              if (storageOptions.isTraceLogEnabled()) {
+                list.add(new GoogleCloudStorageClientGrpcTracingInterceptor());
+              }
+              return ImmutableList.copyOf(list);
+            })
+        .setCredentials(credentials != null ? credentials : NoCredentials.getInstance())
+        .setBlobWriteSessionConfig(
+            getSessionConfig(storageOptions.getWriteChannelOptions(), pCUExecutorService))
+        .build()
+        .getService();
+  }
+
+  public static Builder builder() {
+    return new AutoBuilder_GoogleCloudStorageGrpcClientImpl_Builder();
+  }
+
+  @AutoBuilder(ofClass = GoogleCloudStorageGrpcClientImpl.class)
+  public abstract static class Builder {
+
+    public abstract Builder setOptions(GoogleCloudStorageOptions options);
+
+    public abstract Builder setHttpTransport(@Nullable HttpTransport httpTransport);
+
+    public abstract Builder setCredentials(@Nullable Credentials credentials);
+
+    @VisibleForTesting
+    public abstract Builder setHttpRequestInitializer(
+        @Nullable HttpRequestInitializer httpRequestInitializer);
+
+    public abstract Builder setDownscopedAccessTokenFn(
+        @Nullable Function<List<AccessBoundary>, String> downscopedAccessTokenFn);
+
+    public abstract Builder setGRPCInterceptors(
+        @Nullable ImmutableList<ClientInterceptor> gRPCInterceptors);
+
+    public abstract Builder setGcsClientStatisticInterface(
+        @Nullable GcsClientStatisticInterface gcsClientStatisticInterface);
+
+    @VisibleForTesting
+    public abstract Builder setClientLibraryStorage(@Nullable Storage clientLibraryStorage);
+
+    @VisibleForTesting
+    public abstract Builder setPCUExecutorService(@Nullable ExecutorService pCUExecutorService);
+
+    public abstract GoogleCloudStorageGrpcClientImpl build() throws IOException;
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageHttpClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageHttpClientImpl.java
@@ -1,0 +1,57 @@
+package com.google.cloud.hadoop.gcsio;
+
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.auth.Credentials;
+import com.google.cloud.hadoop.util.AccessBoundary;
+import com.google.cloud.hadoop.util.GcsClientStatisticInterface;
+import com.google.cloud.storage.Storage;
+import com.google.common.collect.ImmutableList;
+import io.grpc.ClientInterceptor;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import jdk.jshell.spi.ExecutionControl.NotImplementedException;
+
+/**
+ * Provides read/write access to Google Cloud Storage (GCS), using Java nio channel semantics. Uses
+ * java-storage client to interact with GCS APIs via the HTTP transport.
+ */
+// TODO : Implement GoogleCloudStorageHttpClientImpl.
+public class GoogleCloudStorageHttpClientImpl extends GoogleCloudStorageClientImpl {
+  GoogleCloudStorageHttpClientImpl(
+      GoogleCloudStorageOptions options,
+      @Nullable Storage clientLibraryStorage,
+      @Nullable Credentials credentials,
+      @Nullable HttpTransport httpTransport,
+      @Nullable HttpRequestInitializer httpRequestInitializer,
+      @Nullable ImmutableList<ClientInterceptor> gRPCInterceptors,
+      @Nullable Function<List<AccessBoundary>, String> downscopedAccessTokenFn,
+      @Nullable ExecutorService pCUExecutorService,
+      @Nullable GcsClientStatisticInterface gcsClientStatisticInterface)
+      throws IOException, NotImplementedException {
+    super(
+        options,
+        clientLibraryStorage,
+        credentials,
+        httpTransport,
+        httpRequestInitializer,
+        gRPCInterceptors,
+        downscopedAccessTokenFn,
+        pCUExecutorService,
+        gcsClientStatisticInterface);
+    throw new NotImplementedException("Storage Client via HTTP transport is not implemented. ");
+  }
+
+  @Override
+  Storage createStorage(
+      Credentials credentials,
+      GoogleCloudStorageOptions storageOptions,
+      List<ClientInterceptor> interceptors,
+      ExecutorService pCUExecutorService)
+      throws IOException {
+    return null;
+  }
+}

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientWriteChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientWriteChannelTest.java
@@ -274,7 +274,7 @@ public class GoogleCloudStorageClientWriteChannelTest {
             .setAppName("gcsio-unit-test")
             .setGrpcEnabled(true)
             .build();
-    return GoogleCloudStorageClientImpl.builder()
+    return GoogleCloudStorageGrpcClientImpl.builder()
         .setOptions(options)
         .setCredentials(fakeCredentials)
         .setHttpTransport(transport)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemJavaStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemJavaStorageNewIntegrationTest.java
@@ -74,7 +74,7 @@ public class GoogleCloudStorageFileSystemJavaStorageNewIntegrationTest
       throws IOException {
     return new GoogleCloudStorageFileSystemImpl(
         options ->
-            GoogleCloudStorageClientImpl.builder()
+            GoogleCloudStorageGrpcClientImpl.builder()
                 .setOptions(options)
                 .setCredentials(httpRequestsInitializer.getCredentials())
                 .setHttpRequestInitializer(gcsRequestsTracker)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTestBase.java
@@ -86,7 +86,7 @@ public abstract class GoogleCloudStorageFileSystemTestBase
   private Class getGoogleCloudStorageImplClass() {
     switch (storageClientType) {
       case STORAGE_CLIENT:
-        return GoogleCloudStorageClientImpl.class;
+        return GoogleCloudStorageGrpcClientImpl.class;
       default:
         return GoogleCloudStorageImpl.class;
     }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageJavaStorageNewIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageJavaStorageNewIntegrationTest.java
@@ -67,7 +67,7 @@ public class GoogleCloudStorageJavaStorageNewIntegrationTest
 
   protected GoogleCloudStorage createGoogleCloudStorage(GoogleCloudStorageOptions options)
       throws IOException {
-    return GoogleCloudStorageClientImpl.builder()
+    return GoogleCloudStorageGrpcClientImpl.builder()
         .setOptions(options)
         .setCredentials(httpRequestsInitializer.getCredentials())
         .setHttpRequestInitializer(gcsRequestsTracker)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockGoogleCloudStorageImplFactory.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockGoogleCloudStorageImplFactory.java
@@ -57,7 +57,7 @@ public class MockGoogleCloudStorageImplFactory {
       GoogleCloudStorageOptions options, HttpTransport transport, Storage storage)
       throws IOException {
     FakeCredentials fakeCredentials = new FakeCredentials();
-    return GoogleCloudStorageClientImpl.builder()
+    return GoogleCloudStorageGrpcClientImpl.builder()
         .setOptions(options)
         .setHttpTransport(transport)
         .setHttpRequestInitializer(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/CsekEncryptionIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/CsekEncryptionIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcClientImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
@@ -138,7 +138,7 @@ public class CsekEncryptionIntegrationTest {
 
   private GoogleCloudStorage makeStorage(GoogleCloudStorageOptions options) throws IOException {
     if (testStorageClientImpl) {
-      return GoogleCloudStorageClientImpl.builder()
+      return GoogleCloudStorageGrpcClientImpl.builder()
           .setOptions(options)
           .setCredentials(GoogleCloudStorageTestHelper.getCredentials())
           .build();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientImplIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientImplIntegrationTest.java
@@ -22,7 +22,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.Credentials;
 import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcClientImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.ListObjectOptions;
@@ -437,7 +437,7 @@ public class GoogleCloudStorageClientImplIntegrationTest {
   private GoogleCloudStorage getGCSImpl(GoogleCloudStorageOptions storageOptions)
       throws IOException {
     Credentials credentials = GoogleCloudStorageTestHelper.getCredentials();
-    return GoogleCloudStorageClientImpl.builder()
+    return GoogleCloudStorageGrpcClientImpl.builder()
         .setOptions(storageOptions)
         .setCredentials(credentials)
         .setPCUExecutorService(MoreExecutors.newDirectExecutorService())

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageClientInterceptorIntegrationTest.java
@@ -25,7 +25,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.hadoop.gcsio.AssertingLogHandler;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientGrpcTracingInterceptor;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcClientImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageTracingFields;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
@@ -202,7 +202,7 @@ public class GoogleCloudStorageClientInterceptorIntegrationTest {
 
   public static GoogleCloudStorage getGCSClientImpl(GoogleCloudStorageOptions options) {
     try {
-      return GoogleCloudStorageClientImpl.builder()
+      return GoogleCloudStorageGrpcClientImpl.builder()
           .setOptions(options)
           .setCredentials(getCredentials())
           .build();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -34,7 +34,7 @@ import com.google.cloud.hadoop.gcsio.CreateBucketOptions;
 import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
 import com.google.cloud.hadoop.gcsio.EventLoggingHttpRequestInitializer;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcClientImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
@@ -619,7 +619,7 @@ public class GoogleCloudStorageImplTest {
         options,
         (httpRequestInitializer, grpcRequestInterceptors) ->
             testStorageClientImpl
-                ? GoogleCloudStorageClientImpl.builder()
+                ? GoogleCloudStorageGrpcClientImpl.builder()
                     .setOptions(options)
                     .setCredentials(credentials)
                     .setHttpRequestInitializer(httpRequestInitializer)
@@ -637,7 +637,7 @@ public class GoogleCloudStorageImplTest {
       throws IOException {
     Credentials credentials = GoogleCloudStorageTestHelper.getCredentials();
     return testStorageClientImpl
-        ? GoogleCloudStorageClientImpl.builder()
+        ? GoogleCloudStorageGrpcClientImpl.builder()
             .setOptions(options)
             .setCredentials(credentials)
             .build()

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -31,7 +31,7 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcClientImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
@@ -88,7 +88,7 @@ public class GoogleCloudStorageTestHelper {
 
   public static GoogleCloudStorage createGcsClientImpl() {
     try {
-      return GoogleCloudStorageClientImpl.builder()
+      return GoogleCloudStorageGrpcClientImpl.builder()
           .setOptions(getStandardOptionBuilder().build())
           .setCredentials(getCredentials())
           .build();


### PR DESCRIPTION
Changes
- Make GoogleCloudStorageClientImpl abstract which will contain the transport agnostic code for java-storage. 
- Child classes GoogleCloudStorageGrpcClientImpl and GoogleCloudStorageHttpClientImpl contains the transport specific implementation.