### PR TITLE
Add java-storage implementation for copy objects method.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchExecutor.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchExecutor.java
@@ -86,12 +86,19 @@ class BatchExecutor {
             }));
   }
 
-  private static <T> void execute(Callable<T> task, FutureCallback<T> callback) {
+  private static <T> void execute(Callable<T> task, FutureCallback<T> callback) throws Exception {
     try {
       T result = task.call();
-      callback.onSuccess(result);
+      if (callback != null) {
+        callback.onSuccess(result);
+      }
     } catch (Throwable throwable) {
-      callback.onFailure(throwable);
+      if (callback != null) {
+        callback.onFailure(throwable);
+      } else {
+        // Re-throw the exception.
+        throw throwable;
+      }
     }
   }
 


### PR DESCRIPTION
`java-storage` client internally uses gcs rewrite API for copy so we don't need the logic to decide weather to issue a copy or rewrite as opposed to the APIary implementation. https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/com.google.cloud.storage.Storage#com_google_cloud_storage_Storage_copy_com_google_cloud_storage_Storage_CopyRequest_