### PR TITLE
Add unit tests for GoogleCloudStorageClientImpl.

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -308,6 +308,14 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
       copyRequestBuilder.setTarget(BlobId.of(dstBucketName, dstObjectName));
     }
 
+    if (storageOptions.getEncryptionKey() != null) {
+      copyRequestBuilder.setSourceOptions(
+          BlobSourceOption.decryptionKey(storageOptions.getEncryptionKey().value()));
+      copyRequestBuilder.setTarget(
+          copyRequestBuilder.build().getTarget().getBlobId(),
+          BlobTargetOption.encryptionKey(storageOptions.getEncryptionKey().value()));
+    }
+
     if (storageOptions.getMaxRewriteChunkSize() > 0) {
       copyRequestBuilder.setMegabytesCopiedPerChunk(
           // Convert raw byte size into Mib.

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -18,7 +18,6 @@ package com.google.cloud.hadoop.gcsio;
 
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.decodeMetadata;
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.encodeMetadata;
 import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.validateCopyArguments;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -387,7 +386,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
         bucket.asBucketInfo().getCreateTimeOffsetDateTime().toInstant().toEpochMilli(),
         bucket.asBucketInfo().getUpdateTimeOffsetDateTime().toInstant().toEpochMilli(),
         bucket.getLocation(),
-        bucket.getStorageClass().name());
+        bucket.getStorageClass() == null ? null : bucket.getStorageClass().name());
   }
 
   /** See {@link GoogleCloudStorage#deleteObjects(List)} for details about the expected behavior. */
@@ -638,25 +637,24 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
             new FutureCallback<>() {
               @Override
               public void onSuccess(Blob blob) {
-                logger.atFiner().log(
-                    "updateItems: Successfully updated object '%s' for resourceId '%s'",
-                    blob, resourceId);
-                resultItemInfos.put(resourceId, createItemInfoForBlob(resourceId, blob));
+                if (blob == null) {
+                  // Indicated that the blob was not found.
+                  logger.atFiner().log("updateItems: object not found %s", resourceId);
+                  resultItemInfos.put(
+                      resourceId, GoogleCloudStorageItemInfo.createNotFound(resourceId));
+                } else {
+                  logger.atFiner().log(
+                      "updateItems: Successfully updated object '%s' for resourceId '%s'",
+                      blob, resourceId);
+                  resultItemInfos.put(resourceId, createItemInfoForBlob(resourceId, blob));
+                }
               }
 
               @Override
               public void onFailure(Throwable throwable) {
-                if (throwable instanceof Exception
-                    && errorExtractor.getErrorType((Exception) throwable) == ErrorType.NOT_FOUND) {
-                  logger.atFiner().log(
-                      "updateItems: object not found %s: %s", resourceId, throwable);
-                  resultItemInfos.put(
-                      resourceId, GoogleCloudStorageItemInfo.createNotFound(resourceId));
-                } else {
-                  innerExceptions.add(
-                      new IOException(
-                          String.format("Error updating '%s' object", resourceId), throwable));
-                }
+                innerExceptions.add(
+                    new IOException(
+                        String.format("Error updating '%s' object", resourceId), throwable));
               }
             });
       }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/MockStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/MockStorage.java
@@ -17,9 +17,17 @@
 package com.google.cloud.hadoop.gcsio.testing;
 
 import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.Empty;
 import com.google.storage.v2.Bucket;
 import com.google.storage.v2.CreateBucketRequest;
+import com.google.storage.v2.DeleteBucketRequest;
+import com.google.storage.v2.DeleteObjectRequest;
+import com.google.storage.v2.GetObjectRequest;
+import com.google.storage.v2.ListBucketsRequest;
+import com.google.storage.v2.ListBucketsResponse;
+import com.google.storage.v2.Object;
 import com.google.storage.v2.StorageGrpc.StorageImplBase;
+import com.google.storage.v2.UpdateObjectRequest;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -29,7 +37,7 @@ import java.util.Queue;
 public final class MockStorage extends StorageImplBase {
 
   private List<AbstractMessage> requests;
-  private Queue<Object> responses;
+  private Queue<java.lang.Object> responses;
 
   public MockStorage() {
     requests = new ArrayList<>();
@@ -69,6 +77,107 @@ public final class MockStorage extends StorageImplBase {
                   "Unrecognized response type %s for method CreateBucket, expected %s or %s",
                   response == null ? "null" : response.getClass().getName(),
                   Bucket.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void deleteBucket(DeleteBucketRequest request, StreamObserver<Empty> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext(((Empty) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method DeleteBucket, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Empty.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void listBuckets(
+      ListBucketsRequest request, StreamObserver<ListBucketsResponse> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof ListBucketsResponse) {
+      requests.add(request);
+      responseObserver.onNext(((ListBucketsResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method ListBuckets, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  ListBucketsResponse.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void deleteObject(DeleteObjectRequest request, StreamObserver<Empty> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof Empty) {
+      requests.add(request);
+      responseObserver.onNext(((Empty) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method DeleteObject, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Empty.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void getObject(GetObjectRequest request, StreamObserver<Object> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof Object) {
+      requests.add(request);
+      responseObserver.onNext(((Object) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method GetObject, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Object.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void updateObject(UpdateObjectRequest request, StreamObserver<Object> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof Object) {
+      requests.add(request);
+      responseObserver.onNext(((Object) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method UpdateObject, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Object.class.getName(),
                   Exception.class.getName())));
     }
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/MockStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/MockStorage.java
@@ -19,6 +19,7 @@ package com.google.cloud.hadoop.gcsio.testing;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Empty;
 import com.google.storage.v2.Bucket;
+import com.google.storage.v2.ComposeObjectRequest;
 import com.google.storage.v2.CreateBucketRequest;
 import com.google.storage.v2.DeleteBucketRequest;
 import com.google.storage.v2.DeleteObjectRequest;
@@ -26,6 +27,8 @@ import com.google.storage.v2.GetObjectRequest;
 import com.google.storage.v2.ListBucketsRequest;
 import com.google.storage.v2.ListBucketsResponse;
 import com.google.storage.v2.Object;
+import com.google.storage.v2.RewriteObjectRequest;
+import com.google.storage.v2.RewriteResponse;
 import com.google.storage.v2.StorageGrpc.StorageImplBase;
 import com.google.storage.v2.UpdateObjectRequest;
 import io.grpc.stub.StreamObserver;
@@ -77,6 +80,26 @@ public final class MockStorage extends StorageImplBase {
                   "Unrecognized response type %s for method CreateBucket, expected %s or %s",
                   response == null ? "null" : response.getClass().getName(),
                   Bucket.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void composeObject(ComposeObjectRequest request, StreamObserver<Object> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof Object) {
+      requests.add(request);
+      responseObserver.onNext(((Object) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method ComposeObject, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Object.class.getName(),
                   Exception.class.getName())));
     }
   }
@@ -178,6 +201,27 @@ public final class MockStorage extends StorageImplBase {
                   "Unrecognized response type %s for method UpdateObject, expected %s or %s",
                   response == null ? "null" : response.getClass().getName(),
                   Object.class.getName(),
+                  Exception.class.getName())));
+    }
+  }
+
+  @Override
+  public void rewriteObject(
+      RewriteObjectRequest request, StreamObserver<RewriteResponse> responseObserver) {
+    java.lang.Object response = responses.poll();
+    if (response instanceof RewriteResponse) {
+      requests.add(request);
+      responseObserver.onNext(((RewriteResponse) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method RewriteObject, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  RewriteResponse.class.getName(),
                   Exception.class.getName())));
     }
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientTest.java
@@ -16,8 +16,12 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.encodeMetadata;
 import static com.google.cloud.hadoop.gcsio.MockGoogleCloudStorageImplFactory.mockedGcsClientImpl;
+import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTest.BYTE_ARRAY_EQUIVALENCE;
+import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTest.assertMapsEqual;
 import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.mockTransport;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -25,18 +29,32 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.cloud.hadoop.gcsio.testing.FakeServer;
 import com.google.cloud.hadoop.gcsio.testing.MockStorage;
 import com.google.cloud.storage.StorageException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.protobuf.Empty;
+import com.google.protobuf.Timestamp;
 import com.google.storage.v2.Bucket;
 import com.google.storage.v2.Bucket.Lifecycle;
 import com.google.storage.v2.Bucket.Lifecycle.Rule;
 import com.google.storage.v2.Bucket.Lifecycle.Rule.Action;
 import com.google.storage.v2.Bucket.Lifecycle.Rule.Condition;
+import com.google.storage.v2.BucketName;
 import com.google.storage.v2.CreateBucketRequest;
+import com.google.storage.v2.DeleteBucketRequest;
+import com.google.storage.v2.DeleteObjectRequest;
+import com.google.storage.v2.ListBucketsResponse;
+import com.google.storage.v2.Object;
 import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +64,56 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GoogleCloudStorageClientTest {
 
-  private static final String BUCKET_NAME = "foo-bucket";
+  private static final String TEST_BUCKET_NAME = "foo-bucket";
+
+  private static final String TEST_OBJECT_NAME = "foo-object";
+
+  private static final Timestamp CREATE_TIME = Timestamp.newBuilder().build();
+
+  private static final Timestamp UPDATE_TIME = CREATE_TIME;
+
+  private static final String BUCKET_STORAGE_CLASS = "STANDARD";
+
+  private static final String BUCKET_LOCATION = "some-location";
+
+  private static final int TTL_DAYS = 10;
+
+  private static final int GENERATION = 123456;
+
+  private static final Bucket TEST_BUCKET =
+      Bucket.newBuilder()
+          .setName(TEST_BUCKET_NAME)
+          .setCreateTime(CREATE_TIME)
+          .setUpdateTime(UPDATE_TIME)
+          .build();
+
+  private static final Bucket TEST_BUCKET_WITH_OPTIONS =
+      Bucket.newBuilder()
+          .setName("foo-bar-bucket")
+          .setStorageClass(BUCKET_STORAGE_CLASS)
+          .setLocation(BUCKET_LOCATION)
+          .setCreateTime(CREATE_TIME)
+          .setUpdateTime(UPDATE_TIME)
+          .setLifecycle(
+              Lifecycle.newBuilder()
+                  .addRule(
+                      Rule.newBuilder()
+                          .setAction(Action.newBuilder().setType("Delete"))
+                          .setCondition(Condition.newBuilder().setAgeDays(TTL_DAYS).build())
+                          .build())
+                  .build())
+          .build();
+
+  private static final Object TEST_OBJECT =
+      Object.newBuilder()
+          .setName(TEST_OBJECT_NAME)
+          .setBucket(BucketName.of("", TEST_BUCKET_NAME).toString())
+          .setGeneration(GENERATION)
+          .setMetageneration(123L)
+          .setCreateTime(CREATE_TIME)
+          .setUpdateTime(UPDATE_TIME)
+          .setSize(1234)
+          .build();
 
   private static final MockHttpTransport transport = mockTransport();
 
@@ -59,65 +126,48 @@ public class GoogleCloudStorageClientTest {
 
   @Test
   public void createBucket_succeeds() throws Exception {
-    mockStorage.addResponse(Bucket.newBuilder().setName(BUCKET_NAME).build());
+    mockStorage.addResponse(TEST_BUCKET);
 
     try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
       GoogleCloudStorage gcs =
           mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
-      gcs.createBucket(BUCKET_NAME);
+      gcs.createBucket(TEST_BUCKET_NAME);
     }
 
     assertEquals(mockStorage.getRequests().size(), 1);
 
     CreateBucketRequest bucketRequest = (CreateBucketRequest) mockStorage.getRequests().get(0);
-    assertEquals(bucketRequest.getBucketId(), BUCKET_NAME);
+    assertEquals(bucketRequest.getBucketId(), TEST_BUCKET_NAME);
   }
 
   @Test
   public void createBucket_withOptions_succeeds() throws Exception {
-    String location = "some-location";
-    String storageClass = "STANDARD";
-    int ttlDays = 10;
-
-    mockStorage.addResponse(
-        Bucket.newBuilder()
-            .setName(BUCKET_NAME)
-            .setStorageClass(storageClass)
-            .setLocation(location)
-            .setLifecycle(
-                Lifecycle.newBuilder()
-                    .addRule(
-                        Rule.newBuilder()
-                            .setAction(Action.newBuilder().setType("Delete"))
-                            .setCondition(Condition.newBuilder().setAgeDays(ttlDays).build())
-                            .build())
-                    .build())
-            .build());
+    mockStorage.addResponse(TEST_BUCKET_WITH_OPTIONS);
 
     CreateBucketOptions bucketOptions =
         CreateBucketOptions.builder()
-            .setLocation(location)
-            .setStorageClass(storageClass)
-            .setTtl(Duration.ofDays(ttlDays))
+            .setLocation(BUCKET_LOCATION)
+            .setStorageClass(BUCKET_STORAGE_CLASS)
+            .setTtl(Duration.ofDays(TTL_DAYS))
             .build();
 
     try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
       GoogleCloudStorage gcs =
           mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
-      gcs.createBucket(BUCKET_NAME, bucketOptions);
+      gcs.createBucket(TEST_BUCKET_NAME, bucketOptions);
     }
 
     assertEquals(mockStorage.getRequests().size(), 1);
 
     CreateBucketRequest bucketRequest = (CreateBucketRequest) mockStorage.getRequests().get(0);
     // Assert correct fields were set in request.
-    assertEquals(bucketRequest.getBucketId(), BUCKET_NAME);
-    assertEquals(bucketRequest.getBucket().getLocation(), location);
-    assertEquals(bucketRequest.getBucket().getStorageClass(), storageClass);
+    assertEquals(bucketRequest.getBucketId(), TEST_BUCKET_NAME);
+    assertEquals(bucketRequest.getBucket().getLocation(), BUCKET_LOCATION);
+    assertEquals(bucketRequest.getBucket().getStorageClass(), BUCKET_STORAGE_CLASS);
     assertEquals(
         bucketRequest.getBucket().getLifecycle().getRule(0).getAction().getType(), "Delete");
     assertEquals(
-        bucketRequest.getBucket().getLifecycle().getRule(0).getCondition().getAgeDays(), ttlDays);
+        bucketRequest.getBucket().getLifecycle().getRule(0).getCondition().getAgeDays(), TTL_DAYS);
   }
 
   @Test
@@ -126,7 +176,7 @@ public class GoogleCloudStorageClientTest {
     try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
       GoogleCloudStorage gcs =
           mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
-      assertThrows(FileAlreadyExistsException.class, () -> gcs.createBucket(BUCKET_NAME));
+      assertThrows(FileAlreadyExistsException.class, () -> gcs.createBucket(TEST_BUCKET_NAME));
     }
   }
 
@@ -138,7 +188,7 @@ public class GoogleCloudStorageClientTest {
     try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
       GoogleCloudStorage gcs =
           mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
-      assertThrows(IOException.class, () -> gcs.createBucket(BUCKET_NAME));
+      assertThrows(IOException.class, () -> gcs.createBucket(TEST_BUCKET_NAME));
     }
   }
 
@@ -150,6 +200,272 @@ public class GoogleCloudStorageClientTest {
 
       assertThrows(IllegalArgumentException.class, () -> gcs.createBucket(null));
       assertThrows(IllegalArgumentException.class, () -> gcs.createBucket(""));
+    }
+  }
+
+  @Test
+  public void deleteBuckets_illegalArguments() throws Exception {
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> gcs.deleteBuckets(Lists.newArrayList((String) null)));
+      assertThrows(IllegalArgumentException.class, () -> gcs.deleteBuckets(Lists.newArrayList("")));
+    }
+  }
+
+  @Test
+  public void deleteBuckets_succeeds() throws Exception {
+    mockStorage.addResponse(Empty.newBuilder().build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      gcs.deleteBuckets(ImmutableList.of(TEST_BUCKET_NAME));
+      assertEquals(mockStorage.getRequests().size(), 1);
+
+      DeleteBucketRequest deleteBucketRequest =
+          (DeleteBucketRequest) mockStorage.getRequests().get(0);
+      assertThat(deleteBucketRequest.getName()).contains(TEST_BUCKET_NAME);
+    }
+  }
+
+  @Test
+  public void deleteBuckets_throwsException() throws Exception {
+    mockStorage.addException(new StatusRuntimeException(Status.INVALID_ARGUMENT));
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      assertThrows(IOException.class, () -> gcs.deleteBuckets(ImmutableList.of(TEST_BUCKET_NAME)));
+    }
+  }
+
+  @Test
+  public void deleteBuckets_throwsFileNotFoundException() throws Exception {
+    mockStorage.addException(new StatusRuntimeException(Status.NOT_FOUND));
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      assertThrows(
+          FileNotFoundException.class, () -> gcs.deleteBuckets(ImmutableList.of(TEST_BUCKET_NAME)));
+    }
+  }
+
+  @Test
+  public void deleteObjects_illegalArguments() throws Exception {
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      ImmutableList.of(StorageResourceId.ROOT, new StorageResourceId(TEST_BUCKET_NAME))
+          .forEach(
+              resourceId ->
+                  assertThrows(
+                      IllegalArgumentException.class,
+                      () -> gcs.deleteObjects(ImmutableList.of(resourceId))));
+    }
+  }
+
+  @Test
+  public void deleteObjects_withoutGeneration_succeeds() throws Exception {
+    // Mock response for get object call for fetching object metadata.
+    mockStorage.addResponse(TEST_OBJECT);
+    mockStorage.addResponse(Empty.newBuilder().build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      gcs.deleteObjects(
+          ImmutableList.of(new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME)));
+
+      assertEquals(mockStorage.getRequests().size(), 2);
+      DeleteObjectRequest actualRequest = (DeleteObjectRequest) mockStorage.getRequests().get(1);
+      assertThat(actualRequest.getBucket()).contains(TEST_BUCKET_NAME);
+      assertEquals(actualRequest.getObject(), TEST_OBJECT_NAME);
+    }
+  }
+
+  @Test
+  public void deleteObjects_withoutGeneration_failsToGetGeneration() throws Exception {
+    // Mock response for get object call for fetching object metadata.
+    mockStorage.addException(new StatusException(Status.INVALID_ARGUMENT));
+    mockStorage.addResponse(Empty.newBuilder().build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      assertThrows(
+          IOException.class,
+          () ->
+              gcs.deleteObjects(
+                  ImmutableList.of(new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME))));
+    }
+  }
+
+  @Test
+  public void deleteObjects_withoutGeneration_objectDoesntExist() throws Exception {
+    // Mock response for get object call for fetching object metadata.
+    mockStorage.addException(new StatusException(Status.NOT_FOUND));
+    mockStorage.addResponse(Empty.newBuilder().build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      gcs.deleteObjects(
+          ImmutableList.of(new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME)));
+
+      // Delete is not issues if object is not found.
+      assertEquals(mockStorage.getRequests().size(), 0);
+    }
+  }
+
+  @Test
+  public void deleteObjects_withGeneration_succeeds() throws Exception {
+    mockStorage.addResponse(Empty.newBuilder().build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      gcs.deleteObjects(
+          ImmutableList.of(new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME, GENERATION)));
+
+      assertEquals(mockStorage.getRequests().size(), 1);
+      DeleteObjectRequest actualRequest = (DeleteObjectRequest) mockStorage.getRequests().get(0);
+      assertThat(actualRequest.getBucket()).contains(TEST_BUCKET_NAME);
+      assertEquals(actualRequest.getObject(), TEST_OBJECT_NAME);
+    }
+  }
+
+  @Test
+  public void deleteObjects_throwsException() throws Exception {
+    mockStorage.addException(new StatusRuntimeException(Status.INVALID_ARGUMENT));
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      assertThrows(
+          IOException.class,
+          () ->
+              gcs.deleteObjects(
+                  ImmutableList.of(
+                      new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME, GENERATION))));
+    }
+  }
+
+  @Test
+  public void listBucketNames_succeeds() throws Exception {
+    mockStorage.addResponse(
+        ListBucketsResponse.newBuilder()
+            .addBuckets(TEST_BUCKET)
+            .addBuckets(TEST_BUCKET_WITH_OPTIONS)
+            .build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+      List<String> listedBuckets = gcs.listBucketNames();
+      assertThat(listedBuckets)
+          .containsExactly(TEST_BUCKET.getName(), TEST_BUCKET_WITH_OPTIONS.getName());
+    }
+  }
+
+  @Test
+  public void listBucketInfo_succeeds() throws Exception {
+    mockStorage.addResponse(
+        ListBucketsResponse.newBuilder()
+            .addBuckets(TEST_BUCKET)
+            .addBuckets(TEST_BUCKET_WITH_OPTIONS)
+            .build());
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      List<GoogleCloudStorageItemInfo> listedBuckets = gcs.listBucketInfo();
+
+      assertThat(listedBuckets)
+          .containsExactly(
+              GoogleCloudStorageItemInfo.createBucket(
+                  new StorageResourceId(TEST_BUCKET.getName()), 0, 0, "", null),
+              GoogleCloudStorageItemInfo.createBucket(
+                  new StorageResourceId(TEST_BUCKET_WITH_OPTIONS.getName()),
+                  0,
+                  0,
+                  BUCKET_LOCATION,
+                  BUCKET_STORAGE_CLASS));
+    }
+  }
+
+  @Test
+  public void updateItems_succeeds() throws Exception {
+    Map<String, byte[]> metadata =
+        ImmutableMap.of(
+            "key1", "value1".getBytes(StandardCharsets.UTF_8),
+            "key2", "value2".getBytes(StandardCharsets.UTF_8));
+    mockStorage.addResponse(
+        TEST_OBJECT.toBuilder().putAllMetadata(encodeMetadata(metadata)).build());
+
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      List<GoogleCloudStorageItemInfo> results =
+          gcs.updateItems(
+              ImmutableList.of(
+                  new UpdatableItemInfo(
+                      new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME), metadata)));
+
+      assertEquals(mockStorage.getRequests().size(), 1);
+      assertEquals(results.size(), 1);
+      assertMapsEqual(metadata, results.get(0).getMetadata(), BYTE_ARRAY_EQUIVALENCE);
+    }
+  }
+
+  @Test
+  public void updateItems_throwsException() throws Exception {
+    mockStorage.addException(new StatusRuntimeException(Status.INVALID_ARGUMENT));
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      assertThrows(
+          IOException.class,
+          () ->
+              gcs.updateItems(
+                  ImmutableList.of(
+                      new UpdatableItemInfo(
+                          new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME),
+                          ImmutableMap.of()))));
+    }
+  }
+
+  @Test
+  public void updateItems_returnsNotFound() throws Exception {
+    mockStorage.addException(new StatusRuntimeException(Status.NOT_FOUND));
+    try (FakeServer fakeServer = FakeServer.of(mockStorage)) {
+      GoogleCloudStorage gcs =
+          mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
+
+      List<GoogleCloudStorageItemInfo> results =
+          gcs.updateItems(
+              ImmutableList.of(
+                  new UpdatableItemInfo(
+                      new StorageResourceId(TEST_BUCKET_NAME, TEST_OBJECT_NAME),
+                      ImmutableMap.of())));
+
+      assertEquals(results.size(), 1);
+      assertThat(results.get(0).exists()).isFalse();
     }
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageNewIntegrationTestBase.java
@@ -983,13 +983,16 @@ public abstract class GoogleCloudStorageNewIntegrationTestBase {
         testBucket2,
         ImmutableList.of(testDir + "f4", testDir + "f5"));
 
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getBucketRequestString(testBucket1),
-            getBucketRequestString(testBucket2),
-            batchRequestString(),
-            copyRequestString(testBucket1, testDir + "f1", testBucket2, testDir + "f4", "copyTo"),
-            copyRequestString(testBucket1, testDir + "f2", testBucket2, testDir + "f5", "copyTo"));
+    if (isTracingSupported) {
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getBucketRequestString(testBucket1),
+              getBucketRequestString(testBucket2),
+              batchRequestString(),
+              copyRequestString(testBucket1, testDir + "f1", testBucket2, testDir + "f4", "copyTo"),
+              copyRequestString(
+                  testBucket1, testDir + "f2", testBucket2, testDir + "f5", "copyTo"));
+    }
 
     List<String> listedObjects = getObjectNames(gcs.listObjectInfo(testBucket2, testDir));
     assertThat(listedObjects).containsExactly(testDir + "f4", testDir + "f5");
@@ -1015,15 +1018,17 @@ public abstract class GoogleCloudStorageNewIntegrationTestBase {
         testBucket2,
         ImmutableList.of(testDir + "f4", testDir + "f5"));
 
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getBucketRequestString(testBucket1),
-            getBucketRequestString(testBucket2),
-            batchRequestString(),
-            copyRequestString(
-                testBucket1, testDir + "f1", testBucket2, testDir + "f4", "rewriteTo"),
-            copyRequestString(
-                testBucket1, testDir + "f2", testBucket2, testDir + "f5", "rewriteTo"));
+    if (isTracingSupported) {
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getBucketRequestString(testBucket1),
+              getBucketRequestString(testBucket2),
+              batchRequestString(),
+              copyRequestString(
+                  testBucket1, testDir + "f1", testBucket2, testDir + "f4", "rewriteTo"),
+              copyRequestString(
+                  testBucket1, testDir + "f2", testBucket2, testDir + "f5", "rewriteTo"));
+    }
 
     List<String> listedObjects = getObjectNames(gcs.listObjectInfo(testBucket2, testDir));
     assertThat(listedObjects).containsExactly(testDir + "f4", testDir + "f5");

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
@@ -1637,7 +1637,7 @@ public class GoogleCloudStorageTest {
     assertThat(itemInfo2.toString()).contains("exists: no");
   }
 
-  static <K, V> void assertMapsEqual(
+  public static <K, V> void assertMapsEqual(
       Map<K, V> expected, Map<K, V> result, Equivalence<V> valueEquivalence) {
     MapDifference<K, V> diff = Maps.difference(expected, result, valueEquivalence);
     if (!diff.areEqual()) {


### PR DESCRIPTION
1. Adds unit tests for
* listBucket
* deleteBucket
* deleteObjects
* updateObjects
* compose
* copy

2. Add redundant APIs for compose and copy so that GoogleCloudStorageClient implementation is invoked for all APIs.  
