### PR TITLE
GCS Specific Metrics

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
@@ -16,9 +16,10 @@
 
 package com.google.cloud.hadoop.fs.gcs;
 
-import static com.google.cloud.hadoop.fs.gcs.GhfsStatisticTypeEnum.TYPE_COUNTER;
-import static com.google.cloud.hadoop.fs.gcs.GhfsStatisticTypeEnum.TYPE_DURATION;
+import static com.google.cloud.hadoop.gcsio.StatisticTypeEnum.TYPE_COUNTER;
+import static com.google.cloud.hadoop.gcsio.StatisticTypeEnum.TYPE_DURATION;
 
+import com.google.cloud.hadoop.gcsio.StatisticTypeEnum;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -149,7 +150,7 @@ public enum GhfsStatistic {
    * @param description description.
    * @param type type
    */
-  GhfsStatistic(String symbol, String description, GhfsStatisticTypeEnum type) {
+  GhfsStatistic(String symbol, String description, StatisticTypeEnum type) {
     this.symbol = symbol;
     this.description = description;
     this.type = type;
@@ -162,7 +163,7 @@ public enum GhfsStatistic {
   private final String description;
 
   /** Statistic type. */
-  private final GhfsStatisticTypeEnum type;
+  private final StatisticTypeEnum type;
 
   /** the name of the statistic */
   public String getSymbol() {
@@ -199,7 +200,7 @@ public enum GhfsStatistic {
    *
    * @return the type.
    */
-  public GhfsStatisticTypeEnum getType() {
+  public StatisticTypeEnum getType() {
     return type;
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
@@ -109,8 +109,8 @@ public class GhfsStorageStatistics extends StorageStatistics {
     return incrementCounter(statistic, 1);
   }
 
-  private long increment(GoogleCloudStorageStatistics statistic) {
-    return incrementCounter(statistic, 1);
+  private void increment(GoogleCloudStorageStatistics statistic) {
+    incrementCounter(statistic, 1);
   }
 
   /**
@@ -129,10 +129,9 @@ public class GhfsStorageStatistics extends StorageStatistics {
    *
    * @param op operation
    * @param count increment value
-   * @return the new value
    */
-  long incrementCounter(GoogleCloudStorageStatistics op, long count) {
-    return opsCount.get(op.getSymbol()).addAndGet(count);
+  void incrementCounter(GoogleCloudStorageStatistics op, long count) {
+    opsCount.get(op.getSymbol()).addAndGet(count);
   }
 
   @Override

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
@@ -253,13 +253,21 @@ public class GhfsStorageStatistics extends StorageStatistics {
     updateGcsIOSpecificStatistics(response.getStatusCode());
   }
 
-  /** Updating the GCS_TOTAL_REQUEST_COUNT */
+
+  /**
+   * Updating the GCS_TOTAL_REQUEST_COUNT
+   *
+   * @param request
+   */
   @Subscribe
   private void subscriberOnHttpRequest(@Nonnull HttpRequest request) {
     incrementGcsTotalRequestCount();
   }
-
-  /** Updating the EXCEPTION_COUNT */
+  /**
+   * Updating the EXCEPTION_COUNT
+   *
+   * @param exception
+   */
   @Subscribe
   private void subscriberOnException(IOException exception) {
     incrementGcsExceptionCount();

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
@@ -253,7 +253,6 @@ public class GhfsStorageStatistics extends StorageStatistics {
     updateGcsIOSpecificStatistics(response.getStatusCode());
   }
 
-
   /**
    * Updating the GCS_TOTAL_REQUEST_COUNT
    *
@@ -263,6 +262,7 @@ public class GhfsStorageStatistics extends StorageStatistics {
   private void subscriberOnHttpRequest(@Nonnull HttpRequest request) {
     incrementGcsTotalRequestCount();
   }
+
   /**
    * Updating the EXCEPTION_COUNT
    *

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStorageStatistics.java
@@ -18,12 +18,23 @@ package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.FILES_CREATED;
 import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.INVOCATION_GET_FILE_CHECKSUM;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.EXCEPTION_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_CLIENT_RATE_LIMIT_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_CLIENT_SIDE_ERROR_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_REQUEST_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_SERVER_SIDE_ERROR_COUNT;
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.InvocationRaisingIOE;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
+import com.google.cloud.hadoop.gcsio.StatisticTypeEnum;
 import com.google.cloud.hadoop.util.ITraceFactory;
 import com.google.cloud.hadoop.util.ITraceOperation;
 import com.google.common.base.Stopwatch;
+import com.google.common.eventbus.Subscribe;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,11 +71,17 @@ public class GhfsStorageStatistics extends StorageStatistics {
 
   public GhfsStorageStatistics() {
     super(NAME);
+
+    for (GoogleCloudStorageStatistics opType : GoogleCloudStorageStatistics.values()) {
+      String symbol = opType.getSymbol();
+      opsCount.put(symbol, new AtomicLong(0));
+    }
+
     for (GhfsStatistic opType : GhfsStatistic.values()) {
       String symbol = opType.getSymbol();
       opsCount.put(symbol, new AtomicLong(0));
 
-      if (opType.getType() == GhfsStatisticTypeEnum.TYPE_DURATION) {
+      if (opType.getType() == StatisticTypeEnum.TYPE_DURATION) {
         minimums.put(getMinKey(symbol), null);
         maximums.put(getMaxKey(symbol), new AtomicLong(0));
         means.put(getMeanKey(symbol), new MeanStatistic());
@@ -92,6 +109,10 @@ public class GhfsStorageStatistics extends StorageStatistics {
     return incrementCounter(statistic, 1);
   }
 
+  private long increment(GoogleCloudStorageStatistics statistic) {
+    return incrementCounter(statistic, 1);
+  }
+
   /**
    * Increment a specific counter.
    *
@@ -100,6 +121,17 @@ public class GhfsStorageStatistics extends StorageStatistics {
    * @return the new value
    */
   long incrementCounter(GhfsStatistic op, long count) {
+    return opsCount.get(op.getSymbol()).addAndGet(count);
+  }
+
+  /**
+   * Increment a specific counter.
+   *
+   * @param op operation
+   * @param count increment value
+   * @return the new value
+   */
+  long incrementCounter(GoogleCloudStorageStatistics op, long count) {
     return opsCount.get(op.getSymbol()).addAndGet(count);
   }
 
@@ -125,7 +157,7 @@ public class GhfsStorageStatistics extends StorageStatistics {
 
   void updateStats(GhfsStatistic statistic, long durationMs, Object context) {
     checkArgument(
-        statistic.getType() == GhfsStatisticTypeEnum.TYPE_DURATION,
+        statistic.getType() == StatisticTypeEnum.TYPE_DURATION,
         String.format("Unexpected instrumentation type %s", statistic));
     updateMinMaxStats(statistic, durationMs, durationMs, context);
 
@@ -180,6 +212,59 @@ public class GhfsStorageStatistics extends StorageStatistics {
     }
   }
 
+  /**
+   * Updating the required gcs specific statistics based on httpresponse.
+   *
+   * @param statusCode
+   */
+  private void updateGcsIOSpecificStatistics(int statusCode) {
+
+    if (statusCode >= 400 && statusCode < 500) {
+      incrementGcsClientSideCounter();
+
+      if (statusCode == 429) {
+        incrementRateLimitingCounter();
+      }
+    }
+
+    if (statusCode >= 500 && statusCode < 600) {
+      incrementGcsServerSideCounter();
+    }
+  }
+
+  /**
+   * Updating the required gcs specific statistics based on GoogleJsonResponseException.
+   *
+   * @param responseException contains statusCode based on which metrics are updated
+   */
+  @Subscribe
+  private void subscriberOnGoogleJsonResponseException(
+      @Nonnull GoogleJsonResponseException responseException) {
+    updateGcsIOSpecificStatistics(responseException.getStatusCode());
+  }
+
+  /**
+   * Updating the required gcs specific statistics based on HttpResponse.
+   *
+   * @param response contains statusCode based on which metrics are updated
+   */
+  @Subscribe
+  private void subscriberOnHttpResponse(@Nonnull HttpResponse response) {
+    updateGcsIOSpecificStatistics(response.getStatusCode());
+  }
+
+  /** Updating the GCS_TOTAL_REQUEST_COUNT */
+  @Subscribe
+  private void subscriberOnHttpRequest(@Nonnull HttpRequest request) {
+    incrementGcsTotalRequestCount();
+  }
+
+  /** Updating the EXCEPTION_COUNT */
+  @Subscribe
+  private void subscriberOnException(IOException exception) {
+    incrementGcsExceptionCount();
+  }
+
   void streamReadBytes(int bytesRead) {
     incrementCounter(GhfsStatistic.STREAM_READ_BYTES, bytesRead);
   }
@@ -214,6 +299,26 @@ public class GhfsStorageStatistics extends StorageStatistics {
 
   void getFileCheckSum() {
     increment(INVOCATION_GET_FILE_CHECKSUM);
+  }
+
+  private void incrementGcsExceptionCount() {
+    increment(EXCEPTION_COUNT);
+  }
+
+  private void incrementGcsTotalRequestCount() {
+    increment(GCS_REQUEST_COUNT);
+  }
+
+  private void incrementRateLimitingCounter() {
+    increment(GCS_CLIENT_RATE_LIMIT_COUNT);
+  }
+
+  private void incrementGcsClientSideCounter() {
+    increment(GCS_CLIENT_SIDE_ERROR_COUNT);
+  }
+
+  private void incrementGcsServerSideCounter() {
+    increment(GCS_SERVER_SIDE_ERROR_COUNT);
   }
 
   private class LongIterator implements Iterator<LongStatistic> {

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFSInputStream.java
@@ -17,6 +17,7 @@
 package com.google.cloud.hadoop.fs.gcs;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -135,6 +136,7 @@ class GoogleHadoopFSInputStream extends FSInputStream {
       return -1;
     }
     if (numRead != 1) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException(
           String.format(
               "Somehow read %d bytes using single-byte buffer for path %s ending in position %d!",
@@ -252,6 +254,7 @@ class GoogleHadoopFSInputStream extends FSInputStream {
       channel.position(pos);
       seekAPITrace(SEEK_METHOD, startTimeNs, pos);
     } catch (IllegalArgumentException e) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException(e);
     }
 
@@ -314,6 +317,7 @@ class GoogleHadoopFSInputStream extends FSInputStream {
   @Override
   public int available() throws IOException {
     if (!channel.isOpen()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new ClosedChannelException();
     }
     return super.available();

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.UriPaths;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
@@ -91,6 +92,8 @@ public class GoogleHadoopFileSystem extends GoogleHadoopFileSystemBase {
     if (bucket == null || bucket.equals(rootBucket)) {
       return;
     }
+
+    GoogleCloudStorageEventBus.postOnException();
     throw new IllegalArgumentException(
         String.format(
             "Wrong bucket: %s, in path: %s, expected bucket: %s", bucket, path, rootBucket));

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -19,6 +19,7 @@ package com.google.cloud.hadoop.fs.gcs;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceFactory;
 import com.google.common.flogger.GoogleLogger;
 import java.io.BufferedOutputStream;
@@ -86,6 +87,7 @@ class GoogleHadoopOutputStream extends OutputStream {
     try {
       return gcsfs.create(gcsPath, options);
     } catch (java.nio.file.FileAlreadyExistsException e) {
+      GoogleCloudStorageEventBus.postOnException();
       throw (FileAlreadyExistsException)
           new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath))
               .initCause(e);
@@ -157,6 +159,7 @@ class GoogleHadoopOutputStream extends OutputStream {
 
   private void throwIfNotOpen() throws IOException {
     if (!isOpen()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new ClosedChannelException();
     }
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopSyncableOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopSyncableOutputStream.java
@@ -19,6 +19,7 @@ import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageItemInfo;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -233,6 +234,7 @@ public class GoogleHadoopSyncableOutputStream extends OutputStream implements Sy
         if (e instanceof InterruptedException) {
           Thread.currentThread().interrupt();
         }
+        GoogleCloudStorageEventBus.postOnException();
         throw new IOException("Failed to delete files while closing stream", e);
       }
     }
@@ -350,6 +352,7 @@ public class GoogleHadoopSyncableOutputStream extends OutputStream implements Sy
       final StorageResourceId tempResourceId =
           StorageResourceId.fromStringPath(curGcsPath.toString(), generationId);
       if (!destResourceId.getBucketName().equals(tempResourceId.getBucketName())) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new IllegalStateException(
             String.format(
                 "Destination bucket in path '%s' doesn't match temp file bucket in path '%s'",
@@ -398,6 +401,7 @@ public class GoogleHadoopSyncableOutputStream extends OutputStream implements Sy
 
   private void throwIfNotOpen() throws IOException {
     if (!isOpen()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new ClosedChannelException();
     }
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/InMemoryGlobberFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/InMemoryGlobberFileSystem.java
@@ -17,6 +17,7 @@ package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.common.collect.Maps;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -102,6 +103,7 @@ class InMemoryGlobberFileSystem extends FileSystem {
     Path qualifiedPath = makeQualified(f);
     List<FileStatus> fileStatuses = fileStatusesByParentPath.get(qualifiedPath);
     if (fileStatuses == null) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new FileNotFoundException(
           String.format("Path '%s' (qualified: '%s') does not exist.", f, qualifiedPath));
     }
@@ -120,6 +122,7 @@ class InMemoryGlobberFileSystem extends FileSystem {
     Path qualifiedPath = makeQualified(f);
     FileStatus fileStatus = fileStatusesByPath.get(f);
     if (fileStatus == null) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new FileNotFoundException(
           String.format("Path '%s' (qualified: '%s') does not exist.", f, qualifiedPath));
     }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageStatisticsTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleCloudStorageStatisticsTest.java
@@ -1,0 +1,170 @@
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_CLIENT_RATE_LIMIT_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_CLIENT_SIDE_ERROR_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_REQUEST_COUNT;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.GCS_SERVER_SIDE_ERROR_COUNT;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.emptyResponse;
+import static com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.mockTransport;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonError.ErrorInfo;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.Json;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.testing.http.HttpTesting;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.cloud.hadoop.util.ApiErrorExtractor;
+import com.google.cloud.hadoop.util.RetryHttpInitializer;
+import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import org.apache.hadoop.fs.StorageStatistics;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GoogleCloudStorageStatisticsTest {
+
+  private GoogleJsonResponseException accessDenied; // STATUS_CODE_FORBIDDEN
+  private GoogleJsonResponseException statusOk; // STATUS_CODE_OK
+
+  private GoogleHadoopFileSystem myGhfs;
+
+  private final ApiErrorExtractor errorExtractor = ApiErrorExtractor.INSTANCE;
+
+  @Before
+  public void setUp() throws Exception {
+
+    myGhfs = createInMemoryGoogleHadoopFileSystem();
+
+    accessDenied =
+        googleJsonResponseException(
+            HttpStatusCodes.STATUS_CODE_FORBIDDEN, "Forbidden", "Forbidden");
+    statusOk = googleJsonResponseException(HttpStatusCodes.STATUS_CODE_OK, "A reason", "ok");
+  }
+
+  @Test
+  public void gcs_request_count_status_metrics() throws Exception {
+    StorageStatistics stats = TestUtils.getStorageStatistics();
+    mockStatusCode(429);
+    TestUtils.verifyCounter((GhfsStorageStatistics) stats, GCS_REQUEST_COUNT, 1);
+  }
+
+  @Test
+  public void gcs_client_429_status_metrics() throws Exception {
+    StorageStatistics stats = TestUtils.getStorageStatistics();
+    mockStatusCode(429);
+    TestUtils.verifyCounterNotZero((GhfsStorageStatistics) stats, GCS_CLIENT_RATE_LIMIT_COUNT);
+  }
+
+  /** Validates accessDenied(). */
+  @Test
+  public void testAccessDenied() {
+    StorageStatistics stats = TestUtils.getStorageStatistics();
+
+    // Check success case.
+    assertThat(errorExtractor.accessDenied(accessDenied)).isTrue();
+    assertThat(errorExtractor.accessDenied(new IOException(accessDenied))).isTrue();
+    assertThat(errorExtractor.accessDenied(new IOException(new IOException(accessDenied))))
+        .isTrue();
+
+    // Check failure case.
+    assertThat(errorExtractor.accessDenied(statusOk)).isFalse();
+    assertThat(errorExtractor.accessDenied(new IOException(statusOk))).isFalse();
+
+    TestUtils.verifyCounterNotZero((GhfsStorageStatistics) stats, GCS_CLIENT_SIDE_ERROR_COUNT);
+  }
+
+  @Test
+  public void isClientError_GoogleJsonErrorWithStatusBadGatewayReturnFalse() throws IOException {
+    StorageStatistics stats = TestUtils.getStorageStatistics();
+
+    IOException withJsonError =
+        googleJsonResponseException(
+            HttpStatusCodes.STATUS_CODE_BAD_GATEWAY, "Bad gateway", "Bad gateway", "Bad gateway");
+    assertThat(errorExtractor.clientError(withJsonError)).isFalse();
+
+    TestUtils.verifyCounterNotZero((GhfsStorageStatistics) stats, GCS_SERVER_SIDE_ERROR_COUNT);
+  }
+
+  /** Builds a fake GoogleJsonResponseException for testing API error handling. */
+  private static GoogleJsonResponseException googleJsonResponseException(
+      int httpStatus, String reason, String message) throws IOException {
+    return googleJsonResponseException(httpStatus, reason, message, message);
+  }
+
+  /** Builds a fake GoogleJsonResponseException for testing API error handling. */
+  private static GoogleJsonResponseException googleJsonResponseException(
+      int httpStatus, String reason, String message, String httpStatusString) throws IOException {
+    ErrorInfo errorInfo = new ErrorInfo();
+    errorInfo.setReason(reason);
+    errorInfo.setMessage(message);
+    return googleJsonResponseException(httpStatus, errorInfo, httpStatusString);
+  }
+
+  private static GoogleJsonResponseException googleJsonResponseException(
+      int status, ErrorInfo errorInfo, String httpStatusString) throws IOException {
+    JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+    HttpTransport transport =
+        new MockHttpTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            errorInfo.setFactory(jsonFactory);
+            GoogleJsonError jsonError = new GoogleJsonError();
+            jsonError.setCode(status);
+            jsonError.setErrors(Collections.singletonList(errorInfo));
+            jsonError.setMessage(httpStatusString);
+            jsonError.setFactory(jsonFactory);
+            GenericJson errorResponse = new GenericJson();
+            errorResponse.set("error", jsonError);
+            errorResponse.setFactory(jsonFactory);
+            return new MockLowLevelHttpRequest()
+                .setResponse(
+                    new MockLowLevelHttpResponse()
+                        .setContent(errorResponse.toPrettyString())
+                        .setContentType(Json.MEDIA_TYPE)
+                        .setStatusCode(status));
+          }
+        };
+    HttpRequest request =
+        transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    request.setThrowExceptionOnExecuteError(false);
+    HttpResponse response = request.execute();
+    return GoogleJsonResponseException.from(jsonFactory, response);
+  }
+
+  private void mockStatusCode(int statusCode) throws IOException {
+    RetryHttpInitializer retryHttpInitializer =
+        new RetryHttpInitializer(
+            null,
+            RetryHttpInitializerOptions.builder()
+                .setDefaultUserAgent("foo-user-agent")
+                .setHttpHeaders(ImmutableMap.of("header-key", "header-value"))
+                .setMaxRequestRetries(5)
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build());
+
+    HttpRequestFactory requestFactory =
+        mockTransport(emptyResponse(statusCode), emptyResponse(statusCode), emptyResponse(200))
+            .createRequestFactory(retryHttpInitializer);
+
+    HttpRequest req = requestFactory.buildGetRequest(new GenericUrl("http://fake-url.com"));
+    HttpResponse res = req.execute();
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -28,6 +28,7 @@ import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_REPAIR_IMPLICIT_DIRECTORIES_ENABLE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics.EXCEPTION_COUNT;
 import static com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage.getInMemoryGoogleCloudStorageOptions;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.ENABLE_SERVICE_ACCOUNTS_SUFFIX;
 import static com.google.common.base.StandardSystemProperty.USER_NAME;
@@ -46,7 +47,9 @@ import com.google.cloud.hadoop.fs.gcs.auth.TestDelegationTokenBindingImpl;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
 import com.google.cloud.hadoop.gcsio.MethodOutcome;
+import com.google.cloud.hadoop.gcsio.StatisticTypeEnum;
 import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
@@ -124,6 +127,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   @Test
   @Override
   public void testRename() throws Exception {
+    StorageStatistics stats = TestUtils.getStorageStatistics();
+
     renameHelper(
         new HdfsBehavior() {
           /**
@@ -134,6 +139,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
             return new MethodOutcome(MethodOutcome.Type.RETURNS_TRUE);
           }
         });
+
+    TestUtils.verifyCounterNotZero((GhfsStorageStatistics) stats, EXCEPTION_COUNT);
   }
 
   @Test
@@ -322,11 +329,13 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   @Test
   public void createNonRecursive_throwsExceptionWhenParentFolderNoExists() {
     GoogleHadoopFileSystem myGhfs = (GoogleHadoopFileSystem) ghfs;
+    StorageStatistics stats = TestUtils.getStorageStatistics();
     Path filePath = new Path("bad/path");
     FileNotFoundException exception =
         assertThrows(
             FileNotFoundException.class,
             () -> myGhfs.createNonRecursive(filePath, true, 1, (short) 1, 1, () -> {}));
+    TestUtils.verifyCounterNotZero((GhfsStorageStatistics) stats, EXCEPTION_COUNT);
     assertThat(exception).hasMessageThat().startsWith("Can not create");
   }
 
@@ -1418,13 +1427,22 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
       String metricName = ghfsStatistic.getSymbol();
 
       checkMetric(metricName, statistics, metricNames, statsString);
-      if (ghfsStatistic.getType() == GhfsStatisticTypeEnum.TYPE_DURATION) {
+      if (ghfsStatistic.getType() == StatisticTypeEnum.TYPE_DURATION) {
         expected += 3;
 
         for (String suffix : ImmutableList.of("_min", "_max", "_mean")) {
           checkMetric(metricName + suffix, statistics, metricNames, statsString);
         }
       }
+    }
+
+    for (GoogleCloudStorageStatistics googleCloudStorageStatusStatistic :
+        GoogleCloudStorageStatistics.values()) {
+      expected++;
+
+      String metricName = googleCloudStorageStatusStatistic.getSymbol();
+
+      checkMetric(metricName, statistics, metricNames, statsString);
     }
 
     assertEquals(expected, metricNames.size());

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/TestUtils.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/TestUtils.java
@@ -18,6 +18,7 @@ package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
 import org.apache.hadoop.fs.GlobalStorageStatistics;
 
 class TestUtils {
@@ -44,5 +45,15 @@ class TestUtils {
 
   static void verifyCounter(GhfsStorageStatistics stats, GhfsStatistic statName, int expected) {
     assertThat(stats.getLong(statName.getSymbol())).isEqualTo(expected);
+  }
+
+  static void verifyCounter(
+      GhfsStorageStatistics stats, GoogleCloudStorageStatistics statName, int expected) {
+    assertThat(stats.getLong(statName.getSymbol())).isEqualTo(expected);
+  }
+
+  static void verifyCounterNotZero(
+      GhfsStorageStatistics stats, GoogleCloudStorageStatistics statName) {
+    assertThat(stats.getLong(statName.getSymbol())).isNotEqualTo(0);
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -28,6 +28,7 @@ import com.google.cloud.hadoop.util.AccessBoundary;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PartFileCleanupType;
 import com.google.cloud.hadoop.util.ErrorTypeExtractor;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.GrpcErrorTypeExtractor;
 import com.google.cloud.storage.BlobWriteSessionConfig;
 import com.google.cloud.storage.BlobWriteSessionConfigs;
@@ -192,6 +193,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
       checkState(generation != 0, "Generation should not be 0 for an existing item");
       return generation;
     }
+    GoogleCloudStorageEventBus.postOnException();
     throw new FileAlreadyExistsException(String.format("Object %s already exists.", resourceId));
   }
 
@@ -263,6 +265,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
       case JOURNALING:
         if (writeOptions.getTemporaryPaths() == null
             || writeOptions.getTemporaryPaths().isEmpty()) {
+          GoogleCloudStorageEventBus.postOnException();
           throw new IllegalArgumentException(
               "Upload using `Journaling` requires the property:fs.gs.write.temporary.dirs to be set.");
         }
@@ -279,6 +282,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
             .withExecutorSupplier(getPCUExecutorSupplier(pCUExecutorService))
             .withPartNamingStrategy(getPartNamingStrategy(writeOptions.getPartFileNamePrefix()));
       default:
+        GoogleCloudStorageEventBus.postOnException();
         throw new IllegalArgumentException(
             String.format("Upload type:%s is not supported.", writeOptions.getUploadType()));
     }
@@ -293,6 +297,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
       case ALWAYS:
         return PartCleanupStrategy.always();
       default:
+        GoogleCloudStorageEventBus.postOnException();
         throw new IllegalArgumentException(
             String.format("Cleanup type:%s is not handled.", cleanupType));
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientWriteChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientWriteChannel.java
@@ -20,6 +20,7 @@ import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.encodeMetadat
 import static com.google.storage.v2.ServiceConstants.Values.MAX_WRITE_CHUNK_BYTES;
 
 import com.google.cloud.hadoop.util.BaseAbstractGoogleAsyncWriteChannel;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BlobWriteSession;
@@ -71,6 +72,7 @@ class GoogleCloudStorageClientWriteChannel extends BaseAbstractGoogleAsyncWriteC
     try {
       uploadOperation = threadPool.submit(new UploadOperation(pipeSource, this.resourceId));
     } catch (Exception e) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new RuntimeException(String.format("Failed to start upload for '%s'", resourceId), e);
     }
   }
@@ -148,6 +150,7 @@ class GoogleCloudStorageClientWriteChannel extends BaseAbstractGoogleAsyncWriteC
         logger.atFiner().log("Uploaded all chunks for resource %s", resourceId);
         return true;
       } catch (Exception e) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new IOException(
             String.format("Error occurred while uploading resource %s", resourceId), e);
       }
@@ -187,6 +190,7 @@ class GoogleCloudStorageClientWriteChannel extends BaseAbstractGoogleAsyncWriteC
       // the gcs-object.
       writableByteChannel.close();
     } catch (Exception e) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException(String.format("Upload failed for '%s'", resourceId), e);
     } finally {
       writableByteChannel = null;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -35,6 +35,7 @@ import com.google.cloud.hadoop.gcsio.cooplock.CoopLockOperationRename;
 import com.google.cloud.hadoop.util.AccessBoundary;
 import com.google.cloud.hadoop.util.CheckedFunction;
 import com.google.cloud.hadoop.util.CredentialAdapter;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ITraceOperation;
 import com.google.cloud.hadoop.util.LazyExecutorService;
 import com.google.cloud.hadoop.util.ThreadTrace;
@@ -269,6 +270,7 @@ public class GoogleCloudStorageFileSystem {
         StorageResourceId.fromUriPath(path, /* allowEmptyObjectName=*/ true);
 
     if (resourceId.isDirectory()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException(
           String.format(
               "Cannot create a file whose name looks like a directory: '%s'", resourceId));
@@ -295,6 +297,7 @@ public class GoogleCloudStorageFileSystem {
 
       // Check if a directory with the same name exists.
       if (getFromFuture(conflictingDirExist)) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new FileAlreadyExistsException("A directory with that name exists: " + path);
       }
     }
@@ -371,6 +374,7 @@ public class GoogleCloudStorageFileSystem {
 
     FileInfo fileInfo = getFileInfo(path);
     if (!fileInfo.exists()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new FileNotFoundException("Item not found: " + path);
     }
 
@@ -401,6 +405,7 @@ public class GoogleCloudStorageFileSystem {
                       fileInfo.getPath(), DELETE_RENAME_LIST_OPTIONS, /* pageToken= */ null)
                   .getItems();
       if (!itemsToDelete.isEmpty() && !recursive) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new DirectoryNotEmptyException("Cannot delete a non-empty directory.");
       }
     } else {
@@ -589,6 +594,7 @@ public class GoogleCloudStorageFileSystem {
 
     // Throw if the source file does not exist.
     if (!srcInfo.exists()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new FileNotFoundException("Item not found: " + src);
     }
 
@@ -605,6 +611,7 @@ public class GoogleCloudStorageFileSystem {
       dstInfo = fileInfos.get(1);
       if (!srcInfo.exists()) {
         coopLockOp.ifPresent(CoopLockOperationRename::unlock);
+        GoogleCloudStorageEventBus.postOnException();
         throw new FileNotFoundException("Item not found: " + src);
       }
       if (!srcInfo.isDirectory()) {
@@ -680,16 +687,19 @@ public class GoogleCloudStorageFileSystem {
 
     // Throw if src is a file and dst == GCS_ROOT
     if (!srcInfo.isDirectory() && dst.equals(GCS_ROOT)) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException("A file cannot be created in root.");
     }
 
     // Throw if the destination is a file that already exists, and it's not a source file.
     if (dstInfo.exists() && !dstInfo.isDirectory() && (srcInfo.isDirectory() || !dst.equals(src))) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException("Cannot overwrite an existing file: " + dst);
     }
 
     // Rename operation cannot be completed if parent of destination does not exist.
     if (dstParentInfo != null && !dstParentInfo.exists()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException(
           "Cannot rename because path does not exist: " + dstParentInfo.getPath());
     }
@@ -716,6 +726,7 @@ public class GoogleCloudStorageFileSystem {
 
       // Throw if renaming directory to self - this is forbidden
       if (src.equals(dst)) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new IOException("Rename dir to self is forbidden");
       }
 
@@ -724,6 +735,7 @@ public class GoogleCloudStorageFileSystem {
       // because this means that src is a parent directory of dst
       // and src cannot be "renamed" to its subdirectory
       if (!dstRelativeToSrc.equals(dst)) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new IOException("Rename to subdir is forbidden");
       }
 
@@ -744,6 +756,7 @@ public class GoogleCloudStorageFileSystem {
 
       if (dstInfo.isDirectory()) {
         if (!dstInfo.exists()) {
+          GoogleCloudStorageEventBus.postOnException();
           throw new IOException("Cannot rename because path does not exist: " + dstInfo.getPath());
         } else {
           dst = dst.resolve(srcItemName);
@@ -923,6 +936,7 @@ public class GoogleCloudStorageFileSystem {
       if (e instanceof InterruptedException) {
         Thread.currentThread().interrupt();
       }
+      GoogleCloudStorageEventBus.postOnException();
       throw new IOException(
           String.format(
               "Failed to get result: %s", e instanceof ExecutionException ? e.getCause() : e),
@@ -1058,6 +1072,7 @@ public class GoogleCloudStorageFileSystem {
           return listedInfo;
         }
       } catch (Exception e) {
+        GoogleCloudStorageEventBus.postOnException();
         dirItemInfosFuture.cancel(/* mayInterruptIfRunning= */ true);
         throw e;
       }
@@ -1065,6 +1080,7 @@ public class GoogleCloudStorageFileSystem {
 
     List<GoogleCloudStorageItemInfo> dirItemInfos = getFromFuture(dirItemInfosFuture);
     if (pathId.isStorageObject() && dirItemInfos.isEmpty()) {
+      GoogleCloudStorageEventBus.postOnException();
       throw new FileNotFoundException("Item not found: " + path);
     }
 
@@ -1123,6 +1139,7 @@ public class GoogleCloudStorageFileSystem {
           return itemInfo;
         }
       } catch (Exception e) {
+        GoogleCloudStorageEventBus.postOnException();
         listDirFuture.cancel(/* mayInterruptIfRunning= */ true);
         throw e;
       }
@@ -1252,6 +1269,7 @@ public class GoogleCloudStorageFileSystem {
     // we make this check therefore this is a good faith effort and not a guarantee.
     for (GoogleCloudStorageItemInfo fileInfo : gcs.getItemInfos(fileIds)) {
       if (fileInfo.exists()) {
+        GoogleCloudStorageEventBus.postOnException();
         throw new FileAlreadyExistsException(
             "Cannot create directories because of existing file: " + fileInfo.getResourceId());
       }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
@@ -26,7 +26,7 @@ import java.util.EnumSet;
 /** Statistics which are collected in GCS Client Side. */
 public enum GoogleCloudStorageStatistics {
 
-  /** Client-side Status Code statistics */
+  /** GCS connector specific statistics */
   GCS_REQUEST_COUNT(
       "gcs_total_request_count", "Counts the total number of gcs requests made", TYPE_COUNTER),
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import java.util.EnumSet;
 
-/** Statistics which are collected in GCS Client Side. */
+/** Statistics which are collected in GCS Connector */
 public enum GoogleCloudStorageStatistics {
 
   /** GCS connector specific statistics */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageStatistics.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.cloud.hadoop.gcsio.StatisticTypeEnum.TYPE_COUNTER;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import java.util.EnumSet;
+
+/** Statistics which are collected in GCS Client Side. */
+public enum GoogleCloudStorageStatistics {
+
+  /** Client-side Status Code statistics */
+  GCS_REQUEST_COUNT(
+      "gcs_total_request_count", "Counts the total number of gcs requests made", TYPE_COUNTER),
+
+  EXCEPTION_COUNT("exception_count", "Counts the number of exceptions encountered", TYPE_COUNTER),
+
+  GCS_CLIENT_SIDE_ERROR_COUNT(
+      "gcs_client_side_error_count",
+      "Counts the occurrence of client side error status code",
+      TYPE_COUNTER),
+
+  GCS_SERVER_SIDE_ERROR_COUNT(
+      "gcs_server_side_error_count",
+      "Counts the occurrence of server side error status code",
+      TYPE_COUNTER),
+
+  GCS_CLIENT_RATE_LIMIT_COUNT(
+      "gcs_client_rate_limit_error_count", "Counts the occurence of 429 status code", TYPE_COUNTER);
+
+  public static final ImmutableSet<GoogleCloudStorageStatistics> VALUES =
+      ImmutableSet.copyOf(EnumSet.allOf(GoogleCloudStorageStatistics.class));
+
+  /** A map used to support the {@link #fromSymbol(String)} call. */
+  private static final ImmutableMap<String, GoogleCloudStorageStatistics> SYMBOL_MAP =
+      Maps.uniqueIndex(Iterators.forArray(values()), GoogleCloudStorageStatistics::getSymbol);
+
+  /**
+   * Statistic definition.
+   *
+   * @param symbol name
+   * @param description description.
+   * @param type type
+   */
+  GoogleCloudStorageStatistics(String symbol, String description, StatisticTypeEnum type) {
+    this.symbol = symbol;
+    this.description = description;
+    this.type = type;
+  }
+
+  /** Statistic name. */
+  private final String symbol;
+
+  /** Statistic description. */
+  private final String description;
+
+  /** Statistic type. */
+  private final StatisticTypeEnum type;
+
+  /** the name of the statistic */
+  public String getSymbol() {
+    return symbol;
+  }
+
+  /**
+   * Get a statistic from a symbol.
+   *
+   * @param symbol statistic to look up
+   * @return the value or null.
+   */
+  public static GoogleCloudStorageStatistics fromSymbol(String symbol) {
+    return SYMBOL_MAP.get(symbol);
+  }
+
+  /** The description of the Statistic */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * The string value is simply the symbol. This makes this operation very low cost.
+   *
+   * @return the symbol of this statistic.
+   */
+  @Override
+  public String toString() {
+    return symbol;
+  }
+
+  /**
+   * What type is this statistic?
+   *
+   * @return the type.
+   */
+  public StatisticTypeEnum getType() {
+    return type;
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StatisticTypeEnum.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StatisticTypeEnum.java
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-package com.google.cloud.hadoop.fs.gcs;
-
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
+package com.google.cloud.hadoop.gcsio;
 
 /** Enum of statistic types. */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
-public enum GhfsStatisticTypeEnum {
+public enum StatisticTypeEnum {
 
   /** Counter. Counts the number of occurrences of each operation */
   TYPE_COUNTER,

--- a/util/src/main/java/com/google/cloud/hadoop/util/ApiErrorExtractor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/ApiErrorExtractor.java
@@ -306,6 +306,8 @@ public class ApiErrorExtractor {
     Throwable cause = throwable;
     while (cause != null) {
       if (cause instanceof GoogleJsonResponseException) {
+        GoogleCloudStorageEventBus.postOnGoogleJsonResponseException(
+            (GoogleJsonResponseException) cause);
         return (GoogleJsonResponseException) cause;
       }
       cause = cause.getCause();

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -20,12 +20,15 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.common.eventbus.EventBus;
+import java.io.IOException;
 
 /** Event Bus class */
 public class GoogleCloudStorageEventBus {
 
   /** Hold the instance of the event bus here */
   private static EventBus eventBus = new EventBus();
+
+  private static IOException exception = new IOException();
 
   /**
    * Method to register an obj to event bus
@@ -65,6 +68,6 @@ public class GoogleCloudStorageEventBus {
 
   /** Posting Exception to invoke corresponding Subscriber method. */
   public static void postOnException() {
-    eventBus.post(null);
+    eventBus.post(exception);
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -66,7 +66,10 @@ public class GoogleCloudStorageEventBus {
     eventBus.post(request);
   }
 
-  /** Posting Exception to invoke corresponding Subscriber method. */
+  /** Posting Exception to invoke corresponding Subscriber method.
+   * Passing a dummy exception as EventBus has @ElementTypesAreNonnullByDefault annotation.
+   *
+   * */
   public static void postOnException() {
     eventBus.post(exception);
   }

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.util;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.common.eventbus.EventBus;
+import java.io.IOException;
+
+/** Event Bus class */
+public class GoogleCloudStorageEventBus {
+
+  /** Hold the instance of the event bus here */
+  private static EventBus eventBus = new EventBus();
+
+  private static IOException exception = new IOException();
+
+  /**
+   * Method to register an obj to event bus
+   *
+   * @param obj to register to event bus
+   */
+  public static void register(Object obj) {
+    eventBus.register(obj);
+  }
+
+  /**
+   * Posting GoogleJsonResponseException to invoke corresponding Subscriber method.
+   *
+   * @param response contains statusCode based on which metrics are updated in Subscriber method
+   */
+  public static void postOnGoogleJsonResponseException(GoogleJsonResponseException response) {
+    eventBus.post(response);
+  }
+
+  /**
+   * Posting HttpResponse to invoke corresponding Subscriber method.
+   *
+   * @param response contains statusCode based on which metrics are updated in Subscriber method
+   */
+  public static void postOnHttpResponse(HttpResponse response) {
+    eventBus.post(response);
+  }
+
+  /**
+   * Posting HttpRequest to invoke corresponding Subscriber method.
+   *
+   * @param request based on which metrics are updated in Subscriber method
+   */
+  public static void postOnHttpRequest(HttpRequest request) {
+    eventBus.post(request);
+  }
+
+  /** Posting Exception to invoke corresponding Subscriber method. */
+  public static void postOnException() {
+    eventBus.post(exception);
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -66,10 +66,10 @@ public class GoogleCloudStorageEventBus {
     eventBus.post(request);
   }
 
-  /** Posting Exception to invoke corresponding Subscriber method.
-   * Passing a dummy exception as EventBus has @ElementTypesAreNonnullByDefault annotation.
-   *
-   * */
+  /**
+   * Posting Exception to invoke corresponding Subscriber method. Passing a dummy exception as
+   * EventBus has @ElementTypesAreNonnullByDefault annotation.
+   */
   public static void postOnException() {
     eventBus.post(exception);
   }

--- a/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/GoogleCloudStorageEventBus.java
@@ -20,15 +20,12 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.common.eventbus.EventBus;
-import java.io.IOException;
 
 /** Event Bus class */
 public class GoogleCloudStorageEventBus {
 
   /** Hold the instance of the event bus here */
   private static EventBus eventBus = new EventBus();
-
-  private static IOException exception = new IOException();
 
   /**
    * Method to register an obj to event bus
@@ -68,6 +65,6 @@ public class GoogleCloudStorageEventBus {
 
   /** Posting Exception to invoke corresponding Subscriber method. */
   public static void postOnException() {
-    eventBus.post(exception);
+    eventBus.post(null);
   }
 }

--- a/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java
@@ -170,6 +170,10 @@ public class RetryHttpInitializer implements HttpRequestInitializer {
     @Override
     public boolean handleResponse(HttpRequest request, HttpResponse response, boolean supportsRetry)
         throws IOException {
+
+      // Incrementing GCS Static Statistics using status code of response.
+      GoogleCloudStorageEventBus.postOnHttpResponse(response);
+
       if (credential != null && credential.handleResponse(request, response, supportsRetry)) {
         // If credential decides it can handle it, the return code or message indicated something
         // specific to authentication, and no backoff is desired.

--- a/util/src/main/java/com/google/cloud/hadoop/util/interceptors/InvocationIdInterceptor.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/interceptors/InvocationIdInterceptor.java
@@ -19,6 +19,7 @@ package com.google.cloud.hadoop.util.interceptors;
 import com.google.api.client.http.HttpExecuteInterceptor;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
+import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.ThreadTrace;
 import com.google.cloud.hadoop.util.TraceOperation;
 import com.google.common.annotations.VisibleForTesting;
@@ -68,6 +69,7 @@ public final class InvocationIdInterceptor implements HttpExecuteInterceptor {
       } else {
         newValue = invocationEntry;
       }
+      GoogleCloudStorageEventBus.postOnHttpRequest(request);
       headers.set(GOOG_API_CLIENT, newValue);
 
       ThreadTrace tt = TraceOperation.current();


### PR DESCRIPTION
Added GCS Connector Specific Metrics :
1. gcs_client_side_error_count : Counts the occurrence of client side error status code
2. gcs_server_side_error_count: Counts the occurrence of server side error status code
3. gcs_client_rate_limit_count: Counts the occurrence of 429 status code
4. gcs_total_request_count: Counts the total number of gcs requests made
5. exception_count: Counts the number of exceptions encountered (Can be expanded in future)