### PR TITLE
Test cleanup (#1112)

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
       - 'VCS_COMMIT_ID=$COMMIT_SHA'
       - 'VCS_TAG=$TAG_NAME'
       - 'CI_BUILD_ID=$BUILD_ID'
-      - 'GCS_TEST_DIRECT_PATH_PREFERRED=false'
+      - 'GCS_TEST_DIRECT_PATH_PREFERRED=true'
 
 # Tests take on average 25 minutes to run
 timeout: 2400s

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationTest;
 import com.google.cloud.hadoop.gcsio.StringPaths;
 import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.GoogleLogger;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -46,10 +47,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -66,6 +64,7 @@ import org.junit.Test;
  * GoogleCloudStorageFileSystemIntegrationTest.
  */
 public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSystemIntegrationTest {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   // GHFS access instance.
   FileSystem ghfs;
@@ -80,11 +79,35 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
   /** Perform initialization after creating test instances. */
   public void postCreateInit(HadoopFileSystemIntegrationHelper helper) throws IOException {
     ghfsHelper = helper;
-    ghfsHelper.ghfs.mkdirs(new Path(ghfsHelper.ghfs.getUri()));
+    makeDirectory();
     super.postCreateInit(ghfsHelper);
 
     // Ensures that we do not accidentally end up testing wrong functionality.
     gcsfs = null;
+  }
+
+  private void makeDirectory() throws IOException {
+    int maxRetries = 5;
+    int retry = 0;
+    while (true) {
+      retry++;
+      try {
+        ghfsHelper.ghfs.mkdirs(new Path(ghfsHelper.ghfs.getUri()));
+        return;
+      } catch (IOException e) {
+        logger.atInfo().withCause(e).log(
+            "Encountered error %s while creating directory. Retrying %d", e.getMessage(), retry);
+        if (retry == maxRetries) {
+          throw e;
+        }
+        try {
+          // Sometime this can hit Create bucket rate limit. Retrying a few time to overcome this.
+          Thread.sleep(ThreadLocalRandom.current().nextInt(2_000, 10_000));
+        } catch (InterruptedException ex) {
+          // Ignored
+        }
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
Enable grpc in intergration tests

Add retry in create bucket to overcome ratelimit issues