### PR TITLE
Configure timeout

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -244,7 +244,8 @@ public class GoogleHadoopFileSystemConfiguration {
 
   /** Configuration key for the connect timeout (in millisecond) for HTTP request to GCS. */
   public static final HadoopConfigurationProperty<Integer> GCS_HTTP_CONNECT_TIMEOUT =
-      new HadoopConfigurationProperty<>("fs.gs.http.connect-timeout", 20 * 1000);
+      new HadoopConfigurationProperty<>(
+          "fs.gs.http.connect-timeout", GoogleCloudStorageOptions.HTTP_REQUEST_CONNECT_TIMEOUT);
 
   /** Configuration key for the connect timeout (in millisecond) for HTTP request to GCS. */
   public static final HadoopConfigurationProperty<Integer> GCS_HTTP_READ_TIMEOUT =

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -1518,7 +1518,6 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   private static Long getMetricValue(StorageStatistics stats, GhfsStatistic invocationCreate) {
-
     return stats.getLong(invocationCreate.getSymbol());
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -1518,6 +1518,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   private static Long getMetricValue(StorageStatistics stats, GhfsStatistic invocationCreate) {
+
     return stats.getLong(invocationCreate.getSymbol());
   }
 }


### PR DESCRIPTION
Making "fs.gs.http.connect-timeout" property configurable. Default is 20 seconds but customer can now set it as per their requirements. 