### PR TITLE
Add getFileInfoObject API in gcsio

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/HadoopFileSystemTestBase.java
@@ -995,6 +995,9 @@ public abstract class HadoopFileSystemTestBase extends GoogleCloudStorageFileSys
   public void testGetFileInfos() {}
 
   @Override
+  public void testGetFileInfoObject() {}
+
+  @Override
   public void testFileCreationSetsAttributes() {}
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystem.java
@@ -262,6 +262,15 @@ public interface GoogleCloudStorageFileSystem {
   FileInfo getFileInfo(URI path) throws IOException;
 
   /**
+   * Gets information about the given path item. Here path should be pointing to a gcs object and
+   * can't be a directory
+   *
+   * @param path The path we want information about.
+   * @return Information about the given path item.
+   */
+  FileInfo getFileInfoObject(URI path) throws IOException;
+
+  /**
    * Gets information about each path in the given list; more efficient than calling getFileInfo()
    * on each path individually in a loop.
    *

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -291,7 +291,6 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
     StorageResourceId resourceId =
         StorageResourceId.fromUriPath(path, /* allowEmptyObjectName= */ false);
     checkArgument(!resourceId.isDirectory(), "Cannot open a directory for reading: %s", path);
-    gcs.getItemInfo(resourceId);
 
     return gcs.open(resourceId, readOptions);
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -291,6 +291,7 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
     StorageResourceId resourceId =
         StorageResourceId.fromUriPath(path, /* allowEmptyObjectName= */ false);
     checkArgument(!resourceId.isDirectory(), "Cannot open a directory for reading: %s", path);
+    gcs.getItemInfo(resourceId);
 
     return gcs.open(resourceId, readOptions);
   }
@@ -858,6 +859,20 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
         FileInfo.fromItemInfo(
             getFileInfoInternal(resourceId, /* inferImplicitDirectories= */ true));
     logger.atFiner().log("getFileInfo(path: %s): %s", path, fileInfo);
+    return fileInfo;
+  }
+
+  @Override
+  public FileInfo getFileInfoObject(URI path) throws IOException {
+    checkArgument(path != null, "path must not be null");
+    StorageResourceId resourceId = StorageResourceId.fromUriPath(path, true);
+    checkArgument(
+        !resourceId.isDirectory(),
+        String.format(
+            "path must be an object and not a directory, path: %s, resourceId: %s",
+            path, resourceId));
+    FileInfo fileInfo = FileInfo.fromItemInfo(gcs.getItemInfo(resourceId));
+    logger.atFiner().log("getFileInfoObject(path: %s): %s", path, fileInfo);
     return fileInfo;
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -224,6 +225,22 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
     FileInfo fileInfo = gcsfs.getFileInfo(path);
     assertThat(fileInfo.getPath()).isEqualTo(path);
     validateFileInfoInternal(bucketName, objectName, expectedToExist, fileInfo);
+  }
+
+  protected void validateGetFileInfoObject(
+      String bucketName, String objectName, boolean expectedToExist) throws IOException {
+    URI path = gcsiHelper.getPath(bucketName, objectName);
+    if (StringPaths.isDirectoryPath(objectName)) {
+      IllegalArgumentException exception =
+          assertThrows(IllegalArgumentException.class, () -> gcsfs.getFileInfoObject(path));
+      assertThat(exception)
+          .hasMessageThat()
+          .containsMatch(Pattern.compile("path must be an object and not a directory"));
+    } else {
+      FileInfo fileInfo = gcsfs.getFileInfoObject(path);
+      assertThat(fileInfo.getPath()).isEqualTo(path);
+      validateFileInfoInternal(bucketName, objectName, expectedToExist, fileInfo);
+    }
   }
 
   /**
@@ -475,6 +492,32 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
 
     validateListFileInfo(
         null, null, /* expectedToExist= */ true, sharedBucketName1, sharedBucketName2, testBucket);
+  }
+
+  @Test
+  public void testGetFileInfoObject() throws Exception {
+    // Objects created for this test.
+    String[] objectNames = {"d1/c1"};
+
+    // -------------------------------------------------------
+    // Create test objects.
+    String testBucket = gcsiHelper.createUniqueBucket("list");
+    gcsiHelper.createObjectsWithSubdirs(testBucket, objectNames);
+
+    // -------------------------------------------------------
+    // Tests for getItemInfoObject().
+    // -------------------------------------------------------
+
+    // Verify that getItemInfoObject() returns correct info for each object.
+    for (String objectName : objectNames) {
+      validateGetFileInfoObject(testBucket, objectName, /* expectedToExist= */ true);
+    }
+
+    String[] pathDoesNotExist = {"/", "d1", "d1/"};
+
+    for (String objectName : pathDoesNotExist) {
+      validateGetFileInfoObject(testBucket, objectName, /* expectedToExist= */ false);
+    }
   }
 
   @Test


### PR DESCRIPTION
Adding a new API `getFileInfoObject`. It differs from getFileInfo in following cases

1. getFileInfo provides the info even for a directory, getFileInfoObject will only provide valid responses if provided `path` is a valid gcs object.
2. getFileInfo makes two parallel calls to `listObject` and `getItemInfo` where as `getFileInfoObject` will only make a call to  `getItemInfo`.

This API will hep in extracting fileInfo where we know for sure that request path is an object and not a directory. Having this knowledge will be cost effective as we will be avoiding a class 'A' operation i.e. listObject call.