### PR TITLE
control grpc write path via flag

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.hadoop.fs.gcs;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageOptions.GRPC_WRITE_DEFAULT;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.HTTP_TRANSPORT_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_ADDRESS_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialConfiguration.PROXY_PASSWORD_SUFFIX;
@@ -497,6 +498,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<ClientType> GCS_CLIENT_TYPE =
       new HadoopConfigurationProperty<>("fs.gs.client.type", ClientType.HTTP_API_CLIENT);
 
+  /** Configuration key to configure client to use for GCS access. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_GRPC_WRITE_ENABLE =
+      new HadoopConfigurationProperty<>("fs.gs.grpc.write.enable", GRPC_WRITE_DEFAULT);
+
   /**
    * Configuration key to configure the properties to optimize gcs-write. This config will be
    * effective only if fs.gs.client.type is set to STORAGE_CLIENT.
@@ -579,6 +584,7 @@ public class GoogleHadoopFileSystemConfiguration {
     String projectId = GCS_PROJECT_ID.get(config, config::get);
     return GoogleCloudStorageOptions.builder()
         .setStorageRootUrl(GCS_ROOT_URL.get(config, config::get))
+        .setGrpcWriteEnabled(GCS_GRPC_WRITE_ENABLE.get(config, config::getBoolean))
         .setStorageServicePath(GCS_SERVICE_PATH.get(config, config::get))
         .setAutoRepairImplicitDirectoriesEnabled(
             GCS_REPAIR_IMPLICIT_DIRECTORIES_ENABLE.get(config, config::getBoolean))

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -103,6 +103,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.grpc.write.buffered.requests", 20L);
           put("fs.gs.grpc.write.timeout.ms", 10 * 60 * 1000L);
           put("fs.gs.grpc.write.message.timeout.ms", 3 * 1000L);
+          put("fs.gs.grpc.write.enable", false);
           put("fs.gs.hierarchical.namespace.folders.enable", false);
           put("fs.gs.http.connect-timeout", 20_000);
           put("fs.gs.http.max.retry", 10);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -119,6 +119,10 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
   @Override
   public WritableByteChannel create(StorageResourceId resourceId, CreateObjectOptions options)
       throws IOException {
+    if (!storageOptions.isGrpcWriteEnabled()) {
+      return super.create(resourceId, options);
+    }
+
     logger.atFiner().log("create(%s)", resourceId);
     checkArgument(
         resourceId.isStorageObject(), "Expected full StorageObject id, got %s", resourceId);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -90,6 +90,8 @@ public abstract class GoogleCloudStorageOptions {
   /** Default setting for whether or not to use rewrite request for copy operation. */
   public static final boolean COPY_WITH_REWRITE_DEFAULT = false;
 
+  public static final boolean GRPC_WRITE_DEFAULT = false;
+
   /** Default setting for max number of bytes rewritten per rewrite request/call. */
   public static final int MAX_BYTES_REWRITTEN_PER_CALL_DEFAULT = 0;
 
@@ -148,7 +150,8 @@ public abstract class GoogleCloudStorageOptions {
         .setOperationTraceLogEnabled(false)
         .setTraceLogTimeThreshold(0)
         .setTraceLogExcludeProperties(ImmutableSet.of())
-        .setHnBucketRenameEnabled(SET_HN_BUCKET_CREATE_ENABLED_DEFAULT);
+        .setHnBucketRenameEnabled(SET_HN_BUCKET_CREATE_ENABLED_DEFAULT)
+        .setGrpcWriteEnabled(GRPC_WRITE_DEFAULT);
   }
 
   public abstract Builder toBuilder();
@@ -166,6 +169,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract String getStorageRootUrl();
 
   public abstract String getStorageServicePath();
+
+  public abstract boolean isGrpcWriteEnabled();
 
   @Nullable
   public abstract String getProjectId();
@@ -340,6 +345,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setHnBucketRenameEnabled(boolean enabled);
 
     public abstract Builder setTraceLogExcludeProperties(ImmutableSet<String> properties);
+
+    public abstract Builder setGrpcWriteEnabled(boolean grpcWriteEnabled);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -153,11 +153,11 @@ public class GoogleCloudStorageImplTest {
 
   /**
    * Even when java-storage client in use, write path get short-circuited via {@link
-   * GoogleCloudStorageOptions.GrpcWriteEnabled} to use the http implementation.
+   * GoogleCloudStorageOptions} to use the http implementation.
    */
   @Test
   public void writeObject_withGrpcWriteDisabled() throws IOException {
-    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, name.getMethodName());
+    StorageResourceId resourceId = new StorageResourceId(testBucket, name.getMethodName());
 
     int uploadChunkSize = 2 * 1024 * 1024;
     TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -149,6 +149,59 @@ public class GoogleCloudStorageImplTest {
     trackingGcs.delegate.close();
   }
 
+  /**
+   * Even when java-storage client in use, write path get short-circuited via {@link
+   * GoogleCloudStorageOptions.GrpcWriteEnabled} to use the http implementation.
+   */
+  @Test
+  public void writeObject_withGrpcWriteDisabled() throws IOException {
+    StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, name.getMethodName());
+
+    int uploadChunkSize = 2 * 1024 * 1024;
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(
+            getOptionsWithUploadChunk(uploadChunkSize)
+                .toBuilder()
+                .setGrpcWriteEnabled(false)
+                .build());
+
+    int partitionsCount = 1;
+    byte[] partition =
+        writeObject(
+            trackingGcs.delegate,
+            resourceId,
+            /* partitionSize= */ uploadChunkSize,
+            partitionsCount);
+
+    assertObjectContent(helperGcs, resourceId, partition, partitionsCount);
+    assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
+        .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
+
+    assertThat(trackingGcs.getAllRequestStrings())
+        .containsExactlyElementsIn(
+            ImmutableList.builder()
+                .add(getRequestString(resourceId.getBucketName(), resourceId.getObjectName()))
+                .add(
+                    TrackingHttpRequestInitializer.resumableUploadRequestString(
+                        resourceId.getBucketName(),
+                        resourceId.getObjectName(),
+                        /* generationId= */ 1,
+                        /* replaceGenerationId= */ true))
+                .addAll(
+                    ImmutableList.of(
+                        TrackingHttpRequestInitializer.resumableUploadChunkRequestString(
+                            resourceId.getBucketName(),
+                            resourceId.getObjectName(),
+                            /* generationId= */ 2,
+                            /* uploadId= */ 1)))
+                .build()
+                .toArray())
+        .inOrder();
+
+    assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings().size()).isEqualTo(0);
+    trackingGcs.delegate.close();
+  }
+
   @Test
   public void writeLargeObject_withSmallUploadChunk() throws IOException {
     StorageResourceId resourceId = new StorageResourceId(TEST_BUCKET, name.getMethodName());

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -117,6 +117,7 @@ public class GoogleCloudStorageTestHelper {
     return GoogleCloudStorageOptions.builder()
         .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
         .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
+        .setGrpcWriteEnabled(true)
         .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId()));
   }
 


### PR DESCRIPTION
Added a configuration ` fs.gs.grpc.write.enable` which controls the write path when gRPC is in use. Given we are seeing degraded performance, by-default grpc write path is disabled and writes gets delegated to existing Apiary path ie. http.