### PR TITLE
Disable Traffic Director

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
       - 'VCS_COMMIT_ID=$COMMIT_SHA'
       - 'VCS_TAG=$TAG_NAME'
       - 'CI_BUILD_ID=$BUILD_ID'
-      - 'GCS_TEST_DIRECT_PATH_PREFERRED=true'
+      - 'GCS_TEST_DIRECT_PATH_PREFERRED=false'
 
 # Tests take on average 25 minutes to run
 timeout: 2400s


### PR DESCRIPTION
This is done to workaround the test failures related some TD issue