### PR TITLE
updating jackson-core version

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -85,6 +85,17 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-jackson2</artifactId>
+      <exclusions>
+         <exclusion>
+             <groupId>com.fasterxml.jackson.core</groupId>
+             <artifactId>jackson-core</artifactId>
+         </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -249,6 +260,17 @@
                     <exclude>grpc/**</exclude>
                   </excludes>
                 </filter>
+                
+                <filter>
+                  <artifact>com.fasterxml.jackson.core:jackson-core</artifact>
+                  <excludes>
+                    <exclude>META-INF/versions/17/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class</exclude>
+                    <exclude>META-INF/versions/17/com/fasterxml/jackson/core/io/doubleparser/FastIntegerMath*.class</exclude>
+                    <exclude>META-INF/versions/19/com/fasterxml/jackson/core/io/doubleparser/FastDoubleSwar.class</exclude>
+                    <exclude>META-INF/versions/19/com/fasterxml/jackson/core/io/doubleparser/FastIntegerMath*.class</exclude>
+                  </excludes>
+                </filter>
+                
               </filters>
               <artifactSet>
                 <includes>


### PR DESCRIPTION
shaded jar https://repo1.maven.org/maven2/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.25/gcs-connector-hadoop3-2.2.25-shaded.jar contains CVE PRISMA-2023-0067.  (https://nvd.nist.gov/vuln/detail/CVE-2023-0067)
This is because it includes  jackson-core  (This is required by google-api-client-jackson2)
```
<groupId>com.fasterxml.jackson.core</groupId>
  <artifactId>jackson-core</artifactId>
  <name>Jackson-core</name>
  <version>2.13.4</version>
```

I have fixed the CVE by excluding the version that had the vulnerability and added the fix by adding 
```
<groupId>com.fasterxml.jackson.core</groupId>
 <artifactId>jackson-core</artifactId>
 <version>2.15.0</version>
```

This PR contains the fix for the issue https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1221