### PR TITLE
Lock the random access if a forward or backward seek is detected

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FileAccessPatternManagerTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FileAccessPatternManagerTest.java
@@ -169,5 +169,28 @@ public class FileAccessPatternManagerTest {
       assertThat(fileAccessPattern.isRandomAccessPattern()).isEqualTo(expectedRandomAccess[i]);
       fileAccessPattern.updateLastServedIndex(currentPosition);
     }
+
+    // R --> R backward seek
+    // a backward seek should lock the random pattern
+    readIndexes = new long[] {4, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4};
+    expectedRandomAccess =
+        new boolean[] {true, true, true, true, true, true, true, true, true, true, true};
+    for (int i = 0; i < readIndexes.length; i++) {
+      long currentPosition = readIndexes[i];
+      fileAccessPattern.updateAccessPattern(currentPosition);
+      assertThat(fileAccessPattern.isRandomAccessPattern()).isEqualTo(expectedRandomAccess[i]);
+      fileAccessPattern.updateLastServedIndex(currentPosition);
+    }
+
+    // R --> R forward seek
+    // a forward seek should lock the random pattern
+    readIndexes = new long[] {0, 11, 12, 13, 14, 15};
+    expectedRandomAccess = new boolean[] {true, true, true, true, true, true};
+    for (int i = 0; i < readIndexes.length; i++) {
+      long currentPosition = readIndexes[i];
+      fileAccessPattern.updateAccessPattern(currentPosition);
+      assertThat(fileAccessPattern.isRandomAccessPattern()).isEqualTo(expectedRandomAccess[i]);
+      fileAccessPattern.updateLastServedIndex(currentPosition);
+    }
   }
 }


### PR DESCRIPTION
The optimized `AUTO_RANDOM` mode currently requires a switch to `sequential` before it can switch to random.  The proposed change locks the access pattern to `random` as soon as a forward or backward seek is detected. 

