### PR TITLE
Add support for tracking Hadoop and GCS API level metrics at a thread…

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsGlobalStorageStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsGlobalStorageStatistics.java
@@ -78,6 +78,9 @@ public class GhfsGlobalStorageStatistics extends StorageStatistics {
   // Initial requests are expected to take time due to warmup.
   private static final int WARMUP_THRESHOLD_SEC = 30;
 
+  private static final GhfsThreadLocalStatistics threadLocalStatistics =
+      new GhfsThreadLocalStatistics();
+
   private final Map<String, AtomicLong> opsCount = new HashMap<>();
   private final Map<String, AtomicLong> minimums = new HashMap<>();
   private final Map<String, AtomicLong> maximums = new HashMap<>();
@@ -124,6 +127,10 @@ public class GhfsGlobalStorageStatistics extends StorageStatistics {
     }
   }
 
+  public GhfsThreadLocalStatistics getThreadLocalStatistics() {
+    return threadLocalStatistics;
+  }
+
   private String getNonZeroMetrics() {
     // TreeMap to keep the result sorted.
     TreeMap<String, Long> result = new TreeMap<>();
@@ -159,6 +166,7 @@ public class GhfsGlobalStorageStatistics extends StorageStatistics {
    * @return the new value
    */
   long incrementCounter(GhfsStatistic op, long count) {
+    threadLocalStatistics.increment(op, count);
     return opsCount.get(op.getSymbol()).addAndGet(count);
   }
 
@@ -170,6 +178,7 @@ public class GhfsGlobalStorageStatistics extends StorageStatistics {
    */
   void incrementCounter(GoogleCloudStorageStatistics op, long count) {
     opsCount.get(op.getSymbol()).addAndGet(count);
+    threadLocalStatistics.increment(op, count);
   }
 
   @Override
@@ -245,7 +254,7 @@ public class GhfsGlobalStorageStatistics extends StorageStatistics {
     String symbol = statistic.getSymbol();
     updateMinMaxStats(minLatency, maxLatency, context, symbol);
     addMeanStatistic(statistic.getSymbol(), totalDuration, count);
-    opsCount.get(symbol).addAndGet(count);
+    incrementCounter(statistic, count);
 
     updateConnectorHadoopApiTime(totalDuration);
   }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
@@ -66,33 +66,48 @@ public enum GhfsStatistic {
       "files_delete_rejected",
       "Total number of files whose delete request was rejected",
       TYPE_COUNTER),
-  INVOCATION_CREATE(StoreStatisticNames.OP_CREATE, "Calls of create()", TYPE_DURATION_TOTAL),
-  INVOCATION_DELETE(StoreStatisticNames.OP_DELETE, "Calls of delete()", TYPE_DURATION_TOTAL),
-  INVOCATION_EXISTS(StoreStatisticNames.OP_EXISTS, "Calls of exists()", TYPE_COUNTER),
+  INVOCATION_CREATE(StoreStatisticNames.OP_CREATE, "Calls of create()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_DELETE(StoreStatisticNames.OP_DELETE, "Calls of delete()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_EXISTS(StoreStatisticNames.OP_EXISTS, "Calls of exists()", TYPE_COUNTER, true),
   INVOCATION_GET_FILE_STATUS(
-      StoreStatisticNames.OP_GET_FILE_STATUS, "Calls of getFileStatus()", TYPE_DURATION_TOTAL),
+      StoreStatisticNames.OP_GET_FILE_STATUS,
+      "Calls of getFileStatus()",
+      TYPE_DURATION_TOTAL,
+      true),
   INVOCATION_GET_FILE_CHECKSUM(
       StoreStatisticNames.OP_GET_FILE_CHECKSUM, "Calls of getFileChecksum()", TYPE_COUNTER),
 
   INVOCATION_LIST_STATUS_RESULT_SIZE(
       "op_get_list_status_result_size", "Number of files returned from list call", TYPE_COUNTER),
   INVOCATION_GLOB_STATUS(
-      StoreStatisticNames.OP_GLOB_STATUS, "Calls of globStatus()", TYPE_DURATION_TOTAL),
-  INVOCATION_HFLUSH(StoreStatisticNames.OP_HFLUSH, "Calls of hflush()", TYPE_DURATION_TOTAL),
-  INVOCATION_HSYNC(StoreStatisticNames.OP_HSYNC, "Calls of hsync()", TYPE_DURATION_TOTAL),
+      StoreStatisticNames.OP_GLOB_STATUS, "Calls of globStatus()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_HFLUSH(StoreStatisticNames.OP_HFLUSH, "Calls of hflush()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_HSYNC(StoreStatisticNames.OP_HSYNC, "Calls of hsync()", TYPE_DURATION_TOTAL, true),
   INVOCATION_LIST_STATUS(
-      StoreStatisticNames.OP_LIST_STATUS, "Calls of listStatus()", TYPE_DURATION_TOTAL),
-  INVOCATION_MKDIRS(StoreStatisticNames.OP_MKDIRS, "Calls of mkdirs()", TYPE_DURATION_TOTAL),
-  INVOCATION_OPEN(StoreStatisticNames.OP_OPEN, "Calls of open()", TYPE_DURATION_TOTAL),
-  INVOCATION_RENAME(StoreStatisticNames.OP_RENAME, "Calls of rename()", TYPE_DURATION_TOTAL),
+      StoreStatisticNames.OP_LIST_STATUS, "Calls of listStatus()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_MKDIRS(StoreStatisticNames.OP_MKDIRS, "Calls of mkdirs()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_OPEN(StoreStatisticNames.OP_OPEN, "Calls of open()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_RENAME(StoreStatisticNames.OP_RENAME, "Calls of rename()", TYPE_DURATION_TOTAL, true),
   INVOCATION_COPY_FROM_LOCAL_FILE(
-      StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE, "Calls of copyFromLocalFile()", TYPE_COUNTER),
+      StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE,
+      "Calls of copyFromLocalFile()",
+      TYPE_COUNTER,
+      true),
   INVOCATION_CREATE_NON_RECURSIVE(
-      StoreStatisticNames.OP_CREATE_NON_RECURSIVE, "Calls of createNonRecursive()", TYPE_DURATION),
+      StoreStatisticNames.OP_CREATE_NON_RECURSIVE,
+      "Calls of createNonRecursive()",
+      TYPE_DURATION,
+      true),
   INVOCATION_GET_DELEGATION_TOKEN(
-      StoreStatisticNames.OP_GET_DELEGATION_TOKEN, "Calls of getDelegationToken()", TYPE_COUNTER),
+      StoreStatisticNames.OP_GET_DELEGATION_TOKEN,
+      "Calls of getDelegationToken()",
+      TYPE_COUNTER,
+      true),
   INVOCATION_LIST_LOCATED_STATUS(
-      StoreStatisticNames.OP_LIST_LOCATED_STATUS, "Calls of listLocatedStatus()", TYPE_COUNTER),
+      StoreStatisticNames.OP_LIST_LOCATED_STATUS,
+      "Calls of listLocatedStatus()",
+      TYPE_COUNTER,
+      true),
 
   /** Stream reads */
   STREAM_READ_BYTES(
@@ -188,6 +203,8 @@ public enum GhfsStatistic {
   private static final ImmutableMap<String, GhfsStatistic> SYMBOL_MAP =
       Maps.uniqueIndex(Iterators.forArray(values()), GhfsStatistic::getSymbol);
 
+  private final boolean isHadoopApi;
+
   /**
    * Statistic definition.
    *
@@ -196,9 +213,14 @@ public enum GhfsStatistic {
    * @param type type
    */
   GhfsStatistic(String symbol, String description, StatisticTypeEnum type) {
+    this(symbol, description, type, false);
+  }
+
+  GhfsStatistic(String symbol, String description, StatisticTypeEnum type, boolean isHadoopApi) {
     this.symbol = symbol;
     this.description = description;
     this.type = type;
+    this.isHadoopApi = isHadoopApi;
   }
 
   /** Statistic name. */
@@ -247,5 +269,9 @@ public enum GhfsStatistic {
    */
   public StatisticTypeEnum getType() {
     return type;
+  }
+
+  boolean getIsHadoopApi() {
+    return this.isHadoopApi;
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
@@ -19,7 +19,9 @@ package com.google.cloud.hadoop.fs.gcs;
 import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.GCS_CONNECTOR_TIME;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import org.apache.hadoop.fs.StorageStatistics;
 
 class GhfsThreadLocalStatistics extends StorageStatistics {
@@ -100,7 +102,9 @@ class GhfsThreadLocalStatistics extends StorageStatistics {
 
   @Override
   public Iterator<LongStatistic> getLongStatistics() {
-    return new MetricsIterator(this.metrics);
+    return this.metrics.entrySet().stream()
+        .map(entry -> new LongStatistic(entry.getKey(), entry.getValue().getValue()))
+        .iterator();
   }
 
   private static class ThreadLocalValue {
@@ -116,32 +120,6 @@ class GhfsThreadLocalStatistics extends StorageStatistics {
 
     void reset() {
       value.set(0L);
-    }
-  }
-
-  private static class MetricsIterator implements Iterator<LongStatistic> {
-    private final List<String> names;
-
-    private final Map<String, ThreadLocalValue> metrics;
-
-    private int index;
-
-    MetricsIterator(Map<String, ThreadLocalValue> metrics) {
-      this.names = new ArrayList<>(metrics.keySet());
-      this.index = 0;
-      this.metrics = metrics;
-    }
-
-    @Override
-    public boolean hasNext() {
-      return index < names.size();
-    }
-
-    @Override
-    public LongStatistic next() {
-      String metricName = names.get(index);
-      index++;
-      return new LongStatistic(metricName, metrics.get(metricName).getValue());
     }
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
@@ -26,12 +26,6 @@ import org.apache.hadoop.fs.StorageStatistics;
 
 class GhfsThreadLocalStatistics extends StorageStatistics {
   static final String NAME = "GhfsThreadLocalStatistics";
-  static final String HADOOP_API_COUNT = "hadoopApiCount";
-  static final String HADOOP_API_TIME = "hadoopApiTime";
-  static final String GCS_API_COUNT = "gcsApiCount";
-  static final String GCS_API_TIME = "gcsApiTime";
-  static final String BACKOFF_COUNT = "backoffCount";
-  static final String BACKOFF_TIME = "backoffTime";
 
   private final ThreadLocalValue hadoopApiCount;
   private final ThreadLocalValue hadoopApiTime;
@@ -44,17 +38,18 @@ class GhfsThreadLocalStatistics extends StorageStatistics {
 
   GhfsThreadLocalStatistics() {
     super(NAME);
-    this.hadoopApiCount = createMetric(HADOOP_API_COUNT);
-    this.hadoopApiTime = createMetric(HADOOP_API_TIME);
-    this.gcsApiCount = createMetric(GCS_API_COUNT);
-    this.gcsApiTime = createMetric(GCS_API_TIME);
-    this.backoffCount = createMetric(BACKOFF_COUNT);
-    this.backoffTime = createMetric(BACKOFF_TIME);
+
+    this.hadoopApiCount = createMetric(Metric.HADOOP_API_COUNT);
+    this.hadoopApiTime = createMetric(Metric.HADOOP_API_TIME);
+    this.gcsApiCount = createMetric(Metric.GCS_API_COUNT);
+    this.gcsApiTime = createMetric(Metric.GCS_API_TIME);
+    this.backoffCount = createMetric(Metric.BACKOFF_COUNT);
+    this.backoffTime = createMetric(Metric.BACKOFF_TIME);
   }
 
-  private ThreadLocalValue createMetric(String name) {
+  private ThreadLocalValue createMetric(Metric metric) {
     ThreadLocalValue result = new ThreadLocalValue();
-    metrics.put(name, result);
+    metrics.put(metric.metricName, result);
 
     return result;
   }
@@ -120,6 +115,21 @@ class GhfsThreadLocalStatistics extends StorageStatistics {
 
     void reset() {
       value.set(0L);
+    }
+  }
+
+  private enum Metric {
+    HADOOP_API_COUNT("hadoopApiCount"),
+    HADOOP_API_TIME("hadoopApiTime"),
+    GCS_API_COUNT("gcsApiCount"),
+    GCS_API_TIME("gcsApiTime"),
+    BACKOFF_COUNT("backoffCount"),
+    BACKOFF_TIME("backoffTime");
+
+    private final String metricName;
+
+    Metric(String metricName) {
+      this.metricName = metricName;
     }
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.GCS_CONNECTOR_TIME;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
+import java.util.*;
+import org.apache.hadoop.fs.StorageStatistics;
+
+class GhfsThreadLocalStatistics extends StorageStatistics {
+  static final String NAME = "GhfsThreadLocalStatistics";
+  static final String HADOOP_API_COUNT = "hadoopApiCount";
+  static final String HADOOP_API_TIME = "hadoopApiTime";
+  static final String GCS_API_COUNT = "gcsApiCount";
+  static final String GCS_API_TIME = "gcsApiTime";
+  static final String BACKOFF_COUNT = "backoffCount";
+  static final String BACKOFF_TIME = "backoffTime";
+
+  private final ThreadLocalValue hadoopApiCount;
+  private final ThreadLocalValue hadoopApiTime;
+  private final ThreadLocalValue gcsApiCount;
+  private final ThreadLocalValue gcsApiTime;
+  private final ThreadLocalValue backoffCount;
+  private final ThreadLocalValue backoffTime;
+
+  private Map<String, ThreadLocalValue> metrics = new HashMap<>();
+
+  GhfsThreadLocalStatistics() {
+    super(NAME);
+    this.hadoopApiCount = createMetric(HADOOP_API_COUNT);
+    this.hadoopApiTime = createMetric(HADOOP_API_TIME);
+    this.gcsApiCount = createMetric(GCS_API_COUNT);
+    this.gcsApiTime = createMetric(GCS_API_TIME);
+    this.backoffCount = createMetric(BACKOFF_COUNT);
+    this.backoffTime = createMetric(BACKOFF_TIME);
+  }
+
+  private ThreadLocalValue createMetric(String name) {
+    ThreadLocalValue result = new ThreadLocalValue();
+    metrics.put(name, result);
+
+    return result;
+  }
+
+  @Override
+  public Long getLong(String s) {
+    if (!metrics.containsKey(s)) {
+      return 0L;
+    }
+
+    return metrics.get(s).getValue();
+  }
+
+  @Override
+  public boolean isTracked(String s) {
+    return metrics.containsKey(s);
+  }
+
+  @Override
+  public void reset() {
+    for (ThreadLocalValue s : metrics.values()) {
+      s.reset();
+    }
+  }
+
+  void increment(GhfsStatistic statistic, long count) {
+    if (statistic == GCS_CONNECTOR_TIME) {
+      this.hadoopApiTime.increment(count);
+    } else if (statistic.getIsHadoopApi()) {
+      this.hadoopApiCount.increment(count);
+    }
+  }
+
+  void increment(GoogleCloudStorageStatistics op, long count) {
+    if (op == GoogleCloudStorageStatistics.GCS_API_TIME) {
+      this.gcsApiTime.increment(count);
+    } else if (op == GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT) {
+      this.gcsApiCount.increment(count);
+    } else if (op == GoogleCloudStorageStatistics.GCS_BACKOFF_COUNT) {
+      this.backoffCount.increment(count);
+    } else if (op == GoogleCloudStorageStatistics.GCS_BACKOFF_TIME) {
+      this.backoffTime.increment(count);
+    }
+  }
+
+  @Override
+  public Iterator<LongStatistic> getLongStatistics() {
+    return new MetricsIterator(this.metrics);
+  }
+
+  private static class ThreadLocalValue {
+    private ThreadLocal<Long> value = ThreadLocal.withInitial(() -> 0L);
+
+    void increment(long count) {
+      value.set(value.get() + count);
+    }
+
+    Long getValue() {
+      return value.get();
+    }
+
+    void reset() {
+      value.set(0L);
+    }
+  }
+
+  private static class MetricsIterator implements Iterator<LongStatistic> {
+    private final List<String> names;
+
+    private final Map<String, ThreadLocalValue> metrics;
+
+    private int index;
+
+    MetricsIterator(Map<String, ThreadLocalValue> metrics) {
+      this.names = new ArrayList<>(metrics.keySet());
+      this.index = 0;
+      this.metrics = metrics;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index < names.size();
+    }
+
+    @Override
+    public LongStatistic next() {
+      String metricName = names.get(index);
+      index++;
+      return new LongStatistic(metricName, metrics.get(metricName).getValue());
+    }
+  }
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -243,6 +243,10 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
         GlobalStorageStatistics.INSTANCE.put(
             GhfsGlobalStorageStatistics.NAME, () -> new GhfsGlobalStorageStatistics());
 
+    GlobalStorageStatistics.INSTANCE.put(
+        GhfsThreadLocalStatistics.NAME,
+        () -> ((GhfsGlobalStorageStatistics) globalStats).getThreadLocalStatistics());
+
     if (GhfsGlobalStorageStatistics.class.isAssignableFrom(globalStats.getClass())) {
       globalStorageStatistics = (GhfsGlobalStorageStatistics) globalStats;
     } else {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
@@ -32,13 +32,19 @@ public class GhfsThreadLocalStatisticsTest {
   private GhfsThreadLocalStatistics statistics;
   private Map<String, Long> expected;
 
+  private static final String GCS_API_COUNT = "gcsApiCount";
+  private static final String GCS_API_TIME = "gcsApiTime";
+  private static final String BACKOFF_COUNT = "backoffCount";
+  private static final String BACKOFF_TIME = "backoffTime";
+  private static final String HADOOP_API_COUNT = "hadoopApiCount";
+  private static final String HADOOP_API_TIME = "hadoopApiTime";
+
   private static Map<GoogleCloudStorageStatistics, String> typeToNameMapping =
       Map.of(
-          GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT,
-              GhfsThreadLocalStatistics.GCS_API_COUNT,
-          GoogleCloudStorageStatistics.GCS_API_TIME, GhfsThreadLocalStatistics.GCS_API_TIME,
-          GoogleCloudStorageStatistics.GCS_BACKOFF_COUNT, GhfsThreadLocalStatistics.BACKOFF_COUNT,
-          GoogleCloudStorageStatistics.GCS_BACKOFF_TIME, GhfsThreadLocalStatistics.BACKOFF_TIME);
+          GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT, GCS_API_COUNT,
+          GoogleCloudStorageStatistics.GCS_API_TIME, GCS_API_TIME,
+          GoogleCloudStorageStatistics.GCS_BACKOFF_COUNT, BACKOFF_COUNT,
+          GoogleCloudStorageStatistics.GCS_BACKOFF_TIME, BACKOFF_TIME);
 
   @Before
   public void init() {
@@ -50,12 +56,12 @@ public class GhfsThreadLocalStatisticsTest {
     Map<String, Long> result =
         new HashMap<>(
             Map.of(
-                GhfsThreadLocalStatistics.BACKOFF_COUNT, 0L,
-                GhfsThreadLocalStatistics.BACKOFF_TIME, 0L,
-                GhfsThreadLocalStatistics.HADOOP_API_COUNT, 0L,
-                GhfsThreadLocalStatistics.HADOOP_API_TIME, 0L,
-                GhfsThreadLocalStatistics.GCS_API_COUNT, 0L,
-                GhfsThreadLocalStatistics.GCS_API_TIME, 0L));
+                BACKOFF_COUNT, 0L,
+                BACKOFF_TIME, 0L,
+                HADOOP_API_COUNT, 0L,
+                HADOOP_API_TIME, 0L,
+                GCS_API_COUNT, 0L,
+                GCS_API_TIME, 0L));
 
     return result;
   }
@@ -111,9 +117,9 @@ public class GhfsThreadLocalStatisticsTest {
     for (GhfsStatistic ghfsStatistic : GhfsStatistic.VALUES) {
       actualMetrics.increment(ghfsStatistic, 1);
       if (ghfsStatistic.getIsHadoopApi()) {
-        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_COUNT, 1L, Long::sum);
+        expectedMetrics.merge(HADOOP_API_COUNT, 1L, Long::sum);
       } else if (ghfsStatistic == GhfsStatistic.GCS_CONNECTOR_TIME) {
-        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_TIME, 1L, Long::sum);
+        expectedMetrics.merge(HADOOP_API_TIME, 1L, Long::sum);
       }
 
       verify(expectedMetrics, actualMetrics);
@@ -123,9 +129,9 @@ public class GhfsThreadLocalStatisticsTest {
       long theValue = Math.abs(ThreadLocalRandom.current().nextLong(1, 2000));
       actualMetrics.increment(ghfsStatistic, theValue);
       if (ghfsStatistic.getIsHadoopApi()) {
-        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_COUNT, theValue, Long::sum);
+        expectedMetrics.merge(HADOOP_API_COUNT, theValue, Long::sum);
       } else if (ghfsStatistic == GhfsStatistic.GCS_CONNECTOR_TIME) {
-        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_TIME, theValue, Long::sum);
+        expectedMetrics.merge(HADOOP_API_TIME, theValue, Long::sum);
       }
 
       verify(expectedMetrics, actualMetrics);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
@@ -50,6 +50,7 @@ public class GhfsThreadLocalStatisticsTest {
   public void init() {
     this.statistics = new GhfsThreadLocalStatistics();
     this.expected = getInitMetrics();
+    this.statistics.reset();
   }
 
   private Map<String, Long> getInitMetrics() {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GhfsThreadLocalStatisticsTest {
+  private GhfsThreadLocalStatistics statistics;
+  private Map<String, Long> expected;
+
+  private static Map<GoogleCloudStorageStatistics, String> typeToNameMapping =
+      Map.of(
+          GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT,
+              GhfsThreadLocalStatistics.GCS_API_COUNT,
+          GoogleCloudStorageStatistics.GCS_API_TIME, GhfsThreadLocalStatistics.GCS_API_TIME,
+          GoogleCloudStorageStatistics.GCS_BACKOFF_COUNT, GhfsThreadLocalStatistics.BACKOFF_COUNT,
+          GoogleCloudStorageStatistics.GCS_BACKOFF_TIME, GhfsThreadLocalStatistics.BACKOFF_TIME);
+
+  @Before
+  public void init() {
+    this.statistics = new GhfsThreadLocalStatistics();
+    this.expected = getInitMetrics();
+  }
+
+  private Map<String, Long> getInitMetrics() {
+    Map<String, Long> result =
+        new HashMap<>(
+            Map.of(
+                GhfsThreadLocalStatistics.BACKOFF_COUNT, 0L,
+                GhfsThreadLocalStatistics.BACKOFF_TIME, 0L,
+                GhfsThreadLocalStatistics.HADOOP_API_COUNT, 0L,
+                GhfsThreadLocalStatistics.HADOOP_API_TIME, 0L,
+                GhfsThreadLocalStatistics.GCS_API_COUNT, 0L,
+                GhfsThreadLocalStatistics.GCS_API_TIME, 0L));
+
+    return result;
+  }
+
+  @Test
+  public void testInitialState() {
+    verify(expected, statistics);
+  }
+
+  @Test
+  public void testNotTracked() {
+    verify(expected, statistics);
+    assertThat(statistics.isTracked("notfound")).isFalse();
+    assertThat(statistics.getLong("notfound")).isEqualTo(0);
+  }
+
+  @Test
+  public void testHadoopApiMetricsTest() {
+    runHadoopApiTests(expected, statistics);
+  }
+
+  @Test
+  public void testGcsApiMetricsTest() {
+    runGcsAPITests(this.expected, statistics);
+  }
+
+  @Test
+  public void testReset() {
+    runGcsAPITests(this.expected, statistics);
+    statistics.reset();
+
+    for (String metric : expected.keySet()) {
+      expected.put(metric, 0L);
+    }
+
+    verify(expected, statistics);
+  }
+
+  @Test
+  public void multiThreadTest() {
+    IntStream.range(0, 5000)
+        .parallel()
+        .forEach(
+            i -> {
+              Map<String, Long> expectedMetrics = getThreadLocalMetrics(statistics);
+              runGcsAPITests(expectedMetrics, statistics);
+              runHadoopApiTests(expectedMetrics, statistics);
+            });
+  }
+
+  private static void runHadoopApiTests(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics actualMetrics) {
+    for (GhfsStatistic ghfsStatistic : GhfsStatistic.VALUES) {
+      actualMetrics.increment(ghfsStatistic, 1);
+      if (ghfsStatistic.getIsHadoopApi()) {
+        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_COUNT, 1L, Long::sum);
+      } else if (ghfsStatistic == GhfsStatistic.GCS_CONNECTOR_TIME) {
+        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_TIME, 1L, Long::sum);
+      }
+
+      verify(expectedMetrics, actualMetrics);
+    }
+
+    for (GhfsStatistic ghfsStatistic : GhfsStatistic.VALUES) {
+      long theValue = Math.abs(ThreadLocalRandom.current().nextLong(1, 2000));
+      actualMetrics.increment(ghfsStatistic, theValue);
+      if (ghfsStatistic.getIsHadoopApi()) {
+        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_COUNT, theValue, Long::sum);
+      } else if (ghfsStatistic == GhfsStatistic.GCS_CONNECTOR_TIME) {
+        expectedMetrics.merge(GhfsThreadLocalStatistics.HADOOP_API_TIME, theValue, Long::sum);
+      }
+
+      verify(expectedMetrics, actualMetrics);
+    }
+  }
+
+  private static void runGcsAPITests(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics actualMetrics) {
+    verify(expectedMetrics, actualMetrics);
+
+    for (GoogleCloudStorageStatistics theStat : typeToNameMapping.keySet()) {
+      actualMetrics.increment(theStat, 1);
+      expectedMetrics.merge(typeToNameMapping.get(theStat), 1L, Long::sum);
+      verify(expectedMetrics, actualMetrics);
+    }
+
+    for (int i = 0; i < 10; i++) {
+      for (GoogleCloudStorageStatistics theStat : typeToNameMapping.keySet()) {
+        Long theValue = ThreadLocalRandom.current().nextLong(1, Integer.MAX_VALUE);
+        actualMetrics.increment(theStat, theValue);
+        expectedMetrics.merge(typeToNameMapping.get(theStat), theValue, Long::sum);
+        verify(expectedMetrics, actualMetrics);
+      }
+    }
+  }
+
+  private static void verify(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics actualMetrics) {
+    expectedMetrics.forEach((key, value) -> checkTracked(key, value, actualMetrics));
+    assertThat(getThreadLocalMetrics(actualMetrics)).isEqualTo(expectedMetrics);
+  }
+
+  private static Map<String, Long> getThreadLocalMetrics(GhfsThreadLocalStatistics statistics) {
+    Map<String, Long> values = new HashMap<>();
+    statistics
+        .getLongStatistics()
+        .forEachRemaining(theStat -> values.put(theStat.getName(), theStat.getValue()));
+    return values;
+  }
+
+  private static void checkTracked(
+      String metric, long expected, GhfsThreadLocalStatistics statistics) {
+    assertThat(statistics.isTracked(metric)).isTrue();
+    assertThat(statistics.getLong(metric)).isEqualTo(expected);
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -129,6 +129,9 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
   private static HashSet<String> EXPECTED_DURATION_METRICS = getExpectedDurationMetrics();
 
+  private static final String GCS_API_COUNT = "gcsApiCount";
+  private static final String HADOOP_API_COUNT = "hadoopApiCount";
+
   @Before
   public void before() throws Exception {
 
@@ -2701,7 +2704,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
       verify(metrics, 3L, stats);
     }
 
-    metrics.merge(GhfsThreadLocalStatistics.GCS_API_COUNT, 1L, Long::sum);
+    metrics.merge(GCS_API_COUNT, 1L, Long::sum);
     verify(metrics, stats);
 
     try (FSDataInputStream ignored = myghfs.open(testFilePath)) {
@@ -2724,8 +2727,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
   private static void verify(
       Map<String, Long> metrics, long gcsApiCount, GhfsThreadLocalStatistics stats) {
-    metrics.merge(GhfsThreadLocalStatistics.HADOOP_API_COUNT, 1L, Long::sum);
-    metrics.merge(GhfsThreadLocalStatistics.GCS_API_COUNT, gcsApiCount, Long::sum);
+    metrics.merge(HADOOP_API_COUNT, 1L, Long::sum);
+    metrics.merge(GCS_API_COUNT, gcsApiCount, Long::sum);
     verify(metrics, stats);
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -98,7 +98,16 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.PrivilegedExceptionAction;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -2722,11 +2731,6 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
   private static void verify(
       Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics statistics) {
-    System.out.println(
-        String.format(
-            "verify: %s; %s", getThreadLocalMetrics(statistics), Thread.currentThread().getId()));
-    //    System.out.println("verify: " + expectedMetrics);
-
     expectedMetrics.forEach((key, value) -> checkTracked(key, value, statistics));
     assertThat(getThreadLocalMetrics(statistics).size()).isEqualTo(expectedMetrics.size());
   }
@@ -2735,8 +2739,6 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
       String metric, long expected, GhfsThreadLocalStatistics statistics) {
     assertThat(statistics.isTracked(metric)).isTrue();
 
-    //    System.out.println(String.format("%s; %s=%s", metric, expected,
-    // statistics.getLong(metric)));
     if (!metric.toLowerCase().contains("time")) {
       // time metrics are not deterministic
       assertThat(statistics.getLong(metric)).isEqualTo(expected);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -101,14 +101,9 @@ import java.security.PrivilegedExceptionAction;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileChecksum;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.statistics.IOStatistics;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -2613,6 +2608,142 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
             .build();
 
     verifyMetrics(stats, expected, stopwatch.elapsed().toMillis());
+  }
+
+  @Test
+  public void testGcsThreadLocalMetrics() throws IOException {
+    Configuration config = loadConfig(storageClientType);
+    config.setBoolean(
+        "fs.gs.status.parallel.enable", false); // to make the test results predictable
+    config.setBoolean("fs.gs.implicit.dir.repair.enable", false);
+    config.setBoolean("fs.gs.create.items.conflict.check.enable", false);
+
+    Path parentPath = ghfsHelper.castAsHadoopPath(getTempFilePath());
+    Path subdirPath = new Path(parentPath, "foo-subdir");
+    GoogleHadoopFileSystem myghfs = new GoogleHadoopFileSystem();
+    myghfs.initialize(subdirPath.toUri(), config);
+
+    GhfsThreadLocalStatistics stats =
+        (GhfsThreadLocalStatistics)
+            GlobalStorageStatistics.INSTANCE.get(GhfsThreadLocalStatistics.NAME);
+
+    // TODO: Some of the GCS API related operations, which are run in a separate thread are not
+    // tracked.
+    // It will be fixed in a separate change
+    runTest(subdirPath, myghfs, stats);
+  }
+
+  @Test
+  public void multiThreadTest() throws IOException {
+    Configuration config = loadConfig(storageClientType);
+    config.setBoolean(
+        "fs.gs.status.parallel.enable", false); // to make the test results predictable
+    config.setBoolean("fs.gs.implicit.dir.repair.enable", false);
+    config.setBoolean("fs.gs.create.items.conflict.check.enable", false);
+
+    Path parentPath = ghfsHelper.castAsHadoopPath(getTempFilePath());
+
+    GhfsThreadLocalStatistics stats =
+        (GhfsThreadLocalStatistics)
+            GlobalStorageStatistics.INSTANCE.get(GhfsThreadLocalStatistics.NAME);
+
+    IntStream.range(0, 10)
+        .parallel()
+        .forEach(
+            i -> {
+              try {
+                Path subdirPath = new Path(parentPath, "foo-subdir" + i);
+                GoogleHadoopFileSystem myghfs = new GoogleHadoopFileSystem();
+                myghfs.initialize(subdirPath.toUri(), config);
+                runTest(subdirPath, myghfs, stats);
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+
+  private static Map<String, Long> getThreadLocalMetrics(GhfsThreadLocalStatistics statistics) {
+    Map<String, Long> values = new HashMap<>();
+    statistics
+        .getLongStatistics()
+        .forEachRemaining(theStat -> values.put(theStat.getName(), theStat.getValue()));
+    return values;
+  }
+
+  private static void runTest(
+      Path subdirPath, GoogleHadoopFileSystem myghfs, GhfsThreadLocalStatistics stats)
+      throws IOException {
+    Map<String, Long> metrics = getThreadLocalMetrics(stats);
+    myghfs.mkdirs(subdirPath);
+
+    verify(metrics, 1L, stats);
+
+    myghfs.getFileStatus(subdirPath);
+    verify(metrics, 2L, stats);
+
+    Path testFilePath = subdirPath.suffix("/test.empty");
+    try (FSDataOutputStream outStream = myghfs.create(testFilePath)) {
+      verify(metrics, 1L, stats);
+
+      outStream.hflush();
+      verify(metrics, 1L, stats);
+
+      outStream.hsync();
+      verify(metrics, 3L, stats);
+    }
+
+    metrics.merge(GhfsThreadLocalStatistics.GCS_API_COUNT, 1L, Long::sum);
+    verify(metrics, stats);
+
+    try (FSDataInputStream ignored = myghfs.open(testFilePath)) {
+      ignored.read();
+      verify(metrics, 1L, stats);
+    }
+
+    Path dst = subdirPath.suffix("/test.rename.empty");
+    myghfs.rename(testFilePath, dst);
+    // TODO: Operations done async in a separate thread are not tracked. This will be fixed in a
+    // separate change.
+    verify(metrics, 2L, stats);
+
+    myghfs.delete(dst);
+    verify(metrics, 2L, stats);
+
+    myghfs.delete(subdirPath, true);
+    verify(metrics, 4L, stats);
+  }
+
+  private static void verify(
+      Map<String, Long> metrics, long gcsApiCount, GhfsThreadLocalStatistics stats) {
+    metrics.merge(GhfsThreadLocalStatistics.HADOOP_API_COUNT, 1L, Long::sum);
+    metrics.merge(GhfsThreadLocalStatistics.GCS_API_COUNT, gcsApiCount, Long::sum);
+    verify(metrics, stats);
+  }
+
+  private static void verify(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics statistics) {
+    System.out.println(
+        String.format(
+            "verify: %s; %s", getThreadLocalMetrics(statistics), Thread.currentThread().getId()));
+    //    System.out.println("verify: " + expectedMetrics);
+
+    expectedMetrics.forEach((key, value) -> checkTracked(key, value, statistics));
+    assertThat(getThreadLocalMetrics(statistics).size()).isEqualTo(expectedMetrics.size());
+  }
+
+  private static void checkTracked(
+      String metric, long expected, GhfsThreadLocalStatistics statistics) {
+    assertThat(statistics.isTracked(metric)).isTrue();
+
+    //    System.out.println(String.format("%s; %s=%s", metric, expected,
+    // statistics.getLong(metric)));
+    if (!metric.toLowerCase().contains("time")) {
+      // time metrics are not deterministic
+      assertThat(statistics.getLong(metric)).isEqualTo(expected);
+    } else if (!metric.toLowerCase().contains("time")) {
+      // back off is not deterministic
+      assertThat(statistics.getLong(metric)).isAtLeast(expected);
+    }
   }
 
   private void verifyMetrics(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -392,6 +392,12 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   @Override
   public void testGcsJsonAPIMetrics() {}
 
+  @Override
+  public void testGcsThreadLocalMetrics() {}
+
+  @Override
+  public void multiThreadTest() {}
+
   /* Custom InMemoryGoogleCloudStorage object which throws exception when reading */
   private class CustomInMemoryGoogleCloudStorage extends InMemoryGoogleCloudStorage {
     private IOException exceptionThrown =


### PR DESCRIPTION
… level

GCS APIs which are called from a thread different the thre which called the Hadoop API is not captured. This will be fixed in a later change