### PR TITLE
Add support for tracking Hadoop and GCS API level metrics at a thread…

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsStatistic.java
@@ -66,33 +66,48 @@ public enum GhfsStatistic {
       "files_delete_rejected",
       "Total number of files whose delete request was rejected",
       TYPE_COUNTER),
-  INVOCATION_CREATE(StoreStatisticNames.OP_CREATE, "Calls of create()", TYPE_DURATION_TOTAL),
-  INVOCATION_DELETE(StoreStatisticNames.OP_DELETE, "Calls of delete()", TYPE_DURATION_TOTAL),
-  INVOCATION_EXISTS(StoreStatisticNames.OP_EXISTS, "Calls of exists()", TYPE_COUNTER),
+  INVOCATION_CREATE(StoreStatisticNames.OP_CREATE, "Calls of create()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_DELETE(StoreStatisticNames.OP_DELETE, "Calls of delete()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_EXISTS(StoreStatisticNames.OP_EXISTS, "Calls of exists()", TYPE_COUNTER, true),
   INVOCATION_GET_FILE_STATUS(
-      StoreStatisticNames.OP_GET_FILE_STATUS, "Calls of getFileStatus()", TYPE_DURATION_TOTAL),
+      StoreStatisticNames.OP_GET_FILE_STATUS,
+      "Calls of getFileStatus()",
+      TYPE_DURATION_TOTAL,
+      true),
   INVOCATION_GET_FILE_CHECKSUM(
       StoreStatisticNames.OP_GET_FILE_CHECKSUM, "Calls of getFileChecksum()", TYPE_COUNTER),
 
   INVOCATION_LIST_STATUS_RESULT_SIZE(
       "op_get_list_status_result_size", "Number of files returned from list call", TYPE_COUNTER),
   INVOCATION_GLOB_STATUS(
-      StoreStatisticNames.OP_GLOB_STATUS, "Calls of globStatus()", TYPE_DURATION_TOTAL),
-  INVOCATION_HFLUSH(StoreStatisticNames.OP_HFLUSH, "Calls of hflush()", TYPE_DURATION_TOTAL),
-  INVOCATION_HSYNC(StoreStatisticNames.OP_HSYNC, "Calls of hsync()", TYPE_DURATION_TOTAL),
+      StoreStatisticNames.OP_GLOB_STATUS, "Calls of globStatus()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_HFLUSH(StoreStatisticNames.OP_HFLUSH, "Calls of hflush()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_HSYNC(StoreStatisticNames.OP_HSYNC, "Calls of hsync()", TYPE_DURATION_TOTAL, true),
   INVOCATION_LIST_STATUS(
-      StoreStatisticNames.OP_LIST_STATUS, "Calls of listStatus()", TYPE_DURATION_TOTAL),
-  INVOCATION_MKDIRS(StoreStatisticNames.OP_MKDIRS, "Calls of mkdirs()", TYPE_DURATION_TOTAL),
-  INVOCATION_OPEN(StoreStatisticNames.OP_OPEN, "Calls of open()", TYPE_DURATION_TOTAL),
-  INVOCATION_RENAME(StoreStatisticNames.OP_RENAME, "Calls of rename()", TYPE_DURATION_TOTAL),
+      StoreStatisticNames.OP_LIST_STATUS, "Calls of listStatus()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_MKDIRS(StoreStatisticNames.OP_MKDIRS, "Calls of mkdirs()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_OPEN(StoreStatisticNames.OP_OPEN, "Calls of open()", TYPE_DURATION_TOTAL, true),
+  INVOCATION_RENAME(StoreStatisticNames.OP_RENAME, "Calls of rename()", TYPE_DURATION_TOTAL, true),
   INVOCATION_COPY_FROM_LOCAL_FILE(
-      StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE, "Calls of copyFromLocalFile()", TYPE_COUNTER),
+      StoreStatisticNames.OP_COPY_FROM_LOCAL_FILE,
+      "Calls of copyFromLocalFile()",
+      TYPE_COUNTER,
+      true),
   INVOCATION_CREATE_NON_RECURSIVE(
-      StoreStatisticNames.OP_CREATE_NON_RECURSIVE, "Calls of createNonRecursive()", TYPE_DURATION),
+      StoreStatisticNames.OP_CREATE_NON_RECURSIVE,
+      "Calls of createNonRecursive()",
+      TYPE_DURATION,
+      true),
   INVOCATION_GET_DELEGATION_TOKEN(
-      StoreStatisticNames.OP_GET_DELEGATION_TOKEN, "Calls of getDelegationToken()", TYPE_COUNTER),
+      StoreStatisticNames.OP_GET_DELEGATION_TOKEN,
+      "Calls of getDelegationToken()",
+      TYPE_COUNTER,
+      true),
   INVOCATION_LIST_LOCATED_STATUS(
-      StoreStatisticNames.OP_LIST_LOCATED_STATUS, "Calls of listLocatedStatus()", TYPE_COUNTER),
+      StoreStatisticNames.OP_LIST_LOCATED_STATUS,
+      "Calls of listLocatedStatus()",
+      TYPE_COUNTER,
+      true),
 
   /** Stream reads */
   STREAM_READ_BYTES(
@@ -188,6 +203,8 @@ public enum GhfsStatistic {
   private static final ImmutableMap<String, GhfsStatistic> SYMBOL_MAP =
       Maps.uniqueIndex(Iterators.forArray(values()), GhfsStatistic::getSymbol);
 
+  private final boolean isHadoopApi;
+
   /**
    * Statistic definition.
    *
@@ -196,9 +213,14 @@ public enum GhfsStatistic {
    * @param type type
    */
   GhfsStatistic(String symbol, String description, StatisticTypeEnum type) {
+    this(symbol, description, type, false);
+  }
+
+  GhfsStatistic(String symbol, String description, StatisticTypeEnum type, boolean isHadoopApi) {
     this.symbol = symbol;
     this.description = description;
     this.type = type;
+    this.isHadoopApi = isHadoopApi;
   }
 
   /** Statistic name. */
@@ -247,5 +269,9 @@ public enum GhfsStatistic {
    */
   public StatisticTypeEnum getType() {
     return type;
+  }
+
+  boolean getIsHadoopApi() {
+    return this.isHadoopApi;
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatistics.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.cloud.hadoop.fs.gcs.GhfsStatistic.GCS_CONNECTOR_TIME;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.hadoop.fs.StorageStatistics;
+
+class GhfsThreadLocalStatistics extends StorageStatistics {
+  static final String NAME = "GhfsThreadLocalStatistics";
+  private Map<String, Metric> metrics = new HashMap<>();
+
+  GhfsThreadLocalStatistics() {
+    super(NAME);
+    Arrays.stream(Metric.values()).forEach(x -> metrics.put(x.metricName, x));
+  }
+
+  @Override
+  public Long getLong(String s) {
+    if (!metrics.containsKey(s)) {
+      return 0L;
+    }
+
+    return metrics.get(s).metricValue.getValue();
+  }
+
+  @Override
+  public boolean isTracked(String s) {
+    return metrics.containsKey(s);
+  }
+
+  @Override
+  public void reset() {
+    for (Metric s : metrics.values()) {
+      s.reset();
+    }
+  }
+
+  void increment(GhfsStatistic statistic, long count) {
+    if (statistic == GCS_CONNECTOR_TIME) {
+      Metric.HADOOP_API_TIME.increment(count);
+    } else if (statistic.getIsHadoopApi()) {
+      Metric.HADOOP_API_COUNT.increment(count);
+    }
+  }
+
+  void increment(GoogleCloudStorageStatistics op, long count) {
+    if (op == GoogleCloudStorageStatistics.GCS_API_TIME) {
+      Metric.GCS_API_TIME.increment(count);
+    } else if (op == GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT) {
+      Metric.GCS_API_COUNT.increment(count);
+    } else if (op == GoogleCloudStorageStatistics.GCS_BACKOFF_COUNT) {
+      Metric.BACKOFF_COUNT.increment(count);
+    } else if (op == GoogleCloudStorageStatistics.GCS_BACKOFF_TIME) {
+      Metric.BACKOFF_TIME.increment(count);
+    }
+  }
+
+  @Override
+  public Iterator<LongStatistic> getLongStatistics() {
+    return this.metrics.entrySet().stream()
+        .map(entry -> new LongStatistic(entry.getKey(), entry.getValue().metricValue.getValue()))
+        .iterator();
+  }
+
+  private static class ThreadLocalValue {
+    private ThreadLocal<Long> value = ThreadLocal.withInitial(() -> 0L);
+
+    void increment(long count) {
+      value.set(value.get() + count);
+    }
+
+    Long getValue() {
+      return value.get();
+    }
+
+    void reset() {
+      value.set(0L);
+    }
+  }
+
+  private enum Metric {
+    HADOOP_API_COUNT("hadoopApiCount"),
+    HADOOP_API_TIME("hadoopApiTime"),
+    GCS_API_COUNT("gcsApiCount"),
+    GCS_API_TIME("gcsApiTime"),
+    BACKOFF_COUNT("backoffCount"),
+    BACKOFF_TIME("backoffTime");
+
+    private final String metricName;
+    private final ThreadLocalValue metricValue;
+
+    Metric(String metricName) {
+      this.metricName = metricName;
+      this.metricValue = new ThreadLocalValue();
+    }
+
+    void reset() {
+      metricValue.reset();
+    }
+
+    void increment(long count) {
+      metricValue.increment(count);
+    }
+  }
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -243,6 +243,10 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
         GlobalStorageStatistics.INSTANCE.put(
             GhfsGlobalStorageStatistics.NAME, () -> new GhfsGlobalStorageStatistics());
 
+    GlobalStorageStatistics.INSTANCE.put(
+        GhfsThreadLocalStatistics.NAME,
+        () -> ((GhfsGlobalStorageStatistics) globalStats).getThreadLocalStatistics());
+
     if (GhfsGlobalStorageStatistics.class.isAssignableFrom(globalStats.getClass())) {
       globalStorageStatistics = (GhfsGlobalStorageStatistics) globalStats;
     } else {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GhfsThreadLocalStatisticsTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageStatistics;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GhfsThreadLocalStatisticsTest {
+  private GhfsThreadLocalStatistics statistics;
+  private Map<String, Long> expected;
+
+  private static final String GCS_API_COUNT = "gcsApiCount";
+  private static final String GCS_API_TIME = "gcsApiTime";
+  private static final String BACKOFF_COUNT = "backoffCount";
+  private static final String BACKOFF_TIME = "backoffTime";
+  private static final String HADOOP_API_COUNT = "hadoopApiCount";
+  private static final String HADOOP_API_TIME = "hadoopApiTime";
+
+  private static Map<GoogleCloudStorageStatistics, String> typeToNameMapping =
+      Map.of(
+          GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT, GCS_API_COUNT,
+          GoogleCloudStorageStatistics.GCS_API_TIME, GCS_API_TIME,
+          GoogleCloudStorageStatistics.GCS_BACKOFF_COUNT, BACKOFF_COUNT,
+          GoogleCloudStorageStatistics.GCS_BACKOFF_TIME, BACKOFF_TIME);
+
+  @Before
+  public void init() {
+    this.statistics = new GhfsThreadLocalStatistics();
+    this.expected = getInitMetrics();
+    this.statistics.reset();
+  }
+
+  private Map<String, Long> getInitMetrics() {
+    Map<String, Long> result =
+        new HashMap<>(
+            Map.of(
+                BACKOFF_COUNT, 0L,
+                BACKOFF_TIME, 0L,
+                HADOOP_API_COUNT, 0L,
+                HADOOP_API_TIME, 0L,
+                GCS_API_COUNT, 0L,
+                GCS_API_TIME, 0L));
+
+    return result;
+  }
+
+  @Test
+  public void testInitialState() {
+    verify(expected, statistics);
+  }
+
+  @Test
+  public void testNotTracked() {
+    verify(expected, statistics);
+    assertThat(statistics.isTracked("notfound")).isFalse();
+    assertThat(statistics.getLong("notfound")).isEqualTo(0);
+  }
+
+  @Test
+  public void testHadoopApiMetricsTest() {
+    runHadoopApiTests(expected, statistics);
+  }
+
+  @Test
+  public void testGcsApiMetricsTest() {
+    runGcsAPITests(this.expected, statistics);
+  }
+
+  @Test
+  public void testReset() {
+    runGcsAPITests(this.expected, statistics);
+    statistics.reset();
+
+    for (String metric : expected.keySet()) {
+      expected.put(metric, 0L);
+    }
+
+    verify(expected, statistics);
+  }
+
+  @Test
+  public void multiThreadTest() {
+    IntStream.range(0, 5000)
+        .parallel()
+        .forEach(
+            i -> {
+              Map<String, Long> expectedMetrics = getThreadLocalMetrics(statistics);
+              runGcsAPITests(expectedMetrics, statistics);
+              runHadoopApiTests(expectedMetrics, statistics);
+            });
+  }
+
+  private static void runHadoopApiTests(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics actualMetrics) {
+    for (GhfsStatistic ghfsStatistic : GhfsStatistic.VALUES) {
+      actualMetrics.increment(ghfsStatistic, 1);
+      if (ghfsStatistic.getIsHadoopApi()) {
+        expectedMetrics.merge(HADOOP_API_COUNT, 1L, Long::sum);
+      } else if (ghfsStatistic == GhfsStatistic.GCS_CONNECTOR_TIME) {
+        expectedMetrics.merge(HADOOP_API_TIME, 1L, Long::sum);
+      }
+
+      verify(expectedMetrics, actualMetrics);
+    }
+
+    for (GhfsStatistic ghfsStatistic : GhfsStatistic.VALUES) {
+      long theValue = Math.abs(ThreadLocalRandom.current().nextLong(1, 2000));
+      actualMetrics.increment(ghfsStatistic, theValue);
+      if (ghfsStatistic.getIsHadoopApi()) {
+        expectedMetrics.merge(HADOOP_API_COUNT, theValue, Long::sum);
+      } else if (ghfsStatistic == GhfsStatistic.GCS_CONNECTOR_TIME) {
+        expectedMetrics.merge(HADOOP_API_TIME, theValue, Long::sum);
+      }
+
+      verify(expectedMetrics, actualMetrics);
+    }
+  }
+
+  private static void runGcsAPITests(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics actualMetrics) {
+    verify(expectedMetrics, actualMetrics);
+
+    for (GoogleCloudStorageStatistics theStat : typeToNameMapping.keySet()) {
+      actualMetrics.increment(theStat, 1);
+      expectedMetrics.merge(typeToNameMapping.get(theStat), 1L, Long::sum);
+      verify(expectedMetrics, actualMetrics);
+    }
+
+    for (int i = 0; i < 10; i++) {
+      for (GoogleCloudStorageStatistics theStat : typeToNameMapping.keySet()) {
+        Long theValue = ThreadLocalRandom.current().nextLong(1, Integer.MAX_VALUE);
+        actualMetrics.increment(theStat, theValue);
+        expectedMetrics.merge(typeToNameMapping.get(theStat), theValue, Long::sum);
+        verify(expectedMetrics, actualMetrics);
+      }
+    }
+  }
+
+  private static void verify(
+      Map<String, Long> expectedMetrics, GhfsThreadLocalStatistics actualMetrics) {
+    expectedMetrics.forEach((key, value) -> checkTracked(key, value, actualMetrics));
+    assertThat(getThreadLocalMetrics(actualMetrics)).isEqualTo(expectedMetrics);
+  }
+
+  private static Map<String, Long> getThreadLocalMetrics(GhfsThreadLocalStatistics statistics) {
+    Map<String, Long> values = new HashMap<>();
+    statistics
+        .getLongStatistics()
+        .forEachRemaining(theStat -> values.put(theStat.getName(), theStat.getValue()));
+    return values;
+  }
+
+  private static void checkTracked(
+      String metric, long expected, GhfsThreadLocalStatistics statistics) {
+    assertThat(statistics.isTracked(metric)).isTrue();
+    assertThat(statistics.getLong(metric)).isEqualTo(expected);
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -2752,7 +2752,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     if (!metric.toLowerCase().contains("time")) {
       // time metrics are not deterministic
-      assertThat(statistics.getLong(metric)).isEqualTo(expected);
+      assertEquals(metric, (long)statistics.getLong(metric), expected);
     } else if (!metric.toLowerCase().contains("time")) {
       // back off is not deterministic
       assertThat(statistics.getLong(metric)).isAtLeast(expected);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -2752,7 +2752,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     if (!metric.toLowerCase().contains("time")) {
       // time metrics are not deterministic
-      assertEquals(metric, (long)statistics.getLong(metric), expected);
+      assertEquals(metric, (long) statistics.getLong(metric), expected);
     } else if (!metric.toLowerCase().contains("time")) {
       // back off is not deterministic
       assertThat(statistics.getLong(metric)).isAtLeast(expected);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -392,6 +392,12 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   @Override
   public void testGcsJsonAPIMetrics() {}
 
+  @Override
+  public void testGcsThreadLocalMetrics() {}
+
+  @Override
+  public void multiThreadTest() {}
+
   /* Custom InMemoryGoogleCloudStorage object which throws exception when reading */
   private class CustomInMemoryGoogleCloudStorage extends InMemoryGoogleCloudStorage {
     private IOException exceptionThrown =


### PR DESCRIPTION
…… (#1299)

* Add support for tracking Hadoop and GCS API level metrics at a thread level

GCS APIs which are called from a thread different the thre which called the Hadoop API is not captured. This will be fixed in a later change