### PR TITLE
Upgrade GCS Java SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <google.auth.version>1.22.0</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-core.verion>2.44.1</google.cloud-core.verion>
-    <google.cloud-storage.bom.version>2.43.1</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.49.1</google.cloud-storage.bom.version>
     <google.error-prone.version>2.16</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
     <google.gax.version>2.54.1</google.gax.version>


### PR DESCRIPTION
Upgrade GCS Java SDK version from 2.43 to 2.49.
This is required for Move api which is available only after 2.48