### PR TITLE
Upgrade GCS Java SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,10 @@
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
     <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
     <google.api.grpc.proto-google-iam-v1.version>1.6.23</google.api.grpc.proto-google-iam-v1.version>
-    <google.auth.version>1.22.0</google.auth.version>
+    <google.auth.version>1.33.1</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-core.verion>2.44.1</google.cloud-core.verion>
-    <google.cloud-storage.bom.version>2.43.1</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.49.0</google.cloud-storage.bom.version>
     <google.error-prone.version>2.16</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
     <google.gax.version>2.54.1</google.gax.version>


### PR DESCRIPTION
Upgrade GCS Java SDK version from 2.43 to 2.49.
This is required for Move api which is available only after 2.48