### PR TITLE
open bounded channel for vectored Reads

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -325,6 +325,7 @@ public class VectoredIOImpl implements Closeable {
       public SeekableByteChannel getReadChannel() throws IOException {
         GoogleCloudStorageReadOptions options =
             channelReadOptions(gcsFs.getOptions().getCloudStorageOptions().getReadChannelOptions());
+        options.toBuilder().setReadOnlyRequestBytesEnabled(true).build();
         if (fileInfo != null) {
           return gcsFs.open(fileInfo, options);
         }
@@ -344,9 +345,8 @@ public class VectoredIOImpl implements Closeable {
           GoogleCloudStorageReadOptions readOptions) {
         GoogleCloudStorageReadOptions.Builder builder = readOptions.toBuilder();
         // For single range read we don't want Read channel to adjust around on channel boundaries
-        // as
-        // channel is used just for one read request.
-        builder.setFadvise(GoogleCloudStorageReadOptions.Fadvise.SEQUENTIAL);
+        // as channel is used just for one read request.
+        builder.setReadOnlyRequestBytesEnabled(true);
         return builder.build();
       }
     }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImpl.java
@@ -325,7 +325,6 @@ public class VectoredIOImpl implements Closeable {
       public SeekableByteChannel getReadChannel() throws IOException {
         GoogleCloudStorageReadOptions options =
             channelReadOptions(gcsFs.getOptions().getCloudStorageOptions().getReadChannelOptions());
-        options.toBuilder().setReadOnlyRequestBytesEnabled(true).build();
         if (fileInfo != null) {
           return gcsFs.open(fileInfo, options);
         }
@@ -346,7 +345,7 @@ public class VectoredIOImpl implements Closeable {
         GoogleCloudStorageReadOptions.Builder builder = readOptions.toBuilder();
         // For single range read we don't want Read channel to adjust around on channel boundaries
         // as channel is used just for one read request.
-        builder.setReadOnlyRequestBytesEnabled(true);
+        builder.setReadExactRequestedBytesEnabled(true);
         return builder.build();
       }
     }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/VectoredIOImplTest.java
@@ -20,7 +20,9 @@ import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemTestHelper.as
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemTestHelper.writeObject;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -32,7 +34,6 @@ import com.google.cloud.hadoop.gcsio.FileInfo;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions;
-import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -223,7 +224,7 @@ public class VectoredIOImplTest {
 
     verify(mockedGcsFs, times(2)).open((FileInfo) any(), any());
 
-    assertThat(readOptionsArgumentCaptor.getValue().getFadvise()).isEqualTo(Fadvise.SEQUENTIAL);
+    assertTrue(readOptionsArgumentCaptor.getValue().isReadExactRequestedBytesEnabled());
     assertThat(fileInfoArgumentCaptor.getValue().getPath()).isEqualTo(fileInfo.getPath());
   }
 
@@ -253,7 +254,13 @@ public class VectoredIOImplTest {
 
     verify(mockedGcsFs, times(1)).open((FileInfo) any(), any());
 
-    assertThat(readOptionsArgumentCaptor.getValue().getFadvise()).isEqualTo(Fadvise.SEQUENTIAL);
+    assertTrue(readOptionsArgumentCaptor.getValue().isReadExactRequestedBytesEnabled());
+    assertFalse(
+        mockedGcsFs
+            .getOptions()
+            .getCloudStorageOptions()
+            .getReadChannelOptions()
+            .isReadExactRequestedBytesEnabled());
     assertThat(fileInfoArgumentCaptor.getValue().getPath()).isEqualTo(fileInfo.getPath());
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -412,7 +412,9 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       if (gzipEncoded) {
         return 0;
       }
-      if (readOptions.getFadvise() != Fadvise.SEQUENTIAL && isFooterRead()) {
+      if (readOptions.getFadvise() != Fadvise.SEQUENTIAL
+          && isFooterRead()
+          && !readOptions.isReadOnlyRequestBytesEnabled()) {
         // Prefetch footer and adjust start position to footerStart.
         return max(0, objectSize - readOptions.getMinRangeRequestSize());
       }
@@ -434,6 +436,11 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
           endPosition = min(startPosition + readOptions.getBlockSize(), objectSize);
         }
       }
+
+      if (readOptions.isReadOnlyRequestBytesEnabled()) {
+        endPosition = startPosition + bytesToRead;
+      }
+
       if (footerContent != null) {
         // If footer is cached open just till footerStart.
         // Remaining content ill be served from cached footer itself.

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -414,7 +414,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       }
       if (readOptions.getFadvise() != Fadvise.SEQUENTIAL
           && isFooterRead()
-          && !readOptions.isReadOnlyRequestBytesEnabled()) {
+          && !readOptions.isReadExactRequestedBytesEnabled()) {
         // Prefetch footer and adjust start position to footerStart.
         return max(0, objectSize - readOptions.getMinRangeRequestSize());
       }
@@ -437,7 +437,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
         }
       }
 
-      if (readOptions.isReadOnlyRequestBytesEnabled()) {
+      if (readOptions.isReadExactRequestedBytesEnabled()) {
         endPosition = startPosition + bytesToRead;
       }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -861,7 +861,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     }
 
     String rangeHeader;
-    if (readOptions.isReadOnlyRequestBytesEnabled() && !gzipEncoded) {
+    if (readOptions.isReadExactRequestedBytesEnabled() && !gzipEncoded) {
       contentChannelPosition = currentPosition;
       contentChannelEnd = contentChannelPosition + bytesToRead;
       rangeHeader = "bytes=" + contentChannelPosition + "-" + (contentChannelEnd - 1);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -861,7 +861,11 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     }
 
     String rangeHeader;
-    if (!metadataInitialized) {
+    if (readOptions.isReadOnlyRequestBytesEnabled() && !gzipEncoded) {
+      contentChannelPosition = currentPosition;
+      contentChannelEnd = contentChannelPosition + bytesToRead;
+      rangeHeader = "bytes=" + contentChannelPosition + "-" + (contentChannelEnd - 1);
+    } else if (!metadataInitialized) {
       contentChannelPosition = getContentChannelPositionForFirstRead(bytesToRead);
       rangeHeader = "bytes=" + contentChannelPosition + "-";
       if (readOptions.getFadvise() == Fadvise.RANDOM

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -58,7 +58,7 @@ public abstract class GoogleCloudStorageReadOptions {
         .setMinRangeRequestSize(2 * 1024 * 1024)
         .setBlockSize(64 * 1024 * 1024)
         .setFadviseRequestTrackCount(3)
-        .setReadOnlyRequestBytesEnabled(false);
+        .setReadExactRequestedBytesEnabled(false);
   }
 
   public abstract Builder toBuilder();
@@ -96,8 +96,8 @@ public abstract class GoogleCloudStorageReadOptions {
   /** See {@link Builder#setGrpcChecksumsEnabled}. */
   public abstract boolean isGrpcChecksumsEnabled();
 
-  /** See {@link Builder#isReadOnlyRequestBytesEnabled}. */
-  public abstract boolean isReadOnlyRequestBytesEnabled();
+  /** See {@link Builder#setReadExactRequestedBytesEnabled}. */
+  public abstract boolean isReadExactRequestedBytesEnabled();
 
   /** See {@link Builder#setGrpcReadTimeout}. */
   public abstract Duration getGrpcReadTimeout();
@@ -204,7 +204,8 @@ public abstract class GoogleCloudStorageReadOptions {
      */
     public abstract Builder setGrpcChecksumsEnabled(boolean grpcChecksumsEnabled);
 
-    public abstract Builder setReadOnlyRequestBytesEnabled(boolean readOnlyRequestBytesEnabled);
+    public abstract Builder setReadExactRequestedBytesEnabled(
+        boolean readExactRequestedBytesEnabled);
 
     /** Sets the property to override the default GCS gRPC read stream timeout. */
     public abstract Builder setGrpcReadTimeout(Duration grpcReadTimeout);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -57,7 +57,8 @@ public abstract class GoogleCloudStorageReadOptions {
         .setInplaceSeekLimit(8 * 1024 * 1024)
         .setMinRangeRequestSize(2 * 1024 * 1024)
         .setBlockSize(64 * 1024 * 1024)
-        .setFadviseRequestTrackCount(3);
+        .setFadviseRequestTrackCount(3)
+        .setReadOnlyRequestBytesEnabled(false);
   }
 
   public abstract Builder toBuilder();
@@ -94,6 +95,9 @@ public abstract class GoogleCloudStorageReadOptions {
 
   /** See {@link Builder#setGrpcChecksumsEnabled}. */
   public abstract boolean isGrpcChecksumsEnabled();
+
+  /** See {@link Builder#isReadOnlyRequestBytesEnabled}. */
+  public abstract boolean isReadOnlyRequestBytesEnabled();
 
   /** See {@link Builder#setGrpcReadTimeout}. */
   public abstract Duration getGrpcReadTimeout();
@@ -199,6 +203,8 @@ public abstract class GoogleCloudStorageReadOptions {
      * them and we're validating them.
      */
     public abstract Builder setGrpcChecksumsEnabled(boolean grpcChecksumsEnabled);
+
+    public abstract Builder setReadOnlyRequestBytesEnabled(boolean readOnlyRequestBytesEnabled);
 
     /** Sets the property to override the default GCS gRPC read stream timeout. */
     public abstract Builder setGrpcReadTimeout(Duration grpcReadTimeout);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -304,6 +304,44 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
+  public void read_onlyRequestedRange() throws IOException {
+    int rangeSize = 2;
+    int seekPosition = 0;
+    byte[] testData = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+    byte[] requestedContent = Arrays.copyOfRange(testData, seekPosition, seekPosition + rangeSize);
+
+    MockHttpTransport transport =
+        mockTransport(
+            // Footer prefetch response
+            dataRangeResponse(requestedContent, 0, testData.length));
+
+    List<HttpRequest> requests = new ArrayList<>();
+
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadOptions options =
+        newLazyReadOptionsBuilder()
+            .setFadvise(Fadvise.SEQUENTIAL)
+            .setMinRangeRequestSize(4)
+            .setReadOnlyRequestBytesEnabled(true)
+            .build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
+    assertThat(requests).isEmpty();
+
+    byte[] readBytes = new byte[rangeSize];
+
+    assertThat(readChannel.read(ByteBuffer.wrap(readBytes))).isEqualTo(readBytes.length);
+    assertThat(readChannel.size()).isEqualTo(testData.length);
+    assertThat(readBytes).isEqualTo(requestedContent);
+
+    List<String> rangeHeaders =
+        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
+
+    assertThat(rangeHeaders).containsExactly("bytes=0-1").inOrder();
+  }
+
+  @Test
   public void read_whenBufferIsEmpty() throws IOException {
     ByteBuffer emptyBuffer = ByteBuffer.wrap(new byte[0]);
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -323,7 +323,7 @@ public class GoogleCloudStorageReadChannelTest {
         newLazyReadOptionsBuilder()
             .setFadvise(Fadvise.SEQUENTIAL)
             .setMinRangeRequestSize(4)
-            .setReadOnlyRequestBytesEnabled(true)
+            .setReadExactRequestedBytesEnabled(true)
             .build();
 
     GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);


### PR DESCRIPTION
Introduced a new ReadOption to open channel just for the requested bytes. Prior to readVectored read channel opened with gcs backend were getting re utilized and subsequent reads were also been served from existing channel. With readVecotred that will never happen.