### PR TITLE
Create performance cache in all flows when `fs.gs.performance.cache.enable` flag is set

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemTestBase.java
@@ -176,6 +176,14 @@ public abstract class GoogleCloudStorageFileSystemTestBase
     assertThat(tmpGcsFs.getGcs()).isInstanceOf(getGoogleCloudStorageImplClass());
     assertThat(gcsfs.getOptions().getCloudStorageOptions().getRequesterPaysOptions())
         .isEqualTo(RequesterPaysOptions.DEFAULT);
+
+    // Verify constructor return a Performance cache instance when enabled.
+    optionsBuilder.setPerformanceCacheEnabled(true);
+    GoogleCloudStorageFileSystem gcsfsWithCache =
+        new GoogleCloudStorageFileSystemImpl(cred, optionsBuilder.build());
+
+    assertThat(gcsfsWithCache.getGcs()).isInstanceOf(PerformanceCachingGoogleCloudStorage.class);
+    assertThat(gcsfsWithCache.getGcs()).isInstanceOf(PerformanceCachingGoogleCloudStorage.class);
   }
 
   /** Verify that PATH_COMPARATOR produces correct sorting order. */


### PR DESCRIPTION
Creates performance cache in all constructors of GoogleCloudStorageFileSystem and modifieds UT to test the code.

Did not add for the third constructor since it uses an already configured GoogleCloudStorage.