### PR TITLE
[Follow-ups] Add integration tests for gcsio layer and add move support in PerformanceCachingGoogleCloudStorage

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -222,8 +222,6 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     }
   }
 
-  // TODO: Enable the integration tests after move is enabled for the cloud project.
-  @Ignore
   @Test
   public void testRenameWithMoveOperation() throws Exception {
     String bucketName = this.gcsiHelper.getUniqueBucketName("move");

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -222,6 +222,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     }
   }
 
+  // TODO: Enable the integration tests after move is enabled for the cloud project.
   @Ignore
   @Test
   public void testRenameWithMoveOperation() throws Exception {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -23,6 +23,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class adds a caching layer around a GoogleCloudStorage instance, caching calls that create,
@@ -93,6 +94,23 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
     // Remove the deleted objects from cache.
     for (StorageResourceId resourceId : resourceIds) {
       cache.removeItem(resourceId);
+    }
+  }
+
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    super.move(sourceToDestinationObjectsMap);
+
+    // On success, invalidate cache entries
+    if (cache != null) {
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcResourceId = entry.getKey();
+
+        // Invalidate the source item.
+        cache.removeItem(srcResourceId);
+      }
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -348,8 +348,10 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       if (!validateObjectName(srcObject.getObjectName())
           || !validateObjectName(dstObject.getObjectName())) {
         innerExceptions.add(
-            createFileNotFoundException(
-                srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
+            new IOException(
+                String.format(
+                    "Invalid object name for move source '%s' or destination '%s'",
+                    srcObject, dstObject)));
         continue;
       }
 
@@ -358,7 +360,8 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
         if (!srcInfo.exists()) {
           // If the source is not found, add an error to the list and continue.
           innerExceptions.add(
-              new IOException(String.format("Source object '%s' not found.", srcObject)));
+              createFileNotFoundException(
+                  srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
           continue;
         }
 
@@ -378,7 +381,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
     }
 
     if (!innerExceptions.isEmpty()) {
-      GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+      throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
     }
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageTest.java
@@ -35,6 +35,7 @@ import com.google.common.hash.Hashing;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,6 +66,7 @@ public class PerformanceCachingGoogleCloudStorageTest {
   // Sample bucket names.
   private static final String BUCKET_A = "alpha";
   private static final String BUCKET_B = "alph";
+  private static final String BUCKET_C = "charlie";
 
   // Sample object names.
   private static final String PREFIX_A = "bar";
@@ -75,6 +77,9 @@ public class PerformanceCachingGoogleCloudStorageTest {
   /* Sample bucket item info. */
   private static final GoogleCloudStorageItemInfo ITEM_A = createBucketItemInfo(BUCKET_A);
   private static final GoogleCloudStorageItemInfo ITEM_B = createBucketItemInfo(BUCKET_B);
+
+  private static final GoogleCloudStorageItemInfo ITEM_C_A_DEST =
+      createObjectItemInfo(BUCKET_C, PREFIX_A);
 
   /* Sample item info. */
   private static final GoogleCloudStorageItemInfo ITEM_A_A =
@@ -115,6 +120,7 @@ public class PerformanceCachingGoogleCloudStorageTest {
     // Prepare the delegate.
     gcsDelegate.createBucket(BUCKET_A, CREATE_BUCKET_OPTIONS);
     gcsDelegate.createBucket(BUCKET_B, CREATE_BUCKET_OPTIONS);
+
     gcsDelegate.createEmptyObject(ITEM_A_A.getResourceId(), CREATE_OBJECT_OPTIONS);
     gcsDelegate.createEmptyObject(ITEM_A_AA.getResourceId(), CREATE_OBJECT_OPTIONS);
     gcsDelegate.createEmptyObject(ITEM_A_ABA.getResourceId(), CREATE_OBJECT_OPTIONS);
@@ -155,6 +161,31 @@ public class PerformanceCachingGoogleCloudStorageTest {
     verify(gcsDelegate).deleteObjects(eq(ids));
     // Verify the state of the cache.
     assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_B_B);
+  }
+
+  @Test
+  public void testMove_invalidatesSourceAndNotDestinationInCache_simple() throws IOException {
+    gcsDelegate.createBucket(BUCKET_C, CREATE_BUCKET_OPTIONS);
+
+    StorageResourceId sourceId = ITEM_A_A.getResourceId();
+    StorageResourceId destinationId = ITEM_C_A_DEST.getResourceId();
+
+    Map<StorageResourceId, StorageResourceId> moveMap = ImmutableMap.of(sourceId, destinationId);
+
+    // Prepare the cache.
+    cache.putItem(ITEM_A_A);
+    assertThat(cache.getItem(sourceId)).isEqualTo(ITEM_A_A);
+    assertThat(cache.getItem(destinationId)).isNull();
+
+    // Call the move operation on the caching GCS instance
+    gcs.move(moveMap);
+
+    // Verify the delegate's move method was called
+    verify(gcsDelegate).move(eq(moveMap));
+    // Verify the source item is removed from the cache
+    assertThat(cache.getItem(sourceId)).isNull();
+    // Verify the destination item was NOT added to the cache by the move operation itself
+    assertThat(cache.getItem(destinationId)).isNull();
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -204,8 +204,6 @@ public class GoogleCloudStorageImplTest {
     trackingGcs.delegate.close();
   }
 
-  // TODO: Enable the integration tests after move is enabled for the cloud project.
-  @Ignore
   @Test
   public void moveObject_successful() throws IOException {
     int expectedSize = 5 * 1024 * 1024;
@@ -252,8 +250,6 @@ public class GoogleCloudStorageImplTest {
     trackingGcs.delegate.close();
   }
 
-  // TODO: Enable the integration tests after move is enabled for the cloud project.
-  @Ignore
   @Test
   public void moveObject_sourceAndDestinationSame_throwsError() throws IOException {
     StorageResourceId resourceId =
@@ -279,8 +275,6 @@ public class GoogleCloudStorageImplTest {
     trackingGcs.delegate.close();
   }
 
-  // TODO: Enable the integration tests after move is enabled for the cloud project.
-  @Ignore
   @Test
   public void moveObject_differentBuckets_throwsError() throws IOException {
     StorageResourceId srcResourceId =
@@ -309,8 +303,6 @@ public class GoogleCloudStorageImplTest {
     trackingGcs.delegate.close();
   }
 
-  // TODO: Enable the integration tests after move is enabled for the cloud project.
-  @Ignore
   @Test
   public void moveObject_sourceNotFound_throwsError() throws IOException {
     StorageResourceId srcResourceId =

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -28,6 +28,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertThrows;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.auth.Credentials;
 import com.google.cloud.hadoop.gcsio.AssertingLogHandler;
 import com.google.cloud.hadoop.gcsio.CreateBucketOptions;
@@ -45,6 +46,7 @@ import com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TrackingStorageWrapper;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -199,6 +201,160 @@ public class GoogleCloudStorageImplTest {
         .inOrder();
 
     assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings().size()).isEqualTo(0);
+    trackingGcs.delegate.close();
+  }
+
+  // TODO: Enable the integration tests after move is enabled for the cloud project.
+  @Ignore
+  @Test
+  public void moveObject_successful() throws IOException {
+    int expectedSize = 5 * 1024 * 1024;
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_dst.txt");
+
+    // Create source object
+    writeObject(helperGcs, srcResourceId, expectedSize, 1);
+    GoogleCloudStorageItemInfo srcInfoBeforeMove = helperGcs.getItemInfo(srcResourceId);
+    assertThat(srcInfoBeforeMove.exists()).isTrue();
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    // Perform move
+    trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId));
+
+    // Assertions
+    GoogleCloudStorageItemInfo srcInfoAfterMove = helperGcs.getItemInfo(srcResourceId);
+    GoogleCloudStorageItemInfo dstInfoAfterMove = helperGcs.getItemInfo(dstResourceId);
+
+    assertThat(srcInfoAfterMove.exists()).isFalse();
+    assertThat(dstInfoAfterMove.exists()).isTrue();
+    assertThat(dstInfoAfterMove.getSize()).isEqualTo(expectedSize);
+
+    // Assert requests
+    assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
+        .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
+
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isNotEmpty();
+    } else {
+      assertThat(trackingGcs.getAllRequestStrings())
+          .containsExactly(
+              TrackingHttpRequestInitializer.moveRequestString(
+                  testBucket,
+                  srcResourceId.getObjectName(),
+                  dstResourceId.getObjectName(),
+                  "moveTo"))
+          .inOrder();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  // TODO: Enable the integration tests after move is enabled for the cloud project.
+  @Ignore
+  @Test
+  public void moveObject_sourceAndDestinationSame_throwsError() throws IOException {
+    StorageResourceId resourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_samesrcdst.txt");
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(resourceId, resourceId)));
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains(
+            String.format("Move destination must be different from source for %s", resourceId));
+
+    assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  // TODO: Enable the integration tests after move is enabled for the cloud project.
+  @Ignore
+  @Test
+  public void moveObject_differentBuckets_throwsError() throws IOException {
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src_diffbuckets.txt");
+    // Create a unique name for the other bucket to avoid conflicts if it were created.
+    String otherBucketName = bucketHelper.getUniqueBucketName("gcsio-other-move-bucket");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(otherBucketName, name.getMethodName() + "_dst_diffbuckets.txt");
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    UnsupportedOperationException thrown =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId)));
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("This operation is not supported across two different buckets.");
+
+    assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  // TODO: Enable the integration tests after move is enabled for the cloud project.
+  @Ignore
+  @Test
+  public void moveObject_sourceNotFound_throwsError() throws IOException {
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src_notfound.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_dst_for_notfound.txt");
+
+    // Source object is not created.
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId)));
+
+    assertThat(thrown).isInstanceOf(java.io.FileNotFoundException.class);
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Item not found: '" + srcResourceId.toString() + "'");
+
+    if (testStorageClientImpl) {
+      Throwable cause = thrown.getCause().getCause();
+      assertThat(cause).isInstanceOf(StorageException.class);
+
+      List<String> grpcRequests = trackingGcs.grpcRequestInterceptor.getAllRequestStrings();
+      assertThat(grpcRequests).isNotEmpty();
+      assertThat(grpcRequests.toString()).contains("MoveObject");
+
+      assertThat(((StorageException) cause).getCode()).isEqualTo(404);
+    } else {
+      Throwable cause = thrown.getCause();
+      assertThat(cause).isInstanceOf(GoogleJsonResponseException.class);
+      GoogleJsonResponseException gjre = (GoogleJsonResponseException) cause;
+      assertThat(gjre.getStatusCode()).isEqualTo(404);
+
+      assertThat(trackingGcs.getAllRequestStrings())
+          .containsExactly(
+              TrackingHttpRequestInitializer.moveRequestString(
+                  testBucket,
+                  srcResourceId.getObjectName(),
+                  dstResourceId.getObjectName(),
+                  "moveTo"));
+    }
     trackingGcs.delegate.close();
   }
 


### PR DESCRIPTION
Changes : 
- Added integration tests for `gcsio` lin GCSImplTest and GCSTest.
- Added support for move in `PerformanceCachingGoogleCloudStorage`
- Added corresponding unit tests for PerformanceCachingGoogleCloudStorage

Enabled integration tests as move api is now enabled for the projects. 