### PR TITLE
Using Apiary client for isHnBucket checks 

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -46,6 +46,7 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageRequest;
 import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.BucketStorageLayout;
 import com.google.api.services.storage.model.Buckets;
 import com.google.api.services.storage.model.ComposeRequest;
 import com.google.api.services.storage.model.Objects;
@@ -1824,7 +1825,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     checkNotNull(listedFolder, "Must provide a non-null container for listedFolder.");
 
     ListFoldersPagedResponse listFolderRespose =
-        storageControlClient.listFolders(listFoldersRequest);
+        lazyGetStorageControlClient().listFolders(listFoldersRequest);
     try (ITraceOperation op = TraceOperation.addToExistingTrace("gcs.folders.list")) {
       Iterator<Folder> itemsIterator = listFolderRespose.getPage().getValues().iterator();
       while (itemsIterator.hasNext()) {
@@ -2414,20 +2415,11 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       return isEnabled;
     }
 
-    String prefix = src.getPath().substring(1);
-
-    StorageControlClient storageControlClient = lazyGetStorageControlClient();
-    GetStorageLayoutRequest request =
-        GetStorageLayoutRequest.newBuilder()
-            .setPrefix(prefix)
-            .setName(StorageLayoutName.format("_", bucketName))
-            .build();
-
+    Storage.Buckets.GetStorageLayout request =
+        initializeRequest(storage.buckets().getStorageLayout(bucketName), bucketName);
     try (ITraceOperation to = TraceOperation.addToExistingTrace("getStorageLayout.HN")) {
-      StorageLayout storageLayout = storageControlClient.getStorageLayout(request);
-      boolean result =
-          storageLayout.hasHierarchicalNamespace()
-              && storageLayout.getHierarchicalNamespace().getEnabled();
+      BucketStorageLayout layout = request.execute();
+      boolean result = layout.getHierarchicalNamespace().getEnabled();
 
       logger.atInfo().log("Checking if %s is HN enabled returned %s", src, result);
 
@@ -2461,7 +2453,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
 
     try (ITraceOperation to = TraceOperation.addToExistingTrace("renameHnFolder")) {
       logger.atFine().log("Renaming HN folder (%s -> %s)", src, dst);
-      this.storageControlClient.renameFolderOperationCallable().call(request);
+      lazyGetStorageControlClient().renameFolderOperationCallable().call(request);
     } catch (Throwable t) {
       logger.atSevere().withCause(t).log("Renaming %s to %s failed", src, dst);
       throw t;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -61,6 +61,8 @@ import com.google.api.client.util.NanoClock;
 import com.google.api.client.util.Sleeper;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.BucketStorageLayout;
+import com.google.api.services.storage.model.BucketStorageLayout.HierarchicalNamespace;
 import com.google.api.services.storage.model.Buckets;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
@@ -84,6 +86,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.net.SocketTimeoutException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SeekableByteChannel;
@@ -2238,6 +2241,38 @@ public class GoogleCloudStorageTest {
     assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
         .containsExactly(listBucketsRequestString(PROJECT_ID))
         .inOrder();
+  }
+
+  /** Test for GoogleCloudStorage.isHnBucket(1). */
+  @Test
+  public void testIsHnBucket_enabled() throws Exception {
+    BucketStorageLayout layout =
+        new BucketStorageLayout()
+            .setHierarchicalNamespace(new HierarchicalNamespace().setEnabled(true));
+    MockHttpTransport transport = mockTransport(jsonDataResponse(layout));
+    GoogleCloudStorage gcs =
+        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
+
+    URI bucketUri = new URI("gs://hns-enabled-bucket");
+    boolean result = gcs.isHnBucket(bucketUri);
+
+    assertThat(result).isTrue();
+  }
+
+  /** Test for GoogleCloudStorage.isHnBucket(1). */
+  @Test
+  public void testIsHnBucket_disabled() throws Exception {
+    BucketStorageLayout layout =
+        new BucketStorageLayout()
+            .setHierarchicalNamespace(new HierarchicalNamespace().setEnabled(false));
+    MockHttpTransport transport = mockTransport(jsonDataResponse(layout));
+    GoogleCloudStorage gcs =
+        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
+
+    URI bucketUri = new URI("gs://hns-disabled-bucket");
+    boolean result = gcs.isHnBucket(bucketUri);
+
+    assertThat(result).isFalse();
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -29,6 +29,7 @@ import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.creat
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.deleteBucketRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.deleteRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getBucketRequestString;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getBucketStorageLayoutRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getMediaRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listBucketsRequestString;
@@ -2253,9 +2254,11 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs =
         mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
 
-    URI bucketUri = new URI("gs://hns-enabled-bucket");
+    URI bucketUri = new URI("gs://" + BUCKET_NAME);
     boolean result = gcs.isHnBucket(bucketUri);
 
+    assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
+        .containsExactly(getBucketStorageLayoutRequestString(BUCKET_NAME));
     assertThat(result).isTrue();
   }
 
@@ -2269,9 +2272,11 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs =
         mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
 
-    URI bucketUri = new URI("gs://hns-disabled-bucket");
+    URI bucketUri = new URI("gs://" + BUCKET_NAME);
     boolean result = gcs.isHnBucket(bucketUri);
 
+    assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
+        .containsExactly(getBucketStorageLayoutRequestString(BUCKET_NAME));
     assertThat(result).isFalse();
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -2254,11 +2254,13 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs =
         mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
 
-    URI bucketUri = new URI("gs://" + BUCKET_NAME);
+    String testHnsBucket = "hns-bucket-enabled";
+    URI bucketUri = new URI("gs://" + testHnsBucket);
     boolean result = gcs.isHnBucket(bucketUri);
 
     assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
-        .containsExactly(getBucketStorageLayoutRequestString(BUCKET_NAME));
+        .containsExactly(getBucketStorageLayoutRequestString(testHnsBucket))
+        .inOrder();
     assertThat(result).isTrue();
   }
 
@@ -2272,11 +2274,13 @@ public class GoogleCloudStorageTest {
     GoogleCloudStorage gcs =
         mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
 
-    URI bucketUri = new URI("gs://" + BUCKET_NAME);
+    String testHnsBucket = "hns-bucket-disabled";
+    URI bucketUri = new URI("gs://" + testHnsBucket);
     boolean result = gcs.isHnBucket(bucketUri);
 
     assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
-        .containsExactly(getBucketStorageLayoutRequestString(BUCKET_NAME));
+        .containsExactly(getBucketStorageLayoutRequestString(testHnsBucket))
+        .inOrder();
     assertThat(result).isFalse();
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
@@ -50,6 +50,9 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
   private static final String GET_BUCKET_REQUEST_FORMAT =
       "GET:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s";
 
+  private static final String GET_BUCKET_STORAGE_LAYOUT_REQUEST_FORMAT =
+      "GET:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/storageLayout";
+
   private static final String POST_REQUEST_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s";
 
@@ -262,6 +265,10 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
 
   public static String getBucketRequestString(String bucketName) {
     return String.format(GET_BUCKET_REQUEST_FORMAT, bucketName);
+  }
+
+  public static String getBucketStorageLayoutRequestString(String bucketName) {
+    return String.format(GET_BUCKET_STORAGE_LAYOUT_REQUEST_FORMAT, bucketName);
   }
 
   public static String postRequestString(String bucketName, String object) {


### PR DESCRIPTION
getStorageLayout call from Apiary client results in faster responses than StorageControlClient so using the same. Here are the results from our experiments,

Using Apiary call,
Before initializing connection - 1202 ms
After initializing connection - 66 ms

Using Storage control client,
Without initializing connection - 2969 ms
After initializing connection - 83 ms

There is around 20% improvement in post-initialization calls and 60% improvement in the pre-initialization calls. This will also helps us reducing the tax for non-HNS users when we enable the HNS flag by default in connector. One can find code changes for benchmarking these APIs [here](https://github.com/animesh-g/hadoop-connectors/pull/4/commits/5db42b44749244c1af155e5d885334e3570b1423).

Older PR from a fork - https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1334
