### PR TITLE
Backport move-api changes to Branch-3.0.x

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -563,6 +563,12 @@ public class GoogleHadoopFileSystemConfiguration {
           "fs.gs.write.parallel.composite.upload.part.file.name.prefix",
           AsyncWriteChannelOptions.DEFAULT.getPartFileNamePrefix());
 
+  /** Configuration key for enabling move operation in gcs instead of copy+delete. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_OPERATION_MOVE_ENABLE =
+      new HadoopConfigurationProperty<>(
+          "fs.gs.operation.move.enable",
+          GoogleCloudStorageOptions.DEFAULT.isMoveOperationEnabled());
+
   static GoogleCloudStorageFileSystemOptions.Builder getGcsFsOptionsBuilder(Configuration config) {
     return GoogleCloudStorageFileSystemOptions.builder()
         .setBucketDeleteEnabled(GCE_BUCKET_DELETE_ENABLE.get(config, config::getBoolean))
@@ -625,7 +631,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setTraceLogEnabled(GCS_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setOperationTraceLogEnabled(GCS_OPERATION_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setTrafficDirectorEnabled(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.get(config, config::getBoolean))
-        .setWriteChannelOptions(getWriteChannelOptions(config));
+        .setWriteChannelOptions(getWriteChannelOptions(config))
+        .setMoveOperationEnabled(GCS_OPERATION_MOVE_ENABLE.get(config, config::getBoolean));
   }
 
   @VisibleForTesting

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -128,6 +128,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
           put("fs.gs.fadvise.request.track.count", 3);
+          put("fs.gs.operation.move.enable", false);
         }
       };
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -221,6 +221,43 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     }
   }
 
+  @Ignore
+  @Test
+  public void testRenameWithMoveOperation() throws Exception {
+    String bucketName = this.gcsiHelper.getUniqueBucketName("move");
+    GoogleHadoopFileSystem googleHadoopFileSystem = new GoogleHadoopFileSystem();
+
+    URI initUri = new URI("gs://" + bucketName);
+    Configuration config = loadConfig();
+    config.setBoolean("fs.gs.operation.move.enable", true);
+    googleHadoopFileSystem.initialize(initUri, config);
+
+    GoogleCloudStorage theGcs = googleHadoopFileSystem.getGcsFs().getGcs();
+    theGcs.createBucket(bucketName);
+
+    try {
+      GoogleCloudStorageFileSystemIntegrationHelper helper =
+          new HadoopFileSystemIntegrationHelper(googleHadoopFileSystem);
+
+      renameHelper(
+          new HdfsBehavior() {
+            /**
+             * Returns the MethodOutcome of trying to rename an existing file into the root
+             * directory.
+             */
+            @Override
+            public MethodOutcome renameFileIntoRootOutcome() {
+              return new MethodOutcome(MethodOutcome.Type.RETURNS_TRUE);
+            }
+          },
+          bucketName,
+          bucketName,
+          helper);
+    } finally {
+      googleHadoopFileSystem.delete(new Path(initUri));
+    }
+  }
+
   @Test
   public void testInitializePath_success() throws Exception {
     List<String> validPaths = Arrays.asList("gs://foo", "gs://foo/bar");

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -221,7 +221,6 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     }
   }
 
-  @Ignore
   @Test
   public void testRenameWithMoveOperation() throws Exception {
     String bucketName = this.gcsiHelper.getUniqueBucketName("move");

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
@@ -64,6 +64,10 @@ public class GoogleHadoopFileSystemJavaStorageClientIntegrationTest
 
   @Ignore
   @Test
+  public void testRenameWithMoveOperation() {}
+
+  @Ignore
+  @Test
   public void testGcsJsonAPIMetrics() {
     // TODO: Update this will once gRPC API metrics are added
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -390,6 +390,9 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   public void testRenameHnBucket() {}
 
   @Override
+  public void testRenameWithMoveOperation() {}
+
+  @Override
   public void testGcsJsonAPIMetrics() {}
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -153,6 +153,13 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    logger.atFiner().log("%s.move(%s)", delegateClassName, sourceToDestinationObjectsMap);
+    delegate.move(sourceToDestinationObjectsMap);
+  }
+
+  @Override
   public boolean isHnBucket(URI src) throws IOException {
     return delegate.isHnBucket(src);
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -282,6 +282,17 @@ public interface GoogleCloudStorage {
   }
 
   /**
+   * Moves objects within the same bucket. Moving objects between different buckets is not allowed.
+   *
+   * @param sourceToDestinationObjectsMap map of destination objects to be moved, keyed by source
+   * @throws java.io.FileNotFoundException if the source object or the destination bucket does not
+   *     exist
+   * @throws IOException in all other error cases
+   */
+  void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException;
+
+  /**
    * Checks if {@code resourceId} belongs to a Hierarchical namespace enabled bucket. This takes a
    * path and not the bucket name since the caller may not have permission to query the bucket.
    *

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
@@ -43,6 +43,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInterceptor {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   public static final String IDEMPOTENCY_TOKEN_HEADER = "x-goog-gcs-idempotency-token";
+  private static final String DEFAULT_IDEMPOTENCY_TOKEN_VALUE = "IDEMPOTENCY_TOKEN_NOT_FOUND";
   private static final DateTimeFormatter dtf =
       DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS");
   private static final Metadata.Key<String> idempotencyKey =
@@ -215,7 +216,14 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
     }
 
     private String getInvocationId() {
-      return headers.get(idempotencyKey);
+      if (this.headers == null) {
+        return DEFAULT_IDEMPOTENCY_TOKEN_VALUE;
+      }
+      String token = this.headers.get(idempotencyKey);
+      if (token == null) {
+        return DEFAULT_IDEMPOTENCY_TOKEN_VALUE;
+      }
+      return token;
     }
 
     private ImmutableMap.Builder<String, Object> getStreamContext() {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -24,7 +24,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -57,6 +56,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.grpc.ClientInterceptor;
 import java.io.IOException;
@@ -244,12 +244,16 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
         new FutureCallback<Blob>() {
           @Override
           public void onSuccess(@Nullable Blob result) {
-            logger.atFiner().log("Move operation succeeded via callback for %s.", StringPaths.fromComponents(srcBucketName, srcObjectName));
+            logger.atFiner().log(
+                "Move operation succeeded via callback for %s.",
+                StringPaths.fromComponents(srcBucketName, srcObjectName));
           }
 
           @Override
           public void onFailure(Throwable t) {
-            logger.atWarning().withCause(t).log("Move operation failed via callback for %s.", StringPaths.fromComponents(srcBucketName, srcObjectName));
+            logger.atWarning().withCause(t).log(
+                "Move operation failed via callback for %s.",
+                StringPaths.fromComponents(srcBucketName, srcObjectName));
           }
         });
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.validateMoveArguments;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -30,8 +32,11 @@ import com.google.cloud.hadoop.util.AccessBoundary;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions.PartFileCleanupType;
 import com.google.cloud.hadoop.util.ErrorTypeExtractor;
+import com.google.cloud.hadoop.util.ErrorTypeExtractor.ErrorType;
 import com.google.cloud.hadoop.util.GoogleCloudStorageEventBus;
 import com.google.cloud.hadoop.util.GrpcErrorTypeExtractor;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobWriteSessionConfig;
 import com.google.cloud.storage.BlobWriteSessionConfigs;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.BufferAllocationStrategy;
@@ -39,6 +44,10 @@ import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.Ex
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartNamingStrategy;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.MoveBlobRequest;
+import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -57,6 +66,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentHashMap.KeySetView;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -139,6 +151,132 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
 
     return new GoogleCloudStorageClientWriteChannel(
         storage, storageOptions, resourceIdWithGeneration, options);
+  }
+
+  /**
+   * See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)} for details
+   * about expected behavior.
+   */
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+
+    validateMoveArguments(sourceToDestinationObjectsMap);
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    // Gather FileNotFoundExceptions for individual objects,
+    // but only throw a single combined exception at the end.
+    ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions =
+        ConcurrentHashMap.newKeySet();
+
+    BatchExecutor executor = new BatchExecutor(storageOptions.getBatchThreads());
+
+    try {
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcObject = entry.getKey();
+        StorageResourceId dstObject = entry.getValue();
+        moveInternal(
+            executor,
+            innerExceptions,
+            srcObject.getBucketName(),
+            srcObject.getGenerationId(),
+            srcObject.getObjectName(),
+            dstObject.getGenerationId(),
+            dstObject.getObjectName());
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    if (!innerExceptions.isEmpty()) {
+      GoogleCloudStorageEventBus.postOnException();
+      throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+    }
+  }
+
+  private void moveInternal(
+      BatchExecutor executor,
+      KeySetView<IOException, Boolean> innerExceptions,
+      String srcBucketName,
+      long srcContentGeneration,
+      String srcObjectName,
+      long dstContentGeneration,
+      String dstObjectName) {
+    MoveBlobRequest.Builder moveRequestBuilder =
+        createMoveRequestBuilder(
+            srcBucketName,
+            srcObjectName,
+            dstObjectName,
+            srcContentGeneration,
+            dstContentGeneration);
+
+    executor.queue(
+        () -> {
+          try {
+            String srcString = StringPaths.fromComponents(srcBucketName, srcObjectName);
+            String dstString = StringPaths.fromComponents(srcBucketName, dstObjectName);
+
+            Blob movedBlob = storage.moveBlob(moveRequestBuilder.build());
+            if (movedBlob != null) {
+              logger.atFiner().log("Successfully moved %s to %s", srcString, dstString);
+            }
+          } catch (StorageException e) {
+            GoogleCloudStorageEventBus.postOnException();
+            if (errorExtractor.getErrorType(e) == ErrorType.NOT_FOUND) {
+              innerExceptions.add(
+                  createFileNotFoundException(srcBucketName, srcObjectName, new IOException(e)));
+            } else {
+              innerExceptions.add(
+                  new IOException(
+                      String.format(
+                          "Error moving '%s'",
+                          StringPaths.fromComponents(srcBucketName, srcObjectName)),
+                      e));
+            }
+          }
+          return null;
+        },
+        null);
+  }
+
+  /** Creates a builder for a blob move request. */
+  private MoveBlobRequest.Builder createMoveRequestBuilder(
+      String srcBucketName,
+      String srcObjectName,
+      String dstObjectName,
+      long srcContentGeneration,
+      long dstContentGeneration) {
+
+    MoveBlobRequest.Builder moveRequestBuilder =
+        MoveBlobRequest.newBuilder().setSource(BlobId.of(srcBucketName, srcObjectName));
+    moveRequestBuilder.setTarget(BlobId.of(srcBucketName, dstObjectName));
+
+    List<BlobTargetOption> blobTargetOptions = new ArrayList<>();
+    List<BlobSourceOption> blobSourceOptions = new ArrayList<>();
+
+    if (srcContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      blobSourceOptions.add(BlobSourceOption.generationMatch(srcContentGeneration));
+    }
+
+    if (dstContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      blobTargetOptions.add(BlobTargetOption.generationMatch(dstContentGeneration));
+    }
+
+    if (storageOptions.getEncryptionKey() != null) {
+      blobSourceOptions.add(
+          BlobSourceOption.decryptionKey(storageOptions.getEncryptionKey().value()));
+      blobTargetOptions.add(
+          BlobTargetOption.encryptionKey(storageOptions.getEncryptionKey().value()));
+    }
+
+    moveRequestBuilder.setSourceOptions(blobSourceOptions);
+    moveRequestBuilder.setTargetOptions(blobTargetOptions);
+
+    return moveRequestBuilder;
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -240,7 +241,17 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
           }
           return null;
         },
-        null);
+        new FutureCallback<Blob>() {
+          @Override
+          public void onSuccess(@Nullable Blob result) {
+            logger.atFiner().log("Move operation succeeded via callback for %s.", StringPaths.fromComponents(srcBucketName, srcObjectName));
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+            logger.atWarning().withCause(t).log("Move operation failed via callback for %s.", StringPaths.fromComponents(srcBucketName, srcObjectName));
+          }
+        });
   }
 
   /** Creates a builder for a blob move request. */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -613,14 +614,25 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
           StorageResourceId.fromUriPath(
               dst, /* allowEmptyObjectName= */ true, /* generationId= */ 0L);
 
-      gcs.copy(ImmutableMap.of(srcResourceId, dstResourceId));
+      if (this.options.getCloudStorageOptions().isMoveOperationEnabled()
+          && srcResourceId.getBucketName().equals(dstResourceId.getBucketName())) {
+        gcs.move(
+            ImmutableMap.of(
+                new StorageResourceId(
+                    srcInfo.getItemInfo().getBucketName(),
+                    srcInfo.getItemInfo().getObjectName(),
+                    srcInfo.getItemInfo().getContentGeneration()),
+                dstResourceId));
+      } else {
+        gcs.copy(ImmutableMap.of(srcResourceId, dstResourceId));
 
-      gcs.deleteObjects(
-          ImmutableList.of(
-              new StorageResourceId(
-                  srcInfo.getItemInfo().getBucketName(),
-                  srcInfo.getItemInfo().getObjectName(),
-                  srcInfo.getItemInfo().getContentGeneration())));
+        gcs.deleteObjects(
+            ImmutableList.of(
+                new StorageResourceId(
+                    srcInfo.getItemInfo().getBucketName(),
+                    srcInfo.getItemInfo().getObjectName(),
+                    srcInfo.getItemInfo().getContentGeneration())));
+      }
     }
 
     repairImplicitDirectory(srcParentInfoFuture);
@@ -763,6 +775,29 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
       }
     }
 
+    StorageResourceId srcResourceId =
+        StorageResourceId.fromUriPath(src, /* allowEmptyObjectName= */ true);
+    StorageResourceId dstResourceId =
+        StorageResourceId.fromUriPath(
+            dst, /* allowEmptyObjectName= */ true, /* generationId= */ 0L);
+    if (this.options.getCloudStorageOptions().isMoveOperationEnabled()
+        && srcResourceId.getBucketName().equals(dstResourceId.getBucketName())) {
+
+      // First, move all items except marker items
+      moveInternal(srcToDstItemNames);
+      // Finally, move marker items (if any) to mark rename operation success
+      moveInternal(srcToDstMarkerItemNames);
+
+      if (srcInfo.getItemInfo().isBucket()) {
+        deleteBucket(Collections.singletonList(srcInfo));
+      } else {
+        // If src is a directory then srcItemInfos does not contain its own name,
+        // we delete item separately in the list.
+        deleteObjects(Collections.singletonList(srcInfo));
+      }
+      return;
+    }
+
     // First, copy all items except marker items
     copyInternal(srcToDstItemNames);
     // Finally, copy marker items (if any) to mark rename operation success
@@ -812,6 +847,27 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
 
     // Perform copy.
     gcs.copy(srcBucketName, srcObjectNames, dstBucketName, dstObjectNames);
+  }
+
+  /** Moves items in given map that maps source items to destination items. */
+  private void moveInternal(Map<FileInfo, URI> srcToDstItemNames) throws IOException {
+    if (srcToDstItemNames.isEmpty()) {
+      return;
+    }
+
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>();
+
+    // Prepare list of items to move.
+    for (Map.Entry<FileInfo, URI> srcToDstItemName : srcToDstItemNames.entrySet()) {
+      StorageResourceId srcResourceId = srcToDstItemName.getKey().getItemInfo().getResourceId();
+
+      StorageResourceId dstResourceId =
+          StorageResourceId.fromUriPath(srcToDstItemName.getValue(), true);
+      sourceToDestinationObjectsMap.put(srcResourceId, dstResourceId);
+    }
+
+    // Perform move.
+    gcs.move(sourceToDestinationObjectsMap);
   }
 
   /**

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -990,6 +990,45 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     }
   }
 
+  /**
+   * Validates basic argument constraints like non-null, non-empty Strings, using {@code
+   * Preconditions} in addition to checking for src/dst bucket equality.
+   */
+  @VisibleForTesting
+  public static void validateMoveArguments(
+      Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap) throws IOException {
+    checkNotNull(sourceToDestinationObjectsMap, "srcObjects must not be null");
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+        sourceToDestinationObjectsMap.entrySet()) {
+      StorageResourceId source = entry.getKey();
+      StorageResourceId destination = entry.getValue();
+      String srcBucketName = source.getBucketName();
+      String dstBucketName = destination.getBucketName();
+      // Avoid move across buckets.
+      if (!srcBucketName.equals(dstBucketName)) {
+        throw new UnsupportedOperationException(
+            "This operation is not supported across two different buckets.");
+      }
+      checkArgument(
+          !isNullOrEmpty(source.getObjectName()), "srcObjectName must not be null or empty");
+      checkArgument(
+          !isNullOrEmpty(destination.getObjectName()), "dstObjectName must not be null or empty");
+      if (srcBucketName.equals(dstBucketName)
+          && source.getObjectName().equals(destination.getObjectName())) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw new IllegalArgumentException(
+            String.format(
+                "Move destination must be different from source for %s.",
+                StringPaths.fromComponents(srcBucketName, source.getObjectName())));
+      }
+    }
+  }
+
   private static GoogleCloudStorageItemInfo getGoogleCloudStorageItemInfo(
       GoogleCloudStorage gcsImpl,
       Map<StorageResourceId, GoogleCloudStorageItemInfo> bucketInfoCache,
@@ -1087,6 +1126,62 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
               dstObject.getBucketName(),
               dstObject.getObjectName());
         }
+      }
+
+      // Execute any remaining requests not divisible by the max batch size.
+      batchHelper.flush();
+
+      if (!innerExceptions.isEmpty()) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+      }
+    }
+  }
+
+  /**
+   * See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)} for details
+   * about expected behavior.
+   */
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+
+    validateMoveArguments(sourceToDestinationObjectsMap);
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    // Gather FileNotFoundExceptions for individual objects,
+    // but only throw a single combined exception at the end.
+    ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions =
+        ConcurrentHashMap.newKeySet();
+
+    String traceContext = String.format("batchmove(size=%s)", sourceToDestinationObjectsMap.size());
+    try (ITraceOperation to = TraceOperation.addToExistingTrace(traceContext)) {
+      // Perform the move operations.
+
+      BatchHelper batchHelper =
+          batchFactory.newBatchHelper(
+              httpRequestInitializer,
+              storage,
+              storageOptions.getMaxRequestsPerBatch(),
+              sourceToDestinationObjectsMap.size(),
+              storageOptions.getBatchThreads(),
+              "batchmove");
+
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcObject = entry.getKey();
+        StorageResourceId dstObject = entry.getValue();
+        moveInternal(
+            batchHelper,
+            innerExceptions,
+            srcObject.getBucketName(),
+            srcObject.getGenerationId(),
+            srcObject.getObjectName(),
+            dstObject.getGenerationId(),
+            dstObject.getObjectName());
       }
 
       // Execute any remaining requests not divisible by the max batch size.
@@ -1206,6 +1301,72 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
                 innerExceptions, jsonError, responseHeaders, srcBucketName, srcObjectName);
           }
         });
+  }
+
+  /**
+   * Performs move operation using GCS MoveObject requests
+   *
+   * <p>See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)}
+   */
+  private void moveInternal(
+      BatchHelper batchHelper,
+      ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions,
+      String bucketName,
+      long srcContentGeneration,
+      String srcObjectName,
+      long dstContentGeneration,
+      String dstObjectName)
+      throws IOException {
+    Storage.Objects.Move moveObject =
+        createMoveObjectRequest(
+            bucketName, srcObjectName, dstObjectName, srcContentGeneration, dstContentGeneration);
+
+    batchHelper.queue(
+        moveObject,
+        new JsonBatchCallback<>() {
+          @Override
+          public void onSuccess(StorageObject moveResponse, HttpHeaders responseHeaders) {
+            String srcString = StringPaths.fromComponents(bucketName, srcObjectName);
+            String dstString = StringPaths.fromComponents(bucketName, dstObjectName);
+            logger.atFiner().log("Successfully moved %s to %s", srcString, dstString);
+          }
+
+          @Override
+          public void onFailure(GoogleJsonError jsonError, HttpHeaders responseHeaders) {
+            GoogleCloudStorageEventBus.postOnException();
+            GoogleJsonResponseException cause =
+                createJsonResponseException(jsonError, responseHeaders);
+            innerExceptions.add(
+                errorExtractor.itemNotFound(cause)
+                    ? createFileNotFoundException(bucketName, srcObjectName, cause)
+                    : new IOException(
+                        String.format(
+                            "Error moving '%s' to '%s'",
+                            StringPaths.fromComponents(bucketName, srcObjectName),
+                            StringPaths.fromComponents(bucketName, dstObjectName)),
+                        cause));
+          }
+        });
+  }
+
+  /** Creates a {@link Storage.Objects.Move} request, configured with generation matches. */
+  private Storage.Objects.Move createMoveObjectRequest(
+      String bucketName,
+      String srcObjectName,
+      String dstObjectName,
+      long srcContentGeneration,
+      long dstContentGeneration)
+      throws IOException {
+    Storage.Objects.Move move = storage.objects().move(bucketName, srcObjectName, dstObjectName);
+
+    if (srcContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      move.setIfSourceGenerationMatch(srcContentGeneration);
+    }
+
+    if (dstContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      move.setIfGenerationMatch(dstContentGeneration);
+    }
+    return initializeRequest(move, bucketName);
   }
 
   /** Processes failed copy requests */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -66,7 +66,8 @@ public abstract class GoogleCloudStorageOptions {
         .setTrafficDirectorEnabled(true)
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setHnBucketRenameEnabled(false)
-        .setGrpcWriteEnabled(false);
+        .setGrpcWriteEnabled(false)
+        .setMoveOperationEnabled(false);
   }
 
   public abstract Builder toBuilder();
@@ -144,6 +145,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract boolean isTraceLogEnabled();
 
   public abstract boolean isOperationTraceLogEnabled();
+
+  public abstract boolean isMoveOperationEnabled();
 
   public RetryHttpInitializerOptions toRetryHttpInitializerOptions() {
     return RetryHttpInitializerOptions.builder()
@@ -231,6 +234,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setOperationTraceLogEnabled(Boolean enable);
 
     public abstract Builder setGrpcWriteEnabled(boolean grpcWriteEnabled);
+
+    public abstract Builder setMoveOperationEnabled(boolean moveOperationEnabled);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -23,6 +23,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class adds a caching layer around a GoogleCloudStorage instance, caching calls that create,
@@ -93,6 +94,23 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
     // Remove the deleted objects from cache.
     for (StorageResourceId resourceId : resourceIds) {
       cache.removeItem(resourceId);
+    }
+  }
+
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    super.move(sourceToDestinationObjectsMap);
+
+    // On success, invalidate cache entries
+    if (cache != null) {
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcResourceId = entry.getKey();
+
+        // Invalidate the source item.
+        cache.removeItem(srcResourceId);
+      }
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -348,8 +348,10 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       if (!validateObjectName(srcObject.getObjectName())
           || !validateObjectName(dstObject.getObjectName())) {
         innerExceptions.add(
-            createFileNotFoundException(
-                srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
+            new IOException(
+                String.format(
+                    "Invalid object name for move source '%s' or destination '%s'",
+                    srcObject, dstObject)));
         continue;
       }
 
@@ -358,7 +360,8 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
         if (!srcInfo.exists()) {
           // If the source is not found, add an error to the list and continue.
           innerExceptions.add(
-              new IOException(String.format("Source object '%s' not found.", srcObject)));
+              createFileNotFoundException(
+                  srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
           continue;
         }
 
@@ -378,7 +381,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
     }
 
     if (!innerExceptions.isEmpty()) {
-      GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+      throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
     }
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
@@ -25,7 +25,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -217,6 +219,17 @@ public class ForwardingGoogleCloudStorageTest {
 
     verify(mockGcsDelegate)
         .copy(eq(TEST_STRING), eq(TEST_STRINGS), eq(TEST_STRING), eq(TEST_STRINGS));
+  }
+
+  @Test
+  public void testMove() throws IOException {
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>();
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(TEST_STRING, TEST_STRING),
+        new StorageResourceId(TEST_STRING, TEST_STRING));
+    gcs.move(sourceToDestinationObjectsMap);
+
+    verify(mockGcsDelegate).move(eq(sourceToDestinationObjectsMap));
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorageTest.java
@@ -35,6 +35,7 @@ import com.google.common.hash.Hashing;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,6 +66,7 @@ public class PerformanceCachingGoogleCloudStorageTest {
   // Sample bucket names.
   private static final String BUCKET_A = "alpha";
   private static final String BUCKET_B = "alph";
+  private static final String BUCKET_C = "charlie";
 
   // Sample object names.
   private static final String PREFIX_A = "bar";
@@ -75,6 +77,9 @@ public class PerformanceCachingGoogleCloudStorageTest {
   /* Sample bucket item info. */
   private static final GoogleCloudStorageItemInfo ITEM_A = createBucketItemInfo(BUCKET_A);
   private static final GoogleCloudStorageItemInfo ITEM_B = createBucketItemInfo(BUCKET_B);
+
+  private static final GoogleCloudStorageItemInfo ITEM_C_A_DEST =
+      createObjectItemInfo(BUCKET_C, PREFIX_A);
 
   /* Sample item info. */
   private static final GoogleCloudStorageItemInfo ITEM_A_A =
@@ -115,6 +120,7 @@ public class PerformanceCachingGoogleCloudStorageTest {
     // Prepare the delegate.
     gcsDelegate.createBucket(BUCKET_A, CREATE_BUCKET_OPTIONS);
     gcsDelegate.createBucket(BUCKET_B, CREATE_BUCKET_OPTIONS);
+
     gcsDelegate.createEmptyObject(ITEM_A_A.getResourceId(), CREATE_OBJECT_OPTIONS);
     gcsDelegate.createEmptyObject(ITEM_A_AA.getResourceId(), CREATE_OBJECT_OPTIONS);
     gcsDelegate.createEmptyObject(ITEM_A_ABA.getResourceId(), CREATE_OBJECT_OPTIONS);
@@ -155,6 +161,31 @@ public class PerformanceCachingGoogleCloudStorageTest {
     verify(gcsDelegate).deleteObjects(eq(ids));
     // Verify the state of the cache.
     assertThat(cache.getAllItemsRaw()).containsExactly(ITEM_B_B);
+  }
+
+  @Test
+  public void testMove_invalidatesSourceAndNotDestinationInCache_simple() throws IOException {
+    gcsDelegate.createBucket(BUCKET_C, CREATE_BUCKET_OPTIONS);
+
+    StorageResourceId sourceId = ITEM_A_A.getResourceId();
+    StorageResourceId destinationId = ITEM_C_A_DEST.getResourceId();
+
+    Map<StorageResourceId, StorageResourceId> moveMap = ImmutableMap.of(sourceId, destinationId);
+
+    // Prepare the cache.
+    cache.putItem(ITEM_A_A);
+    assertThat(cache.getItem(sourceId)).isEqualTo(ITEM_A_A);
+    assertThat(cache.getItem(destinationId)).isNull();
+
+    // Call the move operation on the caching GCS instance
+    gcs.move(moveMap);
+
+    // Verify the delegate's move method was called
+    verify(gcsDelegate).move(eq(moveMap));
+    // Verify the source item is removed from the cache
+    assertThat(cache.getItem(sourceId)).isNull();
+    // Verify the destination item was NOT added to the cache by the move operation itself
+    assertThat(cache.getItem(destinationId)).isNull();
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
@@ -56,6 +56,9 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
   private static final String POST_COPY_REQUEST_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/b/%s/o/%s";
 
+  private static final String POST_MOVE_REQUEST_FORMAT =
+      "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/o/%s";
+
   private static final String POST_COPY_REQUEST_WITH_METADATA_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/b/%s/o/%s?ifGenerationMatch=%s";
 
@@ -325,6 +328,12 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
             urlEncode(dstObject),
             replaceGenerationId ? "generationId_" + generationId : generationId);
     return generationId == null ? request.replaceAll("ifGenerationMatch=[^&]+&", "") : request;
+  }
+
+  public static String moveRequestString(
+      String bucket, String srcObject, String dstObject, String requestType) {
+    return String.format(
+        POST_MOVE_REQUEST_FORMAT, bucket, urlEncode(srcObject), requestType, urlEncode(dstObject));
   }
 
   public static String uploadRequestString(String bucketName, String object, Integer generationId) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -28,6 +28,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertThrows;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.auth.Credentials;
 import com.google.cloud.hadoop.gcsio.AssertingLogHandler;
 import com.google.cloud.hadoop.gcsio.CreateBucketOptions;
@@ -45,6 +46,7 @@ import com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TrackingStorageWrapper;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -199,6 +201,152 @@ public class GoogleCloudStorageImplTest {
         .inOrder();
 
     assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings().size()).isEqualTo(0);
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_successful() throws IOException {
+    int expectedSize = 5 * 1024 * 1024;
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_dst.txt");
+
+    // Create source object
+    writeObject(helperGcs, srcResourceId, expectedSize, 1);
+    GoogleCloudStorageItemInfo srcInfoBeforeMove = helperGcs.getItemInfo(srcResourceId);
+    assertThat(srcInfoBeforeMove.exists()).isTrue();
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    // Perform move
+    trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId));
+
+    // Assertions
+    GoogleCloudStorageItemInfo srcInfoAfterMove = helperGcs.getItemInfo(srcResourceId);
+    GoogleCloudStorageItemInfo dstInfoAfterMove = helperGcs.getItemInfo(dstResourceId);
+
+    assertThat(srcInfoAfterMove.exists()).isFalse();
+    assertThat(dstInfoAfterMove.exists()).isTrue();
+    assertThat(dstInfoAfterMove.getSize()).isEqualTo(expectedSize);
+
+    // Assert requests
+    assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
+        .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
+
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isNotEmpty();
+    } else {
+      assertThat(trackingGcs.getAllRequestStrings())
+          .containsExactly(
+              TrackingHttpRequestInitializer.moveRequestString(
+                  testBucket,
+                  srcResourceId.getObjectName(),
+                  dstResourceId.getObjectName(),
+                  "moveTo"))
+          .inOrder();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_sourceAndDestinationSame_throwsError() throws IOException {
+    StorageResourceId resourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_samesrcdst.txt");
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(resourceId, resourceId)));
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains(
+            String.format("Move destination must be different from source for %s", resourceId));
+
+    assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_differentBuckets_throwsError() throws IOException {
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src_diffbuckets.txt");
+    // Create a unique name for the other bucket to avoid conflicts if it were created.
+    String otherBucketName = bucketHelper.getUniqueBucketName("gcsio-other-move-bucket");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(otherBucketName, name.getMethodName() + "_dst_diffbuckets.txt");
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    UnsupportedOperationException thrown =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId)));
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("This operation is not supported across two different buckets.");
+
+    assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_sourceNotFound_throwsError() throws IOException {
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src_notfound.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_dst_for_notfound.txt");
+
+    // Source object is not created.
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId)));
+
+    assertThat(thrown).isInstanceOf(java.io.FileNotFoundException.class);
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Item not found: '" + srcResourceId.toString() + "'");
+
+    if (testStorageClientImpl) {
+      Throwable cause = thrown.getCause().getCause();
+      assertThat(cause).isInstanceOf(StorageException.class);
+
+      List<String> grpcRequests = trackingGcs.grpcRequestInterceptor.getAllRequestStrings();
+      assertThat(grpcRequests).isNotEmpty();
+      assertThat(grpcRequests.toString()).contains("MoveObject");
+
+      assertThat(((StorageException) cause).getCode()).isEqualTo(404);
+    } else {
+      Throwable cause = thrown.getCause();
+      assertThat(cause).isInstanceOf(GoogleJsonResponseException.class);
+      GoogleJsonResponseException gjre = (GoogleJsonResponseException) cause;
+      assertThat(gjre.getStatusCode()).isEqualTo(404);
+
+      assertThat(trackingGcs.getAllRequestStrings())
+          .containsExactly(
+              TrackingHttpRequestInitializer.moveRequestString(
+                  testBucket,
+                  srcResourceId.getObjectName(),
+                  dstResourceId.getObjectName(),
+                  "moveTo"));
+    }
     trackingGcs.delegate.close();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <google.api-client.version>2.1.1</google.api-client.version>
     <google.api-client-libraries.version>2.0.0</google.api-client-libraries.version>
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
-    <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
+    <google.api-storage.version>v1-rev20250312-${google.api-client-libraries.version}</google.api-storage.version>
     <google.api.grpc.proto-google-iam-v1.version>1.6.23</google.api.grpc.proto-google-iam-v1.version>
     <google.auth.version>1.33.1</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,10 @@
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
     <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
     <google.api.grpc.proto-google-iam-v1.version>1.6.23</google.api.grpc.proto-google-iam-v1.version>
-    <google.auth.version>1.29.0</google.auth.version>
+    <google.auth.version>1.33.1</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-core.verion>2.44.1</google.cloud-core.verion>
-    <google.cloud-storage.bom.version>2.44.1</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.49.0</google.cloud-storage.bom.version>
     <google.error-prone.version>2.16</google.error-prone.version>
     <google.flogger.version>0.7.4</google.flogger.version>
     <google.gax.version>2.54.1</google.gax.version>


### PR DESCRIPTION
Changes 
- Cherry picket the commit for main [move implementation](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1322) and [follow-up](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1342) changes.
- Removed the files `gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientTest.java` and  `gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockStorage.java` while cherry-picking as they not present in `branch-3.0.x`
- Added a non-null `FutureCallback` function in move implementation of GoogleCloudStorageClientImpl. 
It was required because in [master](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/95f39f573c8edf1ac51c8f716c207e0b246e50cf/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchExecutor.java#L90) there is no check for `FutureCallback` being null , while for `branch-3.0.x`, we have a [check](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/b8787748cfd85abd06630e615970cae31284a8f7/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/BatchExecutor.java#L91) for non null callback function in the `BatchExecutor`
- Updated `getInvocation` method in `GoogleCloudStorageClientGrpcTracingInterceptor` to not return null if the idempotency token is `null`. 

Testing
- Ran unit and integration tests locally
- Verified using hadoop move commands(for file and directory) locally for JSON and gRPC

Note : In branch-3.0.x, gRPC implementation of GoogleCloudStorage is primary used for read and create operations, other operation like copy,delete, getFileInfoetc is not implemented. 
