### PR TITLE
Backport move api changes to branch-2.2.x

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -563,6 +563,12 @@ public class GoogleHadoopFileSystemConfiguration {
           "fs.gs.write.parallel.composite.upload.part.file.name.prefix",
           AsyncWriteChannelOptions.DEFAULT.getPartFileNamePrefix());
 
+  /** Configuration key for enabling move operation in gcs instead of copy+delete. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_OPERATION_MOVE_ENABLE =
+      new HadoopConfigurationProperty<>(
+          "fs.gs.operation.move.enable",
+          GoogleCloudStorageOptions.DEFAULT.isMoveOperationEnabled());
+
   // TODO(b/120887495): This @VisibleForTesting annotation was being ignored by prod code.
   // Please check that removing it is correct, and remove this comment along with it.
   // @VisibleForTesting
@@ -636,7 +642,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setOperationTraceLogEnabled(GCS_OPERATION_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setTraceLogTimeThreshold(GCS_TRACE_LOG_TIME_THRESHOLD_MS.get(config, config::getLong))
         .setTraceLogExcludeProperties(
-            ImmutableSet.copyOf(GCS_TRACE_LOG_EXCLUDE_PROPERTIES.getStringCollection(config)));
+            ImmutableSet.copyOf(GCS_TRACE_LOG_EXCLUDE_PROPERTIES.getStringCollection(config)))
+        .setMoveOperationEnabled(GCS_OPERATION_MOVE_ENABLE.get(config, config::getBoolean));
   }
 
   private static PerformanceCachingGoogleCloudStorageOptions getPerformanceCachingOptions(

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -154,6 +154,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
           put("fs.gs.fadvise.request.track.count", 3);
+          put("fs.gs.operation.move.enable", false);
         }
       };
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -188,7 +188,6 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     }
   }
 
-  @Ignore
   @Test
   public void testRenameWithMoveOperation() throws Exception {
     String bucketName = this.gcsiHelper.getUniqueBucketName("move");

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -188,6 +188,43 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     }
   }
 
+  @Ignore
+  @Test
+  public void testRenameWithMoveOperation() throws Exception {
+    String bucketName = this.gcsiHelper.getUniqueBucketName("move");
+    GoogleHadoopFileSystem googleHadoopFileSystem = new GoogleHadoopFileSystem();
+
+    URI initUri = new URI("gs://" + bucketName);
+    Configuration config = loadConfig();
+    config.setBoolean("fs.gs.operation.move.enable", true);
+    googleHadoopFileSystem.initialize(initUri, config);
+
+    GoogleCloudStorage theGcs = googleHadoopFileSystem.getGcsFs().getGcs();
+    theGcs.createBucket(bucketName);
+
+    try {
+      GoogleCloudStorageFileSystemIntegrationHelper helper =
+          new HadoopFileSystemIntegrationHelper(googleHadoopFileSystem);
+
+      renameHelper(
+          new HdfsBehavior() {
+            /**
+             * Returns the MethodOutcome of trying to rename an existing file into the root
+             * directory.
+             */
+            @Override
+            public MethodOutcome renameFileIntoRootOutcome() {
+              return new MethodOutcome(MethodOutcome.Type.RETURNS_TRUE);
+            }
+          },
+          bucketName,
+          bucketName,
+          helper);
+    } finally {
+      googleHadoopFileSystem.delete(new Path(initUri));
+    }
+  }
+
   @Test
   public void testInitializePath_success() throws Exception {
     List<String> validPaths = Arrays.asList("gs://foo", "gs://foo/bar");

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -203,7 +203,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     try {
       GoogleCloudStorageFileSystemIntegrationHelper helper =
-          new HadoopFileSystemIntegrationHelper(googleHadoopFileSystem);
+          new HadoopFileSystemIntegrationHelper(googleHadoopFileSystem, googleHadoopFileSystem);
 
       renameHelper(
           new HdfsBehavior() {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
@@ -61,4 +61,8 @@ public class GoogleHadoopFileSystemJavaStorageClientIntegrationTest
   @Ignore
   @Test
   public void unauthenticatedAccessToPublicBuckets_googleCloudProperties() {}
+
+  @Ignore
+  @Test
+  public void testRenameWithMoveOperation() {}
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -394,6 +394,9 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   public void testRenameHnBucket() {}
 
   @Override
+  public void testRenameWithMoveOperation() {}
+
+  @Override
   public void testHnBucketRecursiveDeleteOperationOnDirectory() {}
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -136,6 +136,13 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    logger.atFiner().log("%s.move(%s)", delegateClassName, sourceToDestinationObjectsMap);
+    delegate.move(sourceToDestinationObjectsMap);
+  }
+
+  @Override
   public boolean isHnBucket(URI src) throws IOException {
     return delegate.isHnBucket(src);
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -258,6 +258,17 @@ public interface GoogleCloudStorage {
   }
 
   /**
+   * Moves objects within the same bucket. Moving objects between different buckets is not allowed.
+   *
+   * @param sourceToDestinationObjectsMap map of destination objects to be moved, keyed by source
+   * @throws java.io.FileNotFoundException if the source object or the destination bucket does not
+   *     exist
+   * @throws IOException in all other error cases
+   */
+  void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException;
+
+  /**
    * Checks if {@code resourceId} belongs to a Hierarchical namespace enabled bucket. This takes a
    * path and not the bucket name since the caller may not have permission to query the bucket.
    *

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
@@ -43,6 +43,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInterceptor {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   public static final String IDEMPOTENCY_TOKEN_HEADER = "x-goog-gcs-idempotency-token";
+
+  private static final String DEFAULT_IDEMPOTENCY_TOKEN_VALUE = "IDEMPOTENCY_TOKEN_NOT_FOUND";
   private static final DateTimeFormatter dtf =
       DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss.SSS");
   private static final Metadata.Key<String> idempotencyKey =
@@ -215,7 +217,14 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
     }
 
     private String getInvocationId() {
-      return headers.get(idempotencyKey);
+      if (this.headers == null) {
+        return DEFAULT_IDEMPOTENCY_TOKEN_VALUE;
+      }
+      String token = this.headers.get(idempotencyKey);
+      if (token == null) {
+        return DEFAULT_IDEMPOTENCY_TOKEN_VALUE;
+      }
+      return token;
     }
 
     private ImmutableMap.Builder<String, Object> getStreamContext() {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -112,7 +112,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
     this.storage =
         clientLibraryStorage == null
             ? createStorage(
-            credentials, options, gRPCInterceptors, pCUExecutorService, downscopedAccessTokenFn)
+                credentials, options, gRPCInterceptors, pCUExecutorService, downscopedAccessTokenFn)
             : clientLibraryStorage;
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.hadoop.gcsio;
 
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
+import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.validateMoveArguments;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -38,6 +40,13 @@ import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.Ex
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartNamingStrategy;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.MoveBlobRequest;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.hadoop.util.ErrorTypeExtractor.ErrorType;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -56,6 +65,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentHashMap.KeySetView;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -138,6 +150,132 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
 
     return new GoogleCloudStorageClientWriteChannel(
         storage, storageOptions, resourceIdWithGeneration, options);
+  }
+
+  /**
+   * See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)} for details
+   * about expected behavior.
+   */
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+
+    validateMoveArguments(sourceToDestinationObjectsMap);
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    // Gather FileNotFoundExceptions for individual objects,
+    // but only throw a single combined exception at the end.
+    ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions =
+        ConcurrentHashMap.newKeySet();
+
+    BatchExecutor executor = new BatchExecutor(storageOptions.getBatchThreads());
+
+    try {
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcObject = entry.getKey();
+        StorageResourceId dstObject = entry.getValue();
+        moveInternal(
+            executor,
+            innerExceptions,
+            srcObject.getBucketName(),
+            srcObject.getGenerationId(),
+            srcObject.getObjectName(),
+            dstObject.getGenerationId(),
+            dstObject.getObjectName());
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    if (!innerExceptions.isEmpty()) {
+      GoogleCloudStorageEventBus.postOnException();
+      throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+    }
+  }
+
+  private void moveInternal(
+      BatchExecutor executor,
+      KeySetView<IOException, Boolean> innerExceptions,
+      String srcBucketName,
+      long srcContentGeneration,
+      String srcObjectName,
+      long dstContentGeneration,
+      String dstObjectName) {
+    MoveBlobRequest.Builder moveRequestBuilder =
+        createMoveRequestBuilder(
+            srcBucketName,
+            srcObjectName,
+            dstObjectName,
+            srcContentGeneration,
+            dstContentGeneration);
+
+    executor.queue(
+        () -> {
+          try {
+            String srcString = StringPaths.fromComponents(srcBucketName, srcObjectName);
+            String dstString = StringPaths.fromComponents(srcBucketName, dstObjectName);
+
+            Blob movedBlob = storage.moveBlob(moveRequestBuilder.build());
+            if (movedBlob != null) {
+              logger.atFiner().log("Successfully moved %s to %s", srcString, dstString);
+            }
+          } catch (StorageException e) {
+            GoogleCloudStorageEventBus.postOnException();
+            if (errorExtractor.getErrorType(e) == ErrorType.NOT_FOUND) {
+              innerExceptions.add(
+                  createFileNotFoundException(srcBucketName, srcObjectName, new IOException(e)));
+            } else {
+              innerExceptions.add(
+                  new IOException(
+                      String.format(
+                          "Error moving '%s'",
+                          StringPaths.fromComponents(srcBucketName, srcObjectName)),
+                      e));
+            }
+          }
+          return null;
+        },
+        null);
+  }
+
+  /** Creates a builder for a blob move request. */
+  private MoveBlobRequest.Builder createMoveRequestBuilder(
+      String srcBucketName,
+      String srcObjectName,
+      String dstObjectName,
+      long srcContentGeneration,
+      long dstContentGeneration) {
+
+    MoveBlobRequest.Builder moveRequestBuilder =
+        MoveBlobRequest.newBuilder().setSource(BlobId.of(srcBucketName, srcObjectName));
+    moveRequestBuilder.setTarget(BlobId.of(srcBucketName, dstObjectName));
+
+    List<BlobTargetOption> blobTargetOptions = new ArrayList<>();
+    List<BlobSourceOption> blobSourceOptions = new ArrayList<>();
+
+    if (srcContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      blobSourceOptions.add(BlobSourceOption.generationMatch(srcContentGeneration));
+    }
+
+    if (dstContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      blobTargetOptions.add(BlobTargetOption.generationMatch(dstContentGeneration));
+    }
+
+    if (storageOptions.getEncryptionKey() != null) {
+      blobSourceOptions.add(
+          BlobSourceOption.decryptionKey(storageOptions.getEncryptionKey().value()));
+      blobTargetOptions.add(
+          BlobTargetOption.encryptionKey(storageOptions.getEncryptionKey().value()));
+    }
+
+    moveRequestBuilder.setSourceOptions(blobSourceOptions);
+    moveRequestBuilder.setTargetOptions(blobTargetOptions);
+
+    return moveRequestBuilder;
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.hadoop.gcsio;
 
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createFileNotFoundException;
-import static com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl.validateMoveArguments;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -40,13 +38,6 @@ import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.Ex
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartNamingStrategy;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.Storage.BlobSourceOption;
-import com.google.cloud.storage.Storage.BlobTargetOption;
-import com.google.cloud.storage.Storage.MoveBlobRequest;
-import com.google.cloud.storage.StorageException;
-import com.google.cloud.hadoop.util.ErrorTypeExtractor.ErrorType;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -65,9 +56,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentHashMap.KeySetView;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -124,7 +112,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
     this.storage =
         clientLibraryStorage == null
             ? createStorage(
-                credentials, options, gRPCInterceptors, pCUExecutorService, downscopedAccessTokenFn)
+            credentials, options, gRPCInterceptors, pCUExecutorService, downscopedAccessTokenFn)
             : clientLibraryStorage;
   }
 
@@ -150,132 +138,6 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
 
     return new GoogleCloudStorageClientWriteChannel(
         storage, storageOptions, resourceIdWithGeneration, options);
-  }
-
-  /**
-   * See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)} for details
-   * about expected behavior.
-   */
-  @Override
-  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
-      throws IOException {
-
-    validateMoveArguments(sourceToDestinationObjectsMap);
-
-    if (sourceToDestinationObjectsMap.isEmpty()) {
-      return;
-    }
-
-    // Gather FileNotFoundExceptions for individual objects,
-    // but only throw a single combined exception at the end.
-    ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions =
-        ConcurrentHashMap.newKeySet();
-
-    BatchExecutor executor = new BatchExecutor(storageOptions.getBatchThreads());
-
-    try {
-      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
-          sourceToDestinationObjectsMap.entrySet()) {
-        StorageResourceId srcObject = entry.getKey();
-        StorageResourceId dstObject = entry.getValue();
-        moveInternal(
-            executor,
-            innerExceptions,
-            srcObject.getBucketName(),
-            srcObject.getGenerationId(),
-            srcObject.getObjectName(),
-            dstObject.getGenerationId(),
-            dstObject.getObjectName());
-      }
-    } finally {
-      executor.shutdown();
-    }
-
-    if (!innerExceptions.isEmpty()) {
-      GoogleCloudStorageEventBus.postOnException();
-      throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
-    }
-  }
-
-  private void moveInternal(
-      BatchExecutor executor,
-      KeySetView<IOException, Boolean> innerExceptions,
-      String srcBucketName,
-      long srcContentGeneration,
-      String srcObjectName,
-      long dstContentGeneration,
-      String dstObjectName) {
-    MoveBlobRequest.Builder moveRequestBuilder =
-        createMoveRequestBuilder(
-            srcBucketName,
-            srcObjectName,
-            dstObjectName,
-            srcContentGeneration,
-            dstContentGeneration);
-
-    executor.queue(
-        () -> {
-          try {
-            String srcString = StringPaths.fromComponents(srcBucketName, srcObjectName);
-            String dstString = StringPaths.fromComponents(srcBucketName, dstObjectName);
-
-            Blob movedBlob = storage.moveBlob(moveRequestBuilder.build());
-            if (movedBlob != null) {
-              logger.atFiner().log("Successfully moved %s to %s", srcString, dstString);
-            }
-          } catch (StorageException e) {
-            GoogleCloudStorageEventBus.postOnException();
-            if (errorExtractor.getErrorType(e) == ErrorType.NOT_FOUND) {
-              innerExceptions.add(
-                  createFileNotFoundException(srcBucketName, srcObjectName, new IOException(e)));
-            } else {
-              innerExceptions.add(
-                  new IOException(
-                      String.format(
-                          "Error moving '%s'",
-                          StringPaths.fromComponents(srcBucketName, srcObjectName)),
-                      e));
-            }
-          }
-          return null;
-        },
-        null);
-  }
-
-  /** Creates a builder for a blob move request. */
-  private MoveBlobRequest.Builder createMoveRequestBuilder(
-      String srcBucketName,
-      String srcObjectName,
-      String dstObjectName,
-      long srcContentGeneration,
-      long dstContentGeneration) {
-
-    MoveBlobRequest.Builder moveRequestBuilder =
-        MoveBlobRequest.newBuilder().setSource(BlobId.of(srcBucketName, srcObjectName));
-    moveRequestBuilder.setTarget(BlobId.of(srcBucketName, dstObjectName));
-
-    List<BlobTargetOption> blobTargetOptions = new ArrayList<>();
-    List<BlobSourceOption> blobSourceOptions = new ArrayList<>();
-
-    if (srcContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
-      blobSourceOptions.add(BlobSourceOption.generationMatch(srcContentGeneration));
-    }
-
-    if (dstContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
-      blobTargetOptions.add(BlobTargetOption.generationMatch(dstContentGeneration));
-    }
-
-    if (storageOptions.getEncryptionKey() != null) {
-      blobSourceOptions.add(
-          BlobSourceOption.decryptionKey(storageOptions.getEncryptionKey().value()));
-      blobTargetOptions.add(
-          BlobTargetOption.encryptionKey(storageOptions.getEncryptionKey().value()));
-    }
-
-    moveRequestBuilder.setSourceOptions(blobSourceOptions);
-    moveRequestBuilder.setTargetOptions(blobTargetOptions);
-
-    return moveRequestBuilder;
   }
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1484,7 +1484,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
 
     batchHelper.queue(
         moveObject,
-        new JsonBatchCallback<>() {
+        new JsonBatchCallback<StorageObject>() {
           @Override
           public void onSuccess(StorageObject moveResponse, HttpHeaders responseHeaders) {
             String srcString = StringPaths.fromComponents(bucketName, srcObjectName);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1154,6 +1154,45 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
     }
   }
 
+  /**
+   * Validates basic argument constraints like non-null, non-empty Strings, using {@code
+   * Preconditions} in addition to checking for src/dst bucket equality.
+   */
+  @VisibleForTesting
+  public static void validateMoveArguments(
+      Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap) throws IOException {
+    checkNotNull(sourceToDestinationObjectsMap, "srcObjects must not be null");
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+        sourceToDestinationObjectsMap.entrySet()) {
+      StorageResourceId source = entry.getKey();
+      StorageResourceId destination = entry.getValue();
+      String srcBucketName = source.getBucketName();
+      String dstBucketName = destination.getBucketName();
+      // Avoid move across buckets.
+      if (!srcBucketName.equals(dstBucketName)) {
+        throw new UnsupportedOperationException(
+            "This operation is not supported across two different buckets.");
+      }
+      checkArgument(
+          !isNullOrEmpty(source.getObjectName()), "srcObjectName must not be null or empty");
+      checkArgument(
+          !isNullOrEmpty(destination.getObjectName()), "dstObjectName must not be null or empty");
+      if (srcBucketName.equals(dstBucketName)
+          && source.getObjectName().equals(destination.getObjectName())) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw new IllegalArgumentException(
+            String.format(
+                "Move destination must be different from source for %s.",
+                StringPaths.fromComponents(srcBucketName, source.getObjectName())));
+      }
+    }
+  }
+
   private static GoogleCloudStorageItemInfo getGoogleCloudStorageItemInfo(
       GoogleCloudStorage gcsImpl,
       Map<StorageResourceId, GoogleCloudStorageItemInfo> bucketInfoCache,
@@ -1249,6 +1288,62 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
               dstObject.getBucketName(),
               dstObject.getObjectName());
         }
+      }
+
+      // Execute any remaining requests not divisible by the max batch size.
+      batchHelper.flush();
+
+      if (!innerExceptions.isEmpty()) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+      }
+    }
+  }
+
+  /**
+   * See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)} for details
+   * about expected behavior.
+   */
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+
+    validateMoveArguments(sourceToDestinationObjectsMap);
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    // Gather FileNotFoundExceptions for individual objects,
+    // but only throw a single combined exception at the end.
+    ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions =
+        ConcurrentHashMap.newKeySet();
+
+    String traceContext = String.format("batchmove(size=%s)", sourceToDestinationObjectsMap.size());
+    try (ITraceOperation to = TraceOperation.addToExistingTrace(traceContext)) {
+      // Perform the move operations.
+
+      BatchHelper batchHelper =
+          batchFactory.newBatchHelper(
+              httpRequestInitializer,
+              storage,
+              storageOptions.getMaxRequestsPerBatch(),
+              sourceToDestinationObjectsMap.size(),
+              storageOptions.getBatchThreads(),
+              "batchmove");
+
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcObject = entry.getKey();
+        StorageResourceId dstObject = entry.getValue();
+        moveInternal(
+            batchHelper,
+            innerExceptions,
+            srcObject.getBucketName(),
+            srcObject.getGenerationId(),
+            srcObject.getObjectName(),
+            dstObject.getGenerationId(),
+            dstObject.getObjectName());
       }
 
       // Execute any remaining requests not divisible by the max batch size.
@@ -1367,6 +1462,72 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
                 innerExceptions, jsonError, responseHeaders, srcBucketName, srcObjectName);
           }
         });
+  }
+
+  /**
+   * Performs move operation using GCS MoveObject requests
+   *
+   * <p>See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)}
+   */
+  private void moveInternal(
+      BatchHelper batchHelper,
+      ConcurrentHashMap.KeySetView<IOException, Boolean> innerExceptions,
+      String bucketName,
+      long srcContentGeneration,
+      String srcObjectName,
+      long dstContentGeneration,
+      String dstObjectName)
+      throws IOException {
+    Storage.Objects.Move moveObject =
+        createMoveObjectRequest(
+            bucketName, srcObjectName, dstObjectName, srcContentGeneration, dstContentGeneration);
+
+    batchHelper.queue(
+        moveObject,
+        new JsonBatchCallback<>() {
+          @Override
+          public void onSuccess(StorageObject moveResponse, HttpHeaders responseHeaders) {
+            String srcString = StringPaths.fromComponents(bucketName, srcObjectName);
+            String dstString = StringPaths.fromComponents(bucketName, dstObjectName);
+            logger.atFiner().log("Successfully moved %s to %s", srcString, dstString);
+          }
+
+          @Override
+          public void onFailure(GoogleJsonError jsonError, HttpHeaders responseHeaders) {
+            GoogleCloudStorageEventBus.postOnException();
+            GoogleJsonResponseException cause =
+                createJsonResponseException(jsonError, responseHeaders);
+            innerExceptions.add(
+                errorExtractor.itemNotFound(cause)
+                    ? createFileNotFoundException(bucketName, srcObjectName, cause)
+                    : new IOException(
+                        String.format(
+                            "Error moving '%s' to '%s'",
+                            StringPaths.fromComponents(bucketName, srcObjectName),
+                            StringPaths.fromComponents(bucketName, dstObjectName)),
+                        cause));
+          }
+        });
+  }
+
+  /** Creates a {@link Storage.Objects.Move} request, configured with generation matches. */
+  private Storage.Objects.Move createMoveObjectRequest(
+      String bucketName,
+      String srcObjectName,
+      String dstObjectName,
+      long srcContentGeneration,
+      long dstContentGeneration)
+      throws IOException {
+    Storage.Objects.Move move = storage.objects().move(bucketName, srcObjectName, dstObjectName);
+
+    if (srcContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      move.setIfSourceGenerationMatch(srcContentGeneration);
+    }
+
+    if (dstContentGeneration != StorageResourceId.UNKNOWN_GENERATION_ID) {
+      move.setIfGenerationMatch(dstContentGeneration);
+    }
+    return initializeRequest(move, bucketName);
   }
 
   /** Processes failed copy requests */

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -141,7 +141,8 @@ public abstract class GoogleCloudStorageOptions {
         .setTraceLogTimeThreshold(0)
         .setTraceLogExcludeProperties(ImmutableSet.of())
         .setHnBucketRenameEnabled(SET_HN_BUCKET_CREATE_ENABLED_DEFAULT)
-        .setGrpcWriteEnabled(GRPC_WRITE_DEFAULT);
+        .setGrpcWriteEnabled(GRPC_WRITE_DEFAULT)
+        .setMoveOperationEnabled(false);
   }
 
   public abstract Builder toBuilder();
@@ -227,6 +228,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract long getTraceLogTimeThreshold();
 
   public abstract ImmutableSet<String> getTraceLogExcludeProperties();
+
+  public abstract boolean isMoveOperationEnabled();
 
   public RetryHttpInitializerOptions toRetryHttpInitializerOptions() {
     return RetryHttpInitializerOptions.builder()
@@ -333,6 +336,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setTraceLogExcludeProperties(ImmutableSet<String> properties);
 
     public abstract Builder setGrpcWriteEnabled(boolean grpcWriteEnabled);
+
+    public abstract Builder setMoveOperationEnabled(boolean moveOperationEnabled);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/PerformanceCachingGoogleCloudStorage.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class adds a caching layer around a GoogleCloudStorage instance, caching calls that create,
@@ -91,6 +92,23 @@ public class PerformanceCachingGoogleCloudStorage extends ForwardingGoogleCloudS
     // Remove the deleted objects from cache.
     for (StorageResourceId resourceId : resourceIds) {
       cache.removeItem(resourceId);
+    }
+  }
+
+  @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    super.move(sourceToDestinationObjectsMap);
+
+    // On success, invalidate cache entries
+    if (cache != null) {
+      for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+          sourceToDestinationObjectsMap.entrySet()) {
+        StorageResourceId srcResourceId = entry.getKey();
+
+        // Invalidate the source item.
+        cache.removeItem(srcResourceId);
+      }
     }
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -318,6 +318,62 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
+  public synchronized void move(
+      Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap) throws IOException {
+    if (sourceToDestinationObjectsMap == null) {
+      throw new IllegalArgumentException("sourceToDestinationObjectsMap must not be null");
+    }
+
+    if (sourceToDestinationObjectsMap.isEmpty()) {
+      return;
+    }
+
+    // Gather exceptions
+    List<IOException> innerExceptions = new ArrayList<>();
+
+    for (Map.Entry<StorageResourceId, StorageResourceId> entry :
+        sourceToDestinationObjectsMap.entrySet()) {
+      StorageResourceId srcObject = entry.getKey();
+      StorageResourceId dstObject = entry.getValue();
+
+      if (!validateObjectName(srcObject.getObjectName())
+          || !validateObjectName(dstObject.getObjectName())) {
+        innerExceptions.add(
+            createFileNotFoundException(
+                srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
+        continue;
+      }
+
+      try {
+        GoogleCloudStorageItemInfo srcInfo = getItemInfo(srcObject);
+        if (!srcInfo.exists()) {
+          // If the source is not found, add an error to the list and continue.
+          innerExceptions.add(
+              new IOException(String.format("Source object '%s' not found.", srcObject)));
+          continue;
+        }
+
+        // Simulate copy part of the move.
+        InMemoryBucketEntry srcBucketEntry = bucketLookup.get(srcObject.getBucketName());
+        InMemoryObjectEntry srcEntry = srcBucketEntry.get(srcObject.getObjectName());
+
+        bucketLookup
+            .get(dstObject.getBucketName())
+            .add(srcEntry.getShallowCopy(dstObject.getBucketName(), dstObject.getObjectName()));
+
+        // simulate delete
+        srcBucketEntry.remove(srcObject.getObjectName());
+      } catch (IOException e) {
+        innerExceptions.add(e);
+      }
+    }
+
+    if (!innerExceptions.isEmpty()) {
+      GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+    }
+  }
+
+  @Override
   public synchronized void copy(
       String srcBucketName,
       List<String> srcObjectNames,

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -339,8 +339,10 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
       if (!validateObjectName(srcObject.getObjectName())
           || !validateObjectName(dstObject.getObjectName())) {
         innerExceptions.add(
-            createFileNotFoundException(
-                srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
+            new IOException(
+                String.format(
+                    "Invalid object name for move source '%s' or destination '%s'",
+                    srcObject, dstObject)));
         continue;
       }
 
@@ -349,7 +351,8 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
         if (!srcInfo.exists()) {
           // If the source is not found, add an error to the list and continue.
           innerExceptions.add(
-              new IOException(String.format("Source object '%s' not found.", srcObject)));
+              createFileNotFoundException(
+                  srcObject.getBucketName(), srcObject.getObjectName(), /* cause= */ null));
           continue;
         }
 
@@ -369,7 +372,7 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
     }
 
     if (!innerExceptions.isEmpty()) {
-      GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
+      throw GoogleCloudStorageExceptions.createCompositeException(innerExceptions);
     }
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -186,6 +188,17 @@ public class ForwardingGoogleCloudStorageTest {
 
     verify(mockGcsDelegate)
         .copy(eq(TEST_STRING), eq(TEST_STRINGS), eq(TEST_STRING), eq(TEST_STRINGS));
+  }
+
+  @Test
+  public void testMove() throws IOException {
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>();
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(TEST_STRING, TEST_STRING),
+        new StorageResourceId(TEST_STRING, TEST_STRING));
+    gcs.move(sourceToDestinationObjectsMap);
+
+    verify(mockGcsDelegate).move(eq(sourceToDestinationObjectsMap));
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -33,6 +33,7 @@ import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getMe
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listBucketsRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestWithTrailingDelimiter;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.moveRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.resumableUploadChunkRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.resumableUploadRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.uploadRequestString;
@@ -1745,6 +1746,73 @@ public class GoogleCloudStorageTest {
         .containsExactly(
             copyRequestString(BUCKET_NAME, OBJECT_NAME, BUCKET_NAME, dstObject, "copyTo"))
         .inOrder();
+  }
+
+  /** Test argument sanitization for GoogleCloudStorage.move(1). */
+  @Test
+  public void testMoveObjectsIllegalArguments() throws IOException {
+    String b = BUCKET_NAME;
+    String o = OBJECT_NAME;
+
+    GoogleCloudStorage gcs = mockedGcsImpl(HTTP_TRANSPORT);
+
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>();
+
+    // Failure if src == dst.
+    sourceToDestinationObjectsMap.put(new StorageResourceId(b, o), new StorageResourceId(b, o));
+    assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+
+    // Failure if srcBucket != dstBucket.
+    sourceToDestinationObjectsMap.clear();
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(b, o), new StorageResourceId("other-bucket", o));
+    assertThrows(
+        UnsupportedOperationException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+  }
+
+  /** Test successful operation of GoogleCloudStorage.move(1). */
+  @Test
+  public void testMoveObjectsOperation() throws IOException {
+    String dstObject = OBJECT_NAME + "-move";
+    StorageObject object = newStorageObject(BUCKET_NAME, dstObject);
+    MockHttpTransport transport =
+        mockTransport(jsonDataResponse(new Objects().setItems(ImmutableList.of(object))));
+
+    GoogleCloudStorage gcs =
+        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
+
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>(1);
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+        new StorageResourceId(BUCKET_NAME, dstObject));
+
+    gcs.move(sourceToDestinationObjectsMap);
+
+    assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
+        .containsExactly(moveRequestString(BUCKET_NAME, OBJECT_NAME, dstObject, "moveTo"))
+        .inOrder();
+  }
+
+  /**
+   * Test GoogleCloudStorage.move(1),throws FILE_NOT_FOUND Exception when the source object does not
+   * exist.
+   */
+  @Test
+  public void testMoveObjectsSourceNotFound() throws IOException {
+    String srcObject = OBJECT_NAME + "-src-nonexistent";
+    String dstObject = OBJECT_NAME + "-move-dst";
+    StorageResourceId srcId = new StorageResourceId(BUCKET_NAME, srcObject);
+    StorageResourceId dstId = new StorageResourceId(BUCKET_NAME, dstObject);
+
+    MockHttpTransport transport = mockTransport(jsonErrorResponse(ErrorResponses.NOT_FOUND));
+
+    GoogleCloudStorage gcs =
+        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithoutRetries);
+
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>(1);
+    sourceToDestinationObjectsMap.put(srcId, dstId);
+
+    assertThrows(FileNotFoundException.class, () -> gcs.move(sourceToDestinationObjectsMap));
   }
 
   /**

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -1754,7 +1754,7 @@ public class GoogleCloudStorageTest {
     String b = BUCKET_NAME;
     String o = OBJECT_NAME;
 
-    GoogleCloudStorage gcs = mockedGcsImpl(HTTP_TRANSPORT);
+    GoogleCloudStorage gcs = mockedGcs(HTTP_TRANSPORT);
 
     Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>();
 
@@ -1779,7 +1779,7 @@ public class GoogleCloudStorageTest {
         mockTransport(jsonDataResponse(new Objects().setItems(ImmutableList.of(object))));
 
     GoogleCloudStorage gcs =
-        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
+        mockedGcs(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
 
     Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>(1);
     sourceToDestinationObjectsMap.put(
@@ -1807,7 +1807,7 @@ public class GoogleCloudStorageTest {
     MockHttpTransport transport = mockTransport(jsonErrorResponse(ErrorResponses.NOT_FOUND));
 
     GoogleCloudStorage gcs =
-        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithoutRetries);
+        mockedGcs(GCS_OPTIONS, transport, trackingRequestInitializerWithoutRetries);
 
     Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>(1);
     sourceToDestinationObjectsMap.put(srcId, dstId);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
@@ -57,6 +57,9 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
   private static final String POST_COPY_REQUEST_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/b/%s/o/%s";
 
+  private static final String POST_MOVE_REQUEST_FORMAT =
+      "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/o/%s";
+
   private static final String POST_COPY_REQUEST_WITH_METADATA_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/b/%s/o/%s?ifGenerationMatch=%s";
 
@@ -328,6 +331,12 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
             urlEncode(dstObject),
             replaceGenerationId ? "generationId_" + generationId : generationId);
     return generationId == null ? request.replaceAll("ifGenerationMatch=[^&]+&", "") : request;
+  }
+
+  public static String moveRequestString(
+      String bucket, String srcObject, String dstObject, String requestType) {
+    return String.format(
+        POST_MOVE_REQUEST_FORMAT, bucket, urlEncode(srcObject), requestType, urlEncode(dstObject));
   }
 
   public static String uploadRequestString(String bucketName, String object, Integer generationId) {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -237,9 +237,6 @@ public class GoogleCloudStorageImplTest {
     assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
         .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
 
-    if (testStorageClientImpl) {
-      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isNotEmpty();
-    } else {
       assertThat(trackingGcs.getAllRequestStrings())
           .containsExactly(
               TrackingHttpRequestInitializer.moveRequestString(
@@ -248,7 +245,6 @@ public class GoogleCloudStorageImplTest {
                   dstResourceId.getObjectName(),
                   "moveTo"))
           .inOrder();
-    }
     trackingGcs.delegate.close();
   }
 
@@ -271,9 +267,7 @@ public class GoogleCloudStorageImplTest {
             String.format("Move destination must be different from source for %s", resourceId));
 
     assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
-    if (testStorageClientImpl) {
-      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
-    }
+
     trackingGcs.delegate.close();
   }
 
@@ -299,9 +293,6 @@ public class GoogleCloudStorageImplTest {
         .contains("This operation is not supported across two different buckets.");
 
     assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
-    if (testStorageClientImpl) {
-      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
-    }
     trackingGcs.delegate.close();
   }
 
@@ -326,16 +317,6 @@ public class GoogleCloudStorageImplTest {
         .hasMessageThat()
         .contains("Item not found: '" + srcResourceId.toString() + "'");
 
-    if (testStorageClientImpl) {
-      Throwable cause = thrown.getCause().getCause();
-      assertThat(cause).isInstanceOf(StorageException.class);
-
-      List<String> grpcRequests = trackingGcs.grpcRequestInterceptor.getAllRequestStrings();
-      assertThat(grpcRequests).isNotEmpty();
-      assertThat(grpcRequests.toString()).contains("MoveObject");
-
-      assertThat(((StorageException) cause).getCode()).isEqualTo(404);
-    } else {
       Throwable cause = thrown.getCause();
       assertThat(cause).isInstanceOf(GoogleJsonResponseException.class);
       GoogleJsonResponseException gjre = (GoogleJsonResponseException) cause;
@@ -348,7 +329,6 @@ public class GoogleCloudStorageImplTest {
                   srcResourceId.getObjectName(),
                   dstResourceId.getObjectName(),
                   "moveTo"));
-    }
     trackingGcs.delegate.close();
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -27,6 +27,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.auth.Credentials;
 import com.google.cloud.hadoop.gcsio.AssertingLogHandler;
 import com.google.cloud.hadoop.gcsio.CreateBucketOptions;
@@ -44,6 +45,7 @@ import com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TrackingStorageWrapper;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
+import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -201,6 +203,152 @@ public class GoogleCloudStorageImplTest {
         .inOrder();
 
     assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings().size()).isEqualTo(0);
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_successful() throws IOException {
+    int expectedSize = 5 * 1024 * 1024;
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_dst.txt");
+
+    // Create source object
+    writeObject(helperGcs, srcResourceId, expectedSize, 1);
+    GoogleCloudStorageItemInfo srcInfoBeforeMove = helperGcs.getItemInfo(srcResourceId);
+    assertThat(srcInfoBeforeMove.exists()).isTrue();
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    // Perform move
+    trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId));
+
+    // Assertions
+    GoogleCloudStorageItemInfo srcInfoAfterMove = helperGcs.getItemInfo(srcResourceId);
+    GoogleCloudStorageItemInfo dstInfoAfterMove = helperGcs.getItemInfo(dstResourceId);
+
+    assertThat(srcInfoAfterMove.exists()).isFalse();
+    assertThat(dstInfoAfterMove.exists()).isTrue();
+    assertThat(dstInfoAfterMove.getSize()).isEqualTo(expectedSize);
+
+    // Assert requests
+    assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
+        .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
+
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isNotEmpty();
+    } else {
+      assertThat(trackingGcs.getAllRequestStrings())
+          .containsExactly(
+              TrackingHttpRequestInitializer.moveRequestString(
+                  testBucket,
+                  srcResourceId.getObjectName(),
+                  dstResourceId.getObjectName(),
+                  "moveTo"))
+          .inOrder();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_sourceAndDestinationSame_throwsError() throws IOException {
+    StorageResourceId resourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_samesrcdst.txt");
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(resourceId, resourceId)));
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains(
+            String.format("Move destination must be different from source for %s", resourceId));
+
+    assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_differentBuckets_throwsError() throws IOException {
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src_diffbuckets.txt");
+    // Create a unique name for the other bucket to avoid conflicts if it were created.
+    String otherBucketName = bucketHelper.getUniqueBucketName("gcsio-other-move-bucket");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(otherBucketName, name.getMethodName() + "_dst_diffbuckets.txt");
+
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    UnsupportedOperationException thrown =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId)));
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("This operation is not supported across two different buckets.");
+
+    assertThat(trackingGcs.getAllRequestStrings()).isEmpty();
+    if (testStorageClientImpl) {
+      assertThat(trackingGcs.grpcRequestInterceptor.getAllRequestStrings()).isEmpty();
+    }
+    trackingGcs.delegate.close();
+  }
+
+  @Test
+  public void moveObject_sourceNotFound_throwsError() throws IOException {
+    StorageResourceId srcResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_src_notfound.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(testBucket, name.getMethodName() + "_dst_for_notfound.txt");
+
+    // Source object is not created.
+    TrackingStorageWrapper<GoogleCloudStorage> trackingGcs =
+        newTrackingGoogleCloudStorage(GCS_OPTIONS);
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () -> trackingGcs.delegate.move(ImmutableMap.of(srcResourceId, dstResourceId)));
+
+    assertThat(thrown).isInstanceOf(java.io.FileNotFoundException.class);
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Item not found: '" + srcResourceId.toString() + "'");
+
+    if (testStorageClientImpl) {
+      Throwable cause = thrown.getCause().getCause();
+      assertThat(cause).isInstanceOf(StorageException.class);
+
+      List<String> grpcRequests = trackingGcs.grpcRequestInterceptor.getAllRequestStrings();
+      assertThat(grpcRequests).isNotEmpty();
+      assertThat(grpcRequests.toString()).contains("MoveObject");
+
+      assertThat(((StorageException) cause).getCode()).isEqualTo(404);
+    } else {
+      Throwable cause = thrown.getCause();
+      assertThat(cause).isInstanceOf(GoogleJsonResponseException.class);
+      GoogleJsonResponseException gjre = (GoogleJsonResponseException) cause;
+      assertThat(gjre.getStatusCode()).isEqualTo(404);
+
+      assertThat(trackingGcs.getAllRequestStrings())
+          .containsExactly(
+              TrackingHttpRequestInitializer.moveRequestString(
+                  testBucket,
+                  srcResourceId.getObjectName(),
+                  dstResourceId.getObjectName(),
+                  "moveTo"));
+    }
     trackingGcs.delegate.close();
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageImplTest.java
@@ -45,7 +45,6 @@ import com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TestBucketHelper;
 import com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.TrackingStorageWrapper;
 import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
-import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -237,14 +236,11 @@ public class GoogleCloudStorageImplTest {
     assertThat(trackingGcs.requestsTracker.getAllRequestInvocationIds().size())
         .isEqualTo(trackingGcs.requestsTracker.getAllRequests().size());
 
-      assertThat(trackingGcs.getAllRequestStrings())
-          .containsExactly(
-              TrackingHttpRequestInitializer.moveRequestString(
-                  testBucket,
-                  srcResourceId.getObjectName(),
-                  dstResourceId.getObjectName(),
-                  "moveTo"))
-          .inOrder();
+    assertThat(trackingGcs.getAllRequestStrings())
+        .containsExactly(
+            TrackingHttpRequestInitializer.moveRequestString(
+                testBucket, srcResourceId.getObjectName(), dstResourceId.getObjectName(), "moveTo"))
+        .inOrder();
     trackingGcs.delegate.close();
   }
 
@@ -317,18 +313,18 @@ public class GoogleCloudStorageImplTest {
         .hasMessageThat()
         .contains("Item not found: '" + srcResourceId.toString() + "'");
 
-      Throwable cause = thrown.getCause();
-      assertThat(cause).isInstanceOf(GoogleJsonResponseException.class);
-      GoogleJsonResponseException gjre = (GoogleJsonResponseException) cause;
-      assertThat(gjre.getStatusCode()).isEqualTo(404);
+    Throwable cause = thrown.getCause();
+    assertThat(cause).isInstanceOf(GoogleJsonResponseException.class);
+    GoogleJsonResponseException gjre = (GoogleJsonResponseException) cause;
+    assertThat(gjre.getStatusCode()).isEqualTo(404);
 
-      assertThat(trackingGcs.getAllRequestStrings())
-          .containsExactly(
-              TrackingHttpRequestInitializer.moveRequestString(
-                  testBucket,
-                  srcResourceId.getObjectName(),
-                  dstResourceId.getObjectName(),
-                  "moveTo"));
+    assertThat(trackingGcs.getAllRequestStrings())
+        .containsExactly(
+            TrackingHttpRequestInitializer.moveRequestString(
+                testBucket,
+                srcResourceId.getObjectName(),
+                dstResourceId.getObjectName(),
+                "moveTo"));
     trackingGcs.delegate.close();
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTest.java
@@ -1130,6 +1130,99 @@ public class GoogleCloudStorageTest {
   }
 
   @Test
+  public void testMoveSingleItem_withMove() throws IOException {
+    String bucketName = getSharedBucketName();
+
+    StorageResourceId srcResourceId =
+        new StorageResourceId(bucketName, "testMoveSingleItem_srcFile.txt");
+    StorageResourceId dstResourceId =
+        new StorageResourceId(bucketName, "testMoveSingleItem_dstFile.txt");
+
+    rawStorage.deleteObjects(ImmutableList.of(srcResourceId, dstResourceId));
+
+    assertThat(rawStorage.getItemInfo(srcResourceId).exists()).isFalse();
+    assertThat(rawStorage.getItemInfo(dstResourceId).exists()).isFalse();
+
+    byte[] objectContent = writeObject(rawStorage, srcResourceId, /* objectSize= */ 4096);
+    assertThat(rawStorage.getItemInfo(srcResourceId).exists()).isTrue();
+
+    rawStorage.move(ImmutableMap.of(srcResourceId, dstResourceId));
+
+    // Verify source no longer exists
+    GoogleCloudStorageItemInfo srcInfo = rawStorage.getItemInfo(srcResourceId);
+    assertWithMessage("Source object %s should not exist after move", srcResourceId)
+        .that(srcInfo.exists())
+        .isFalse();
+
+    // Verify destination exists and has the correct content
+    GoogleCloudStorageItemInfo dstInfo = rawStorage.getItemInfo(dstResourceId);
+    assertWithMessage("Destination object %s should exist after move", dstResourceId)
+        .that(dstInfo.exists())
+        .isTrue();
+    assertObjectContent(rawStorage, dstResourceId, objectContent);
+  }
+
+  @Test
+  public void testMoveMultipleItems() throws IOException {
+    String bucketName = getSharedBucketName();
+
+    StorageResourceId src1 = new StorageResourceId(bucketName, "testMoveMultipleItems_src1.txt");
+    StorageResourceId dst1 = new StorageResourceId(bucketName, "testMoveMultipleItems_dst1.txt");
+    StorageResourceId src2 = new StorageResourceId(bucketName, "testMoveMultipleItems_src2.dat");
+    StorageResourceId dst2 = new StorageResourceId(bucketName, "testMoveMultipleItems_dst2.dat");
+    StorageResourceId src3 =
+        new StorageResourceId(bucketName, "testMoveMultipleItems_src3/sub.txt");
+    StorageResourceId dst3 =
+        new StorageResourceId(bucketName, "testMoveMultipleItems_dst3/sub_moved.txt");
+
+    rawStorage.deleteObjects(ImmutableList.of(src1, dst1, src2, dst2, src3, dst3));
+
+    byte[] content1 = writeObject(rawStorage, src1, 100);
+    byte[] content2 = writeObject(rawStorage, src2, 200);
+    byte[] content3 = writeObject(rawStorage, src3, 300);
+
+    Map<StorageResourceId, StorageResourceId> moveMap =
+        ImmutableMap.of(
+            src1, dst1,
+            src2, dst2,
+            src3, dst3);
+
+    rawStorage.move(moveMap);
+
+    // Verify sources are deleted and destinations exist with correct content
+    assertThat(rawStorage.getItemInfo(src1).exists()).isFalse();
+    assertObjectContent(rawStorage, dst1, content1);
+    assertThat(rawStorage.getItemInfo(dst1).getSize()).isEqualTo(content1.length);
+
+    assertThat(rawStorage.getItemInfo(src2).exists()).isFalse();
+    assertObjectContent(rawStorage, dst2, content2);
+    assertThat(rawStorage.getItemInfo(dst2).getSize()).isEqualTo(content2.length);
+
+    assertThat(rawStorage.getItemInfo(src3).exists()).isFalse();
+    assertObjectContent(rawStorage, dst3, content3);
+    assertThat(rawStorage.getItemInfo(dst3).getSize()).isEqualTo(content3.length);
+  }
+
+  @Test
+  public void testMove_sourceNotExists_throwsFileNotFound() throws IOException {
+    String bucketName = getSharedBucketName();
+    StorageResourceId nonExistentSource =
+        new StorageResourceId(bucketName, "nonExistentSourceForMove.txt");
+    StorageResourceId destination =
+        new StorageResourceId(bucketName, "destinationForNonExistentMove.txt");
+
+    // Verify source doesn't exist
+    rawStorage.deleteObjects(ImmutableList.of(nonExistentSource, destination));
+    assertThat(rawStorage.getItemInfo(nonExistentSource).exists()).isFalse();
+
+    Map<StorageResourceId, StorageResourceId> moveMap =
+        ImmutableMap.of(nonExistentSource, destination);
+
+    // Verify FileNotFound Exception thrown
+    assertThrows(FileNotFoundException.class, () -> rawStorage.move(moveMap));
+  }
+
+  @Test
   public void testOpen() throws IOException {
     String bucketName = getSharedBucketName();
 
@@ -1503,7 +1596,7 @@ public class GoogleCloudStorageTest {
   }
 
   @Test
-  public void testMoveSingleItem() throws IOException {
+  public void testMoveSingleItem_withCopyDelete() throws IOException {
     String bucketName = getSharedBucketName();
 
     StorageResourceId srcResourceId = new StorageResourceId(bucketName, "testMoveSingleItem_src");

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,11 @@
     <google.api-bigquery.version>v2-rev20221028-${google.api-client-libraries.version}</google.api-bigquery.version>
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
     <google.api-storage.version>v1-rev20250312-${google.api-client-libraries.version}</google.api-storage.version>
-    <google.auth.version>1.33.1</google.auth.version>
+    <google.auth.version>1.29.0</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-bigquerystorage.version>2.39.1</google.cloud-bigquerystorage.version>
     <google.cloud-core.version>2.44.1</google.cloud-core.version>
-    <google.cloud-storage.bom.version>2.49.0</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.44.1</google.cloud-storage.bom.version>
     <google.flogger.version>0.7.1</google.flogger.version>
     <google.gax.version>2.54.1</google.gax.version>
     <google.gson.version>2.8.9</google.gson.version>
@@ -101,7 +101,7 @@
     <google.http-client.version>1.42.3</google.http-client.version>
     <google.oauth-client.version>1.34.1</google.oauth-client.version>
     <google.protobuf.version>3.25.3</google.protobuf.version>
-    <grpc.version>1.70.0</grpc.version>
+    <grpc.version>1.67.1</grpc.version>
     <hadoop.two.version>2.10.2</hadoop.two.version>
     <hadoop.three.version>3.2.4</hadoop.three.version>
     <opencensus.version>0.31.0</opencensus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <google.http-client.version>1.42.3</google.http-client.version>
     <google.oauth-client.version>1.34.1</google.oauth-client.version>
     <google.protobuf.version>3.25.3</google.protobuf.version>
-    <grpc.version>1.67.1</grpc.version>
+    <grpc.version>1.70.0</grpc.version>
     <hadoop.two.version>2.10.2</hadoop.two.version>
     <hadoop.three.version>3.2.4</hadoop.three.version>
     <opencensus.version>0.31.0</opencensus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,11 @@
     <google.api-bigquery.version>v2-rev20221028-${google.api-client-libraries.version}</google.api-bigquery.version>
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
     <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
-    <google.auth.version>1.29.0</google.auth.version>
+    <google.auth.version>1.33.1</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-bigquerystorage.version>2.39.1</google.cloud-bigquerystorage.version>
     <google.cloud-core.version>2.44.1</google.cloud-core.version>
-    <google.cloud-storage.bom.version>2.44.1</google.cloud-storage.bom.version>
+    <google.cloud-storage.bom.version>2.49.0</google.cloud-storage.bom.version>
     <google.flogger.version>0.7.1</google.flogger.version>
     <google.gax.version>2.54.1</google.gax.version>
     <google.gson.version>2.8.9</google.gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <google.api-client-libraries.version>2.0.0</google.api-client-libraries.version>
     <google.api-bigquery.version>v2-rev20221028-${google.api-client-libraries.version}</google.api-bigquery.version>
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
-    <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
+    <google.api-storage.version>v1-rev20250312-${google.api-client-libraries.version}</google.api-storage.version>
     <google.auth.version>1.33.1</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud-bigquerystorage.version>2.39.1</google.cloud-bigquerystorage.version>


### PR DESCRIPTION
Changes 
- Cherry picke the commit for main [move implementation](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1322) and  [follow up](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1342)
- Ported the move changes for only JSON implementation
- Updated `GoogleCloudStorageFileSystem` for the move changes done in `GoogleCloudStorageFileSystemImpl` in master. 

Fixed branch level incompatibilites 
- Updated GoogleCloudStorageTest to use `mockedGcs` instead of `mockedGcsImpl`
- Fixed other java incompatibility issues

Testing
- Ran unit and integration tests locally
- Verified using hadoop move commands(for file and directory) locally for JSON and gRPC