### PR TITLE
ADC Authentication support for Integration tests in gcsio layer

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
@@ -23,6 +23,9 @@ public abstract class TestConfiguration {
 
   public static final String GCS_TEST_DIRECT_PATH_PREFERRED = "GCS_TEST_DIRECT_PATH_PREFERRED";
 
+  public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE = "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
+
+
   /** Environment-based test configuration. */
   public static class EnvironmentBasedTestConfiguration extends TestConfiguration {
     @Override
@@ -33,6 +36,14 @@ public abstract class TestConfiguration {
     @Override
     public String getServiceAccountJsonKeyFile() {
       return System.getenv(GCS_TEST_JSON_KEYFILE);
+    }
+
+    @Override
+    public boolean isApplicationDefaultModeEnabled(){
+
+      String applicationDefaultModeEnable = System.getenv(GCS_TEST_APPLICATION_DEFAULT_ENABLE);
+      return (Boolean.parseBoolean(applicationDefaultModeEnable));
+
     }
 
     @Override
@@ -57,6 +68,8 @@ public abstract class TestConfiguration {
   public abstract String getProjectId();
 
   public abstract String getServiceAccountJsonKeyFile();
+
+  public abstract boolean isApplicationDefaultModeEnabled();
 
   public abstract boolean isDirectPathPreferred();
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
@@ -23,8 +23,8 @@ public abstract class TestConfiguration {
 
   public static final String GCS_TEST_DIRECT_PATH_PREFERRED = "GCS_TEST_DIRECT_PATH_PREFERRED";
 
-  public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE = "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
-
+  public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE =
+      "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
 
   /** Environment-based test configuration. */
   public static class EnvironmentBasedTestConfiguration extends TestConfiguration {
@@ -39,11 +39,12 @@ public abstract class TestConfiguration {
     }
 
     @Override
-    public boolean isApplicationDefaultModeEnabled(){
-
+    public boolean isApplicationDefaultModeEnabled() {
       String applicationDefaultModeEnable = System.getenv(GCS_TEST_APPLICATION_DEFAULT_ENABLE);
+      if (applicationDefaultModeEnable == null) {
+        return false;
+      }
       return (Boolean.parseBoolean(applicationDefaultModeEnable));
-
     }
 
     @Override

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -49,7 +49,6 @@ import com.google.common.collect.Lists;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.BaseEncoding;
 import com.google.protobuf.ByteString;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -71,7 +70,6 @@ import java.util.stream.Collectors;
 /** Helper methods for GCS integration tests. */
 public class GoogleCloudStorageTestHelper {
 
-  public static final String AUTH_MODE_APPLICATION_DEFAULT = "APPLICATION_DEFAULT";
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   // Application name for OAuth.
@@ -101,27 +99,23 @@ public class GoogleCloudStorageTestHelper {
     }
   }
 
-  public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE = "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
-  static String appDefaultEnable = System.getenv(GCS_TEST_APPLICATION_DEFAULT_ENABLE);
 
 
   public static Credentials getCredentials() throws IOException {
     String serviceAccountJsonKeyFile =
             TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
     if (serviceAccountJsonKeyFile == null) {
-      if(Boolean.parseBoolean(appDefaultEnable)){
+      if(TestConfiguration.getInstance().isApplicationDefaultModeEnabled()){
         return GoogleCredentials.getApplicationDefault();
       }
-      else{
+      else {
         return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
       }
-
     }
     try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
       return ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);
     }
   }
-
 
   public static GoogleCloudStorageOptions.Builder getStandardOptionBuilder() {
     return GoogleCloudStorageOptions.builder()

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -69,7 +69,6 @@ import java.util.stream.Collectors;
 
 /** Helper methods for GCS integration tests. */
 public class GoogleCloudStorageTestHelper {
-
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   // Application name for OAuth.
@@ -105,8 +104,7 @@ public class GoogleCloudStorageTestHelper {
     if (serviceAccountJsonKeyFile == null) {
       Boolean isApplicationDefaultModeEnabled =
           TestConfiguration.getInstance().isApplicationDefaultModeEnabled();
-
-      if (isApplicationDefaultModeEnabled) {
+          if (isApplicationDefaultModeEnabled) {
         return GoogleCredentials.getApplicationDefault();
       } else {
         return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -104,11 +104,9 @@ public class GoogleCloudStorageTestHelper {
     if (serviceAccountJsonKeyFile == null) {
       Boolean isApplicationDefaultModeEnabled =
           TestConfiguration.getInstance().isApplicationDefaultModeEnabled();
-      if (isApplicationDefaultModeEnabled) {
-        return GoogleCredentials.getApplicationDefault();
-      } else {
-        return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
-      }
+      return isApplicationDefaultModeEnabled
+          ? GoogleCredentials.getApplicationDefault()
+          : ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
     }
     try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
       return ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -101,20 +101,6 @@ public class GoogleCloudStorageTestHelper {
     }
   }
 
-//  public static Credentials getCredentials() throws IOException {
-  // String serviceAccountJsonKeyFile =
-  //  TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
-  // if (serviceAccountJsonKeyFile == null) {
-//    return GoogleCredentials.getApplicationDefault();
-  // return // ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
-  // }
-  // try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
-  //   return
-  // //ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);
-  // }
-  // }
-//  }
-
   public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE = "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
   static String appDefaultEnable = System.getenv(GCS_TEST_APPLICATION_DEFAULT_ENABLE);
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -80,9 +80,9 @@ public class GoogleCloudStorageTestHelper {
   public static GoogleCloudStorage createGoogleCloudStorage() {
     try {
       return GoogleCloudStorageImpl.builder()
-              .setOptions(getStandardOptionBuilder().build())
-              .setCredentials(getCredentials())
-              .build();
+          .setOptions(getStandardOptionBuilder().build())
+          .setCredentials(getCredentials())
+          .build();
     } catch (IOException e) {
       throw new RuntimeException("Failed to create GoogleCloudStorage instance", e);
     }
@@ -91,24 +91,24 @@ public class GoogleCloudStorageTestHelper {
   public static GoogleCloudStorage createGcsClientImpl() {
     try {
       return GoogleCloudStorageClientImpl.builder()
-              .setOptions(getStandardOptionBuilder().build())
-              .setCredentials(getCredentials())
-              .build();
+          .setOptions(getStandardOptionBuilder().build())
+          .setCredentials(getCredentials())
+          .build();
     } catch (IOException e) {
       throw new RuntimeException("Failed to create GoogleCloudStorage instance", e);
     }
   }
 
-
-
   public static Credentials getCredentials() throws IOException {
     String serviceAccountJsonKeyFile =
-            TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
+        TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
     if (serviceAccountJsonKeyFile == null) {
-      if(TestConfiguration.getInstance().isApplicationDefaultModeEnabled()){
+      Boolean isApplicationDefaultModeEnabled =
+          TestConfiguration.getInstance().isApplicationDefaultModeEnabled();
+
+      if (isApplicationDefaultModeEnabled) {
         return GoogleCredentials.getApplicationDefault();
-      }
-      else {
+      } else {
         return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
       }
     }
@@ -119,10 +119,10 @@ public class GoogleCloudStorageTestHelper {
 
   public static GoogleCloudStorageOptions.Builder getStandardOptionBuilder() {
     return GoogleCloudStorageOptions.builder()
-            .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
-            .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
-            .setGrpcWriteEnabled(true)
-            .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId()));
+        .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
+        .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
+        .setGrpcWriteEnabled(true)
+        .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId()));
   }
 
   /** More efficient version of checking byte arrays than using Assert.assertArrayEquals. */
@@ -138,43 +138,43 @@ public class GoogleCloudStorageTestHelper {
 
     if (expected.length != actual.length) {
       fail(
-              String.format(
-                      "Length mismatch: expected: %d, actual: %d", expected.length, actual.length));
+          String.format(
+              "Length mismatch: expected: %d, actual: %d", expected.length, actual.length));
     }
 
     for (int i = 0; i < expected.length; ++i) {
       if (expected[i] != actual[i]) {
         fail(
-                String.format(
-                        "Mismatch at index %d. expected: 0x%02x, actual: 0x%02x",
-                        i, expected[i], actual[i]));
+            String.format(
+                "Mismatch at index %d. expected: 0x%02x, actual: 0x%02x",
+                i, expected[i], actual[i]));
       }
     }
   }
 
   public static void assertObjectContent(
-          GoogleCloudStorage gcs, StorageResourceId resourceId, byte[] expectedBytes)
-          throws IOException {
+      GoogleCloudStorage gcs, StorageResourceId resourceId, byte[] expectedBytes)
+      throws IOException {
     assertObjectContent(gcs, resourceId, expectedBytes, /* expectedBytesCount= */ 1);
   }
 
   public static void assertObjectContent(
-          GoogleCloudStorage gcs,
-          StorageResourceId resourceId,
-          GoogleCloudStorageReadOptions readOptions,
-          byte[] expectedBytes)
-          throws IOException {
+      GoogleCloudStorage gcs,
+      StorageResourceId resourceId,
+      GoogleCloudStorageReadOptions readOptions,
+      byte[] expectedBytes)
+      throws IOException {
     assertObjectContent(gcs, resourceId, readOptions, expectedBytes, /* expectedBytesCount= */ 1);
   }
 
   public static void assertObjectContent(
-          GoogleCloudStorage gcs,
-          StorageResourceId id,
-          GoogleCloudStorageReadOptions readOptions,
-          byte[] expectedBytes,
-          int expectedBytesCount,
-          int offset)
-          throws IOException {
+      GoogleCloudStorage gcs,
+      StorageResourceId id,
+      GoogleCloudStorageReadOptions readOptions,
+      byte[] expectedBytes,
+      int expectedBytesCount,
+      int offset)
+      throws IOException {
     checkArgument(expectedBytesCount > 0, "expectedBytesCount should be greater than 0");
 
     int expectedBytesLength = expectedBytes.length;
@@ -204,20 +204,20 @@ public class GoogleCloudStorageTestHelper {
   }
 
   public static void assertObjectContent(
-          GoogleCloudStorage gcs,
-          StorageResourceId id,
-          GoogleCloudStorageReadOptions readOptions,
-          byte[] expectedBytes,
-          int expectedBytesCount)
-          throws IOException {
+      GoogleCloudStorage gcs,
+      StorageResourceId id,
+      GoogleCloudStorageReadOptions readOptions,
+      byte[] expectedBytes,
+      int expectedBytesCount)
+      throws IOException {
     assertObjectContent(gcs, id, readOptions, expectedBytes, expectedBytesCount, /* offset= */ 0);
   }
 
   public static void assertObjectContent(
-          GoogleCloudStorage gcs, StorageResourceId id, byte[] expectedBytes, int expectedBytesCount)
-          throws IOException {
+      GoogleCloudStorage gcs, StorageResourceId id, byte[] expectedBytes, int expectedBytesCount)
+      throws IOException {
     assertObjectContent(
-            gcs, id, GoogleCloudStorageReadOptions.DEFAULT, expectedBytes, expectedBytesCount);
+        gcs, id, GoogleCloudStorageReadOptions.DEFAULT, expectedBytes, expectedBytesCount);
   }
 
   private static byte[] getExpectedBytesRead(byte[] expectedBytes, long totalRead, int read) {
@@ -241,18 +241,18 @@ public class GoogleCloudStorageTestHelper {
   }
 
   public static byte[] writeObject(
-          GoogleCloudStorage gcs, StorageResourceId resourceId, int objectSize) throws IOException {
+      GoogleCloudStorage gcs, StorageResourceId resourceId, int objectSize) throws IOException {
     return writeObject(gcs, resourceId, objectSize, /* partitionsCount= */ 1);
   }
 
   public static byte[] writeObject(
-          GoogleCloudStorage gcs, StorageResourceId resourceId, int partitionSize, int partitionsCount)
-          throws IOException {
+      GoogleCloudStorage gcs, StorageResourceId resourceId, int partitionSize, int partitionsCount)
+      throws IOException {
     return writeObject(gcs.create(resourceId), partitionSize, partitionsCount);
   }
 
   public static byte[] writeObject(
-          WritableByteChannel channel, int partitionSize, int partitionsCount) throws IOException {
+      WritableByteChannel channel, int partitionSize, int partitionsCount) throws IOException {
     checkArgument(partitionsCount > 0, "partitionsCount should be greater than 0");
 
     byte[] partition = new byte[partitionSize];
@@ -266,15 +266,15 @@ public class GoogleCloudStorageTestHelper {
     }
     long endTime = System.currentTimeMillis();
     logger.atFine().log(
-            "Took %sms to write %sB", (endTime - startTime), (long) partitionsCount * partitionSize);
+        "Took %sms to write %sB", (endTime - startTime), (long) partitionsCount * partitionSize);
     return partition;
   }
 
   public static Map<String, byte[]> getDecodedMetadata(Map<String, String> metadata) {
     return metadata.entrySet().stream()
-            .collect(
-                    Collectors.toMap(
-                            entity -> entity.getKey(), entity -> decodeMetadataValues(entity.getValue())));
+        .collect(
+            Collectors.toMap(
+                entity -> entity.getKey(), entity -> decodeMetadataValues(entity.getValue())));
   }
 
   public static byte[] decodeMetadataValues(String value) {
@@ -295,14 +295,14 @@ public class GoogleCloudStorageTestHelper {
   public static StorageObject newStorageObject(String bucketName, String objectName) {
     Random r = new Random();
     return new StorageObject()
-            .setBucket(bucketName)
-            .setName(objectName)
-            .setSize(BigInteger.valueOf(r.nextInt(Integer.MAX_VALUE)))
-            .setStorageClass("standard")
-            .setGeneration((long) r.nextInt(Integer.MAX_VALUE))
-            .setMetageneration((long) r.nextInt(Integer.MAX_VALUE))
-            .setTimeCreated(new DateTime(new Date()))
-            .setUpdated(new DateTime(new Date()));
+        .setBucket(bucketName)
+        .setName(objectName)
+        .setSize(BigInteger.valueOf(r.nextInt(Integer.MAX_VALUE)))
+        .setStorageClass("standard")
+        .setGeneration((long) r.nextInt(Integer.MAX_VALUE))
+        .setMetageneration((long) r.nextInt(Integer.MAX_VALUE))
+        .setTimeCreated(new DateTime(new Date()))
+        .setUpdated(new DateTime(new Date()));
   }
 
   /** Helper for dealing with buckets in GCS integration tests. */
@@ -313,7 +313,7 @@ public class GoogleCloudStorageTestHelper {
 
     // If bucket created before this time, it considered leaked
     private static final long LEAKED_BUCKETS_CUTOFF_TIME =
-            Instant.now().minus(Duration.ofHours(6)).toEpochMilli();
+        Instant.now().minus(Duration.ofHours(6)).toEpochMilli();
 
     private final String bucketPrefix;
     private final String uniqueBucketPrefix;
@@ -331,8 +331,8 @@ public class GoogleCloudStorageTestHelper {
       this.bucketPrefix = bucketPrefix + DELIMITER;
       this.uniqueBucketPrefix = makeUniqueBucketNamePrefix(bucketPrefix);
       checkState(
-              this.uniqueBucketPrefix.startsWith(this.bucketPrefix),
-              "uniqueBucketPrefix should start with bucketPrefix");
+          this.uniqueBucketPrefix.startsWith(this.bucketPrefix),
+          "uniqueBucketPrefix should start with bucketPrefix");
     }
 
     private static String makeUniqueBucketNamePrefix(String prefix) {
@@ -343,7 +343,7 @@ public class GoogleCloudStorageTestHelper {
       int usernamePrefixLen = min(username.length(), 8);
       username = username.substring(0, usernamePrefixLen);
       String uuidSuffix =
-              UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12 - usernamePrefixLen);
+          UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12 - usernamePrefixLen);
       return prefix + DELIMITER + username + DELIMITER + uuidSuffix;
     }
 
@@ -354,8 +354,8 @@ public class GoogleCloudStorageTestHelper {
      */
     public String getUniqueBucketName(String suffix) {
       checkArgument(
-              bucketPrefix.length() + suffix.length() <= 48,
-              "bucketPrefix and suffix can have cumulative length upto 48 chars to limit bucket name to 63 chars");
+          bucketPrefix.length() + suffix.length() <= 48,
+          "bucketPrefix and suffix can have cumulative length upto 48 chars to limit bucket name to 63 chars");
       return uniqueBucketPrefix + DELIMITER + suffix;
     }
 
@@ -366,13 +366,13 @@ public class GoogleCloudStorageTestHelper {
     public void cleanup(GoogleCloudStorage storage) throws IOException {
       Stopwatch storageStopwatch = Stopwatch.createStarted();
       logger.atInfo().log(
-              "Cleaning up GCS buckets that start with %s prefix or leaked", uniqueBucketPrefix);
+          "Cleaning up GCS buckets that start with %s prefix or leaked", uniqueBucketPrefix);
 
       List<String> bucketsToDelete = new ArrayList<>();
       for (GoogleCloudStorageItemInfo bucketInfo : storage.listBucketInfo()) {
         String bucketName = bucketInfo.getBucketName();
         if (bucketName.startsWith(bucketPrefix)
-                && (bucketName.startsWith(uniqueBucketPrefix)
+            && (bucketName.startsWith(uniqueBucketPrefix)
                 || bucketInfo.getCreationTime() < LEAKED_BUCKETS_CUTOFF_TIME)) {
           bucketsToDelete.add(bucketName);
         }
@@ -381,40 +381,40 @@ public class GoogleCloudStorageTestHelper {
       Collections.shuffle(bucketsToDelete);
       if (bucketsToDelete.size() > MAX_CLEANUP_BUCKETS) {
         logger.atInfo().log(
-                "GCS has %s buckets to cleanup. It's too many, will cleanup only %s buckets: %s",
-                bucketsToDelete.size(), MAX_CLEANUP_BUCKETS, bucketsToDelete);
+            "GCS has %s buckets to cleanup. It's too many, will cleanup only %s buckets: %s",
+            bucketsToDelete.size(), MAX_CLEANUP_BUCKETS, bucketsToDelete);
         bucketsToDelete = bucketsToDelete.subList(0, MAX_CLEANUP_BUCKETS);
       } else if (bucketsToDelete.size() > 0) {
         logger.atInfo().log(
-                "GCS has %s buckets to cleanup: %s", bucketsToDelete.size(), bucketsToDelete);
+            "GCS has %s buckets to cleanup: %s", bucketsToDelete.size(), bucketsToDelete);
       }
 
       List<GoogleCloudStorageItemInfo> objectsToDelete =
-              bucketsToDelete.parallelStream()
-                      .flatMap(
-                              bucket -> {
-                                try {
-                                  return storage
-                                          .listObjectInfo(
-                                                  bucket,
-                                                  /* objectNamePrefix= */ null,
-                                                  ListObjectOptions.DEFAULT_FLAT_LIST)
-                                          .stream();
-                                } catch (IOException e) {
-                                  throw new RuntimeException(e);
-                                }
-                              })
-                      .collect(toImmutableList());
+          bucketsToDelete.parallelStream()
+              .flatMap(
+                  bucket -> {
+                    try {
+                      return storage
+                          .listObjectInfo(
+                              bucket,
+                              /* objectNamePrefix= */ null,
+                              ListObjectOptions.DEFAULT_FLAT_LIST)
+                          .stream();
+                    } catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
+                  })
+              .collect(toImmutableList());
       logger.atInfo().log(
-              "GCS has %s objects to cleanup: %s", objectsToDelete.size(), objectsToDelete);
+          "GCS has %s objects to cleanup: %s", objectsToDelete.size(), objectsToDelete);
 
       try {
         storage.deleteObjects(
-                Lists.transform(objectsToDelete, GoogleCloudStorageItemInfo::getResourceId));
+            Lists.transform(objectsToDelete, GoogleCloudStorageItemInfo::getResourceId));
         storage.deleteBuckets(bucketsToDelete);
       } catch (IOException ioe) {
         logger.atWarning().withCause(ioe).log(
-                "Caught exception during GCS (%s) buckets cleanup", storage);
+            "Caught exception during GCS (%s) buckets cleanup", storage);
       }
 
       logger.atInfo().log("GCS cleaned up in %s seconds", storageStopwatch.elapsed().getSeconds());
@@ -434,24 +434,24 @@ public class GoogleCloudStorageTestHelper {
     public final T delegate;
 
     public TrackingStorageWrapper(
-            GoogleCloudStorageOptions options,
-            CheckedFunction2<TrackingHttpRequestInitializer, ImmutableList, T, IOException>
-                    delegateStorageFn,
-            Credentials credentials)
-            throws IOException {
+        GoogleCloudStorageOptions options,
+        CheckedFunction2<TrackingHttpRequestInitializer, ImmutableList, T, IOException>
+            delegateStorageFn,
+        Credentials credentials)
+        throws IOException {
       this.requestsTracker =
-              new TrackingHttpRequestInitializer(
-                      new RetryHttpInitializer(credentials, options.toRetryHttpInitializerOptions()));
+          new TrackingHttpRequestInitializer(
+              new RetryHttpInitializer(credentials, options.toRetryHttpInitializerOptions()));
       this.grpcRequestInterceptor = new TrackingGrpcRequestInterceptor();
       this.delegate =
-              delegateStorageFn.apply(this.requestsTracker, ImmutableList.of(grpcRequestInterceptor));
+          delegateStorageFn.apply(this.requestsTracker, ImmutableList.of(grpcRequestInterceptor));
     }
 
     public ImmutableList getAllRequestStrings() {
       return ImmutableList.builder()
-              .addAll(requestsTracker.getAllRequestStrings())
-              .addAll(grpcRequestInterceptor.getAllRequestStrings())
-              .build();
+          .addAll(requestsTracker.getAllRequestStrings())
+          .addAll(grpcRequestInterceptor.getAllRequestStrings())
+          .build();
     }
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -104,7 +104,7 @@ public class GoogleCloudStorageTestHelper {
     if (serviceAccountJsonKeyFile == null) {
       Boolean isApplicationDefaultModeEnabled =
           TestConfiguration.getInstance().isApplicationDefaultModeEnabled();
-          if (isApplicationDefaultModeEnabled) {
+      if (isApplicationDefaultModeEnabled) {
         return GoogleCredentials.getApplicationDefault();
       } else {
         return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -29,6 +29,7 @@ import com.google.api.services.storage.StorageScopes;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
@@ -48,6 +49,7 @@ import com.google.common.collect.Lists;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.io.BaseEncoding;
 import com.google.protobuf.ByteString;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -68,6 +70,8 @@ import java.util.stream.Collectors;
 
 /** Helper methods for GCS integration tests. */
 public class GoogleCloudStorageTestHelper {
+
+  public static final String AUTH_MODE_APPLICATION_DEFAULT = "APPLICATION_DEFAULT";
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   // Application name for OAuth.
@@ -78,9 +82,9 @@ public class GoogleCloudStorageTestHelper {
   public static GoogleCloudStorage createGoogleCloudStorage() {
     try {
       return GoogleCloudStorageImpl.builder()
-          .setOptions(getStandardOptionBuilder().build())
-          .setCredentials(getCredentials())
-          .build();
+              .setOptions(getStandardOptionBuilder().build())
+              .setCredentials(getCredentials())
+              .build();
     } catch (IOException e) {
       throw new RuntimeException("Failed to create GoogleCloudStorage instance", e);
     }
@@ -89,31 +93,56 @@ public class GoogleCloudStorageTestHelper {
   public static GoogleCloudStorage createGcsClientImpl() {
     try {
       return GoogleCloudStorageClientImpl.builder()
-          .setOptions(getStandardOptionBuilder().build())
-          .setCredentials(getCredentials())
-          .build();
+              .setOptions(getStandardOptionBuilder().build())
+              .setCredentials(getCredentials())
+              .build();
     } catch (IOException e) {
       throw new RuntimeException("Failed to create GoogleCloudStorage instance", e);
     }
   }
 
+//  public static Credentials getCredentials() throws IOException {
+  // String serviceAccountJsonKeyFile =
+  //  TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
+  // if (serviceAccountJsonKeyFile == null) {
+//    return GoogleCredentials.getApplicationDefault();
+  // return // ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
+  // }
+  // try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
+  //   return
+  // //ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);
+  // }
+  // }
+//  }
+
+  public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE = "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
+  static String appDefaultEnable = System.getenv(GCS_TEST_APPLICATION_DEFAULT_ENABLE);
+
+
   public static Credentials getCredentials() throws IOException {
     String serviceAccountJsonKeyFile =
-        TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
+            TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
     if (serviceAccountJsonKeyFile == null) {
-      return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
+      if(Boolean.parseBoolean(appDefaultEnable)){
+        return GoogleCredentials.getApplicationDefault();
+      }
+      else{
+        return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
+      }
+
     }
     try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
       return ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);
     }
   }
 
+
   public static GoogleCloudStorageOptions.Builder getStandardOptionBuilder() {
     return GoogleCloudStorageOptions.builder()
-        .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
-        .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
-        .setGrpcWriteEnabled(true)
-        .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId()));
+            .setAppName(GoogleCloudStorageTestHelper.APP_NAME)
+            .setDirectPathPreferred(TestConfiguration.getInstance().isDirectPathPreferred())
+            .setGrpcWriteEnabled(true)
+            .setProjectId(checkNotNull(TestConfiguration.getInstance().getProjectId()));
   }
 
   /** More efficient version of checking byte arrays than using Assert.assertArrayEquals. */
@@ -129,43 +158,43 @@ public class GoogleCloudStorageTestHelper {
 
     if (expected.length != actual.length) {
       fail(
-          String.format(
-              "Length mismatch: expected: %d, actual: %d", expected.length, actual.length));
+              String.format(
+                      "Length mismatch: expected: %d, actual: %d", expected.length, actual.length));
     }
 
     for (int i = 0; i < expected.length; ++i) {
       if (expected[i] != actual[i]) {
         fail(
-            String.format(
-                "Mismatch at index %d. expected: 0x%02x, actual: 0x%02x",
-                i, expected[i], actual[i]));
+                String.format(
+                        "Mismatch at index %d. expected: 0x%02x, actual: 0x%02x",
+                        i, expected[i], actual[i]));
       }
     }
   }
 
   public static void assertObjectContent(
-      GoogleCloudStorage gcs, StorageResourceId resourceId, byte[] expectedBytes)
-      throws IOException {
+          GoogleCloudStorage gcs, StorageResourceId resourceId, byte[] expectedBytes)
+          throws IOException {
     assertObjectContent(gcs, resourceId, expectedBytes, /* expectedBytesCount= */ 1);
   }
 
   public static void assertObjectContent(
-      GoogleCloudStorage gcs,
-      StorageResourceId resourceId,
-      GoogleCloudStorageReadOptions readOptions,
-      byte[] expectedBytes)
-      throws IOException {
+          GoogleCloudStorage gcs,
+          StorageResourceId resourceId,
+          GoogleCloudStorageReadOptions readOptions,
+          byte[] expectedBytes)
+          throws IOException {
     assertObjectContent(gcs, resourceId, readOptions, expectedBytes, /* expectedBytesCount= */ 1);
   }
 
   public static void assertObjectContent(
-      GoogleCloudStorage gcs,
-      StorageResourceId id,
-      GoogleCloudStorageReadOptions readOptions,
-      byte[] expectedBytes,
-      int expectedBytesCount,
-      int offset)
-      throws IOException {
+          GoogleCloudStorage gcs,
+          StorageResourceId id,
+          GoogleCloudStorageReadOptions readOptions,
+          byte[] expectedBytes,
+          int expectedBytesCount,
+          int offset)
+          throws IOException {
     checkArgument(expectedBytesCount > 0, "expectedBytesCount should be greater than 0");
 
     int expectedBytesLength = expectedBytes.length;
@@ -195,20 +224,20 @@ public class GoogleCloudStorageTestHelper {
   }
 
   public static void assertObjectContent(
-      GoogleCloudStorage gcs,
-      StorageResourceId id,
-      GoogleCloudStorageReadOptions readOptions,
-      byte[] expectedBytes,
-      int expectedBytesCount)
-      throws IOException {
+          GoogleCloudStorage gcs,
+          StorageResourceId id,
+          GoogleCloudStorageReadOptions readOptions,
+          byte[] expectedBytes,
+          int expectedBytesCount)
+          throws IOException {
     assertObjectContent(gcs, id, readOptions, expectedBytes, expectedBytesCount, /* offset= */ 0);
   }
 
   public static void assertObjectContent(
-      GoogleCloudStorage gcs, StorageResourceId id, byte[] expectedBytes, int expectedBytesCount)
-      throws IOException {
+          GoogleCloudStorage gcs, StorageResourceId id, byte[] expectedBytes, int expectedBytesCount)
+          throws IOException {
     assertObjectContent(
-        gcs, id, GoogleCloudStorageReadOptions.DEFAULT, expectedBytes, expectedBytesCount);
+            gcs, id, GoogleCloudStorageReadOptions.DEFAULT, expectedBytes, expectedBytesCount);
   }
 
   private static byte[] getExpectedBytesRead(byte[] expectedBytes, long totalRead, int read) {
@@ -232,18 +261,18 @@ public class GoogleCloudStorageTestHelper {
   }
 
   public static byte[] writeObject(
-      GoogleCloudStorage gcs, StorageResourceId resourceId, int objectSize) throws IOException {
+          GoogleCloudStorage gcs, StorageResourceId resourceId, int objectSize) throws IOException {
     return writeObject(gcs, resourceId, objectSize, /* partitionsCount= */ 1);
   }
 
   public static byte[] writeObject(
-      GoogleCloudStorage gcs, StorageResourceId resourceId, int partitionSize, int partitionsCount)
-      throws IOException {
+          GoogleCloudStorage gcs, StorageResourceId resourceId, int partitionSize, int partitionsCount)
+          throws IOException {
     return writeObject(gcs.create(resourceId), partitionSize, partitionsCount);
   }
 
   public static byte[] writeObject(
-      WritableByteChannel channel, int partitionSize, int partitionsCount) throws IOException {
+          WritableByteChannel channel, int partitionSize, int partitionsCount) throws IOException {
     checkArgument(partitionsCount > 0, "partitionsCount should be greater than 0");
 
     byte[] partition = new byte[partitionSize];
@@ -257,15 +286,15 @@ public class GoogleCloudStorageTestHelper {
     }
     long endTime = System.currentTimeMillis();
     logger.atFine().log(
-        "Took %sms to write %sB", (endTime - startTime), (long) partitionsCount * partitionSize);
+            "Took %sms to write %sB", (endTime - startTime), (long) partitionsCount * partitionSize);
     return partition;
   }
 
   public static Map<String, byte[]> getDecodedMetadata(Map<String, String> metadata) {
     return metadata.entrySet().stream()
-        .collect(
-            Collectors.toMap(
-                entity -> entity.getKey(), entity -> decodeMetadataValues(entity.getValue())));
+            .collect(
+                    Collectors.toMap(
+                            entity -> entity.getKey(), entity -> decodeMetadataValues(entity.getValue())));
   }
 
   public static byte[] decodeMetadataValues(String value) {
@@ -286,14 +315,14 @@ public class GoogleCloudStorageTestHelper {
   public static StorageObject newStorageObject(String bucketName, String objectName) {
     Random r = new Random();
     return new StorageObject()
-        .setBucket(bucketName)
-        .setName(objectName)
-        .setSize(BigInteger.valueOf(r.nextInt(Integer.MAX_VALUE)))
-        .setStorageClass("standard")
-        .setGeneration((long) r.nextInt(Integer.MAX_VALUE))
-        .setMetageneration((long) r.nextInt(Integer.MAX_VALUE))
-        .setTimeCreated(new DateTime(new Date()))
-        .setUpdated(new DateTime(new Date()));
+            .setBucket(bucketName)
+            .setName(objectName)
+            .setSize(BigInteger.valueOf(r.nextInt(Integer.MAX_VALUE)))
+            .setStorageClass("standard")
+            .setGeneration((long) r.nextInt(Integer.MAX_VALUE))
+            .setMetageneration((long) r.nextInt(Integer.MAX_VALUE))
+            .setTimeCreated(new DateTime(new Date()))
+            .setUpdated(new DateTime(new Date()));
   }
 
   /** Helper for dealing with buckets in GCS integration tests. */
@@ -304,7 +333,7 @@ public class GoogleCloudStorageTestHelper {
 
     // If bucket created before this time, it considered leaked
     private static final long LEAKED_BUCKETS_CUTOFF_TIME =
-        Instant.now().minus(Duration.ofHours(6)).toEpochMilli();
+            Instant.now().minus(Duration.ofHours(6)).toEpochMilli();
 
     private final String bucketPrefix;
     private final String uniqueBucketPrefix;
@@ -322,8 +351,8 @@ public class GoogleCloudStorageTestHelper {
       this.bucketPrefix = bucketPrefix + DELIMITER;
       this.uniqueBucketPrefix = makeUniqueBucketNamePrefix(bucketPrefix);
       checkState(
-          this.uniqueBucketPrefix.startsWith(this.bucketPrefix),
-          "uniqueBucketPrefix should start with bucketPrefix");
+              this.uniqueBucketPrefix.startsWith(this.bucketPrefix),
+              "uniqueBucketPrefix should start with bucketPrefix");
     }
 
     private static String makeUniqueBucketNamePrefix(String prefix) {
@@ -334,7 +363,7 @@ public class GoogleCloudStorageTestHelper {
       int usernamePrefixLen = min(username.length(), 8);
       username = username.substring(0, usernamePrefixLen);
       String uuidSuffix =
-          UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12 - usernamePrefixLen);
+              UUID.randomUUID().toString().replaceAll("-", "").substring(0, 12 - usernamePrefixLen);
       return prefix + DELIMITER + username + DELIMITER + uuidSuffix;
     }
 
@@ -345,8 +374,8 @@ public class GoogleCloudStorageTestHelper {
      */
     public String getUniqueBucketName(String suffix) {
       checkArgument(
-          bucketPrefix.length() + suffix.length() <= 48,
-          "bucketPrefix and suffix can have cumulative length upto 48 chars to limit bucket name to 63 chars");
+              bucketPrefix.length() + suffix.length() <= 48,
+              "bucketPrefix and suffix can have cumulative length upto 48 chars to limit bucket name to 63 chars");
       return uniqueBucketPrefix + DELIMITER + suffix;
     }
 
@@ -357,13 +386,13 @@ public class GoogleCloudStorageTestHelper {
     public void cleanup(GoogleCloudStorage storage) throws IOException {
       Stopwatch storageStopwatch = Stopwatch.createStarted();
       logger.atInfo().log(
-          "Cleaning up GCS buckets that start with %s prefix or leaked", uniqueBucketPrefix);
+              "Cleaning up GCS buckets that start with %s prefix or leaked", uniqueBucketPrefix);
 
       List<String> bucketsToDelete = new ArrayList<>();
       for (GoogleCloudStorageItemInfo bucketInfo : storage.listBucketInfo()) {
         String bucketName = bucketInfo.getBucketName();
         if (bucketName.startsWith(bucketPrefix)
-            && (bucketName.startsWith(uniqueBucketPrefix)
+                && (bucketName.startsWith(uniqueBucketPrefix)
                 || bucketInfo.getCreationTime() < LEAKED_BUCKETS_CUTOFF_TIME)) {
           bucketsToDelete.add(bucketName);
         }
@@ -372,40 +401,40 @@ public class GoogleCloudStorageTestHelper {
       Collections.shuffle(bucketsToDelete);
       if (bucketsToDelete.size() > MAX_CLEANUP_BUCKETS) {
         logger.atInfo().log(
-            "GCS has %s buckets to cleanup. It's too many, will cleanup only %s buckets: %s",
-            bucketsToDelete.size(), MAX_CLEANUP_BUCKETS, bucketsToDelete);
+                "GCS has %s buckets to cleanup. It's too many, will cleanup only %s buckets: %s",
+                bucketsToDelete.size(), MAX_CLEANUP_BUCKETS, bucketsToDelete);
         bucketsToDelete = bucketsToDelete.subList(0, MAX_CLEANUP_BUCKETS);
       } else if (bucketsToDelete.size() > 0) {
         logger.atInfo().log(
-            "GCS has %s buckets to cleanup: %s", bucketsToDelete.size(), bucketsToDelete);
+                "GCS has %s buckets to cleanup: %s", bucketsToDelete.size(), bucketsToDelete);
       }
 
       List<GoogleCloudStorageItemInfo> objectsToDelete =
-          bucketsToDelete.parallelStream()
-              .flatMap(
-                  bucket -> {
-                    try {
-                      return storage
-                          .listObjectInfo(
-                              bucket,
-                              /* objectNamePrefix= */ null,
-                              ListObjectOptions.DEFAULT_FLAT_LIST)
-                          .stream();
-                    } catch (IOException e) {
-                      throw new RuntimeException(e);
-                    }
-                  })
-              .collect(toImmutableList());
+              bucketsToDelete.parallelStream()
+                      .flatMap(
+                              bucket -> {
+                                try {
+                                  return storage
+                                          .listObjectInfo(
+                                                  bucket,
+                                                  /* objectNamePrefix= */ null,
+                                                  ListObjectOptions.DEFAULT_FLAT_LIST)
+                                          .stream();
+                                } catch (IOException e) {
+                                  throw new RuntimeException(e);
+                                }
+                              })
+                      .collect(toImmutableList());
       logger.atInfo().log(
-          "GCS has %s objects to cleanup: %s", objectsToDelete.size(), objectsToDelete);
+              "GCS has %s objects to cleanup: %s", objectsToDelete.size(), objectsToDelete);
 
       try {
         storage.deleteObjects(
-            Lists.transform(objectsToDelete, GoogleCloudStorageItemInfo::getResourceId));
+                Lists.transform(objectsToDelete, GoogleCloudStorageItemInfo::getResourceId));
         storage.deleteBuckets(bucketsToDelete);
       } catch (IOException ioe) {
         logger.atWarning().withCause(ioe).log(
-            "Caught exception during GCS (%s) buckets cleanup", storage);
+                "Caught exception during GCS (%s) buckets cleanup", storage);
       }
 
       logger.atInfo().log("GCS cleaned up in %s seconds", storageStopwatch.elapsed().getSeconds());
@@ -425,24 +454,24 @@ public class GoogleCloudStorageTestHelper {
     public final T delegate;
 
     public TrackingStorageWrapper(
-        GoogleCloudStorageOptions options,
-        CheckedFunction2<TrackingHttpRequestInitializer, ImmutableList, T, IOException>
-            delegateStorageFn,
-        Credentials credentials)
-        throws IOException {
+            GoogleCloudStorageOptions options,
+            CheckedFunction2<TrackingHttpRequestInitializer, ImmutableList, T, IOException>
+                    delegateStorageFn,
+            Credentials credentials)
+            throws IOException {
       this.requestsTracker =
-          new TrackingHttpRequestInitializer(
-              new RetryHttpInitializer(credentials, options.toRetryHttpInitializerOptions()));
+              new TrackingHttpRequestInitializer(
+                      new RetryHttpInitializer(credentials, options.toRetryHttpInitializerOptions()));
       this.grpcRequestInterceptor = new TrackingGrpcRequestInterceptor();
       this.delegate =
-          delegateStorageFn.apply(this.requestsTracker, ImmutableList.of(grpcRequestInterceptor));
+              delegateStorageFn.apply(this.requestsTracker, ImmutableList.of(grpcRequestInterceptor));
     }
 
     public ImmutableList getAllRequestStrings() {
       return ImmutableList.builder()
-          .addAll(requestsTracker.getAllRequestStrings())
-          .addAll(grpcRequestInterceptor.getAllRequestStrings())
-          .build();
+              .addAll(requestsTracker.getAllRequestStrings())
+              .addAll(grpcRequestInterceptor.getAllRequestStrings())
+              .build();
     }
   }
 }


### PR DESCRIPTION
### Add APPLICATION_DEFAULT Authentication in `GoogleCloudStorageTestHelper` helping running gcsio layer integration tests locally. 

This PR refines how `GoogleCloudStorageTestHelper` handles authentication, offering more control and better fallbacks:

* **Explicit ADC Fallback:** If a JSON key file is missing, you can now explicitly enable Application Default Credentials (ADC) by setting `GCS_TEST_APPLICATION_DEFAULT_ENABLE=true`.
* **System Default Reliance:** If neither a key file nor the ADC environment variable is set, the helper will gracefully fall back to system defaults (e.g., Compute Engine credentials).

---

### Enabling ADC for Local Testing

To use ADC for your local tests, follow these steps:

1.  **Set up ADC:** On your command line, run `gcloud init` and then `gcloud auth application-default login`. This establishes your default credentials.

2.  **Point to Credentials:**
    * **On your command line:** Export the path to your credentials :
        ```bash
        export GOOGLE_APPLICATION_CREDENTIALS="KEY_PATH"
        ```
      For more on KEY_PATH and Credentials, refer to this link:

       [ADC setup] (https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment)



    * **For IntelliJ (or similar IDEs):** Go to your test file's run/debug configuration settings. Under **Environment Variables**, add:
        ```
        GCS_TEST_APPLICATION_DEFAULT_ENABLE=true
        ```

---