### PR TITLE
Fix copy for `gRPC` path 

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -159,7 +159,7 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
 
   // Request only object fields that are used in Hadoop FileStatus:
   // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
-  private static final String OBJECT_FIELDS = "bucket,name,size,updated";
+  private static final String OBJECT_FIELDS = "bucket,name,size,updated,generation";
   private static final ListFileOptions LIST_OPTIONS =
       ListFileOptions.DEFAULT.toBuilder().setFields(OBJECT_FIELDS).build();
   private static final String XATTR_KEY_PREFIX = "GHFS_XATTR_";

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
@@ -266,7 +266,8 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
 
   private class WriteObjectStreamTracer extends TrackingStreamTracer {
 
-    private String streamUploadId = null;
+    private static final String STREAM_UPLOAD_ID_NOT_FOUND = "STREAM_UPLOAD_ID_NOT_FOUND";
+    private String streamUploadId = STREAM_UPLOAD_ID_NOT_FOUND;
 
     WriteObjectStreamTracer(String rpcMethod) {
       super(rpcMethod);
@@ -301,7 +302,7 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
           "%s",
           toJson(
               getResponseTrackingInfo()
-                  .put(GoogleCloudStorageTracingFields.UPLOAD_ID.name, streamUploadId)
+                  .put(GoogleCloudStorageTracingFields.UPLOAD_ID.name, this.streamUploadId)
                   .put(
                       GoogleCloudStorageTracingFields.PERSISTED_SIZE.name,
                       response.getPersistedSize())
@@ -309,7 +310,7 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
     }
 
     private void updateUploadId(@Nonnull String uploadId) {
-      if (streamUploadId == null) {
+      if (streamUploadId.equals(STREAM_UPLOAD_ID_NOT_FOUND)) {
         this.streamUploadId = uploadId;
       }
       checkState(


### PR DESCRIPTION
Root Cause : In `gRPC` copy we have precontiion check for [generation matching](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/7f5f6bbb12eff18714dca88b511613819d832965/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java#L581) while in JSON [`copy`](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/7f5f6bbb12eff18714dca88b511613819d832965/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java#L1139) there is no such check. It was happeining because we were not fetching `generationId` during list leading to being set to null and giving error during read itself. 

Changes for the fix
- Added `generation` in OBJECT_FIELDS to fetch `generation` as well during list operation
- Updated the `GoogleCloudStorageClientGrpcTracingInterceptor` to not put null `uploadId` in list