### PR TITLE
[Bug fix] Correcting checksum calculation when received buffer is already moved

### DIFF
--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -317,6 +317,51 @@ public class GoogleCloudStorageTest {
     }
   }
 
+  /**
+   * Test success operation of GoogleCloudStorage.create(2) with checksum compare when the buffer is
+   * moved.
+   */
+  @Test
+  public void testCreateObjectWithChecksumMatchSeekingbuffer() throws Exception {
+    byte[] testData = {0x01, 0x02, 0x03, 0x05, 0x08, 0x09, 0x10, 0x05, 0x02, 0x01};
+
+    ByteBuffer buf = ByteBuffer.wrap(testData);
+    // moving the buffer position.
+    buf.position(1);
+
+    Hasher testCrc32cHasher = Hashing.crc32c().newHasher();
+    testCrc32cHasher.putBytes(buf);
+    String testCrc32c =
+        BaseEncoding.base64().encode(Ints.toByteArray(testCrc32cHasher.hash().asInt()));
+    // reset the position to 1.
+    buf.position(1);
+
+    AsyncWriteChannelOptions writeOptions =
+        AsyncWriteChannelOptions.builder().setRollingChecksumEnabled(true).build();
+
+    MockHttpTransport transport =
+        mockTransport(
+            resumableUploadResponse(BUCKET_NAME, OBJECT_NAME),
+            jsonDataResponse(
+                newStorageObject(BUCKET_NAME, OBJECT_NAME)
+                    .setSize(BigInteger.valueOf(testData.length - 1))
+                    .setCrc32c(testCrc32c)));
+
+    GoogleCloudStorage gcs =
+        mockedGcsImpl(
+            GCS_OPTIONS.toBuilder().setWriteChannelOptions(writeOptions).build(),
+            transport,
+            trackingRequestInitializerWithRetries);
+
+    try (WritableByteChannel writeChannel =
+        gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME, 1))) {
+      assertThat(writeChannel.isOpen()).isTrue();
+      System.out.println(buf.remaining());
+      int totalBytesWritten = writeChannel.write(buf);
+      assertThat(totalBytesWritten).isEqualTo(testData.length - 1);
+    }
+  }
+
   /** Test failed operation of GoogleCloudStorage.create(2) with checksum compare. */
   @Test
   public void testCreateObjectThrowsExceptionOnChecksumMismatch() throws Exception {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -322,7 +322,7 @@ public class GoogleCloudStorageTest {
    * moved.
    */
   @Test
-  public void testCreateObjectWithChecksumMatchSeekingbuffer() throws Exception {
+  public void testCreateObjectWithChecksumMatchSeekingBuffer() throws Exception {
     byte[] testData = {0x01, 0x02, 0x03, 0x05, 0x08, 0x09, 0x10, 0x05, 0x02, 0x01};
 
     ByteBuffer buf = ByteBuffer.wrap(testData);
@@ -333,7 +333,7 @@ public class GoogleCloudStorageTest {
     testCrc32cHasher.putBytes(buf);
     String testCrc32c =
         BaseEncoding.base64().encode(Ints.toByteArray(testCrc32cHasher.hash().asInt()));
-    // reset the position to 1.
+    // reset the position to 1 after putBytes.
     buf.position(1);
 
     AsyncWriteChannelOptions writeOptions =
@@ -356,7 +356,6 @@ public class GoogleCloudStorageTest {
     try (WritableByteChannel writeChannel =
         gcs.create(new StorageResourceId(BUCKET_NAME, OBJECT_NAME, 1))) {
       assertThat(writeChannel.isOpen()).isTrue();
-      System.out.println(buf.remaining());
       int totalBytesWritten = writeChannel.write(buf);
       assertThat(totalBytesWritten).isEqualTo(testData.length - 1);
     }

--- a/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
@@ -144,7 +144,7 @@ public abstract class AbstractGoogleAsyncWriteChannel<T> implements WritableByte
       ByteBuffer src, int writtenBytes, int originalPosition) {
     ByteBuffer duplicateBuffer = src.duplicate();
     duplicateBuffer.position(originalPosition);
-    // Only calculate hash for written bytes.
+    // Only calculate hash for written bytes offset from the original position.
     duplicateBuffer.limit(originalPosition + writtenBytes);
     cumulativeCrc32cHasher.putBytes(duplicateBuffer);
   }

--- a/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/AbstractGoogleAsyncWriteChannel.java
@@ -145,7 +145,7 @@ public abstract class AbstractGoogleAsyncWriteChannel<T> implements WritableByte
     ByteBuffer duplicateBuffer = src.duplicate();
     duplicateBuffer.position(originalPosition);
     // Only calculate hash for written bytes.
-    duplicateBuffer.limit(writtenBytes);
+    duplicateBuffer.limit(originalPosition + writtenBytes);
     cumulativeCrc32cHasher.putBytes(duplicateBuffer);
   }
 


### PR DESCRIPTION
Identified an issue where checksum calculations could be giving false positives. However Hadoop always seems to be writing at buffer starting a 0, so we didn't encounter this problem in our testing(for Hadoop CLI, Spark and Trino). I believe this fix is more critical for clients directly using gcsio e.g. Apache Beam.

testing done,
- Write and append from Hadoop CLI
- Added a unit test for simulating this scenario

I will backport this change to release branches as well.

note: reuploadFromCache could be broken for long time due to similar issue because it resets the buffer at position 0 via buffer.flip() without checking if original write was triggered with a moved buffer. It needs to be handled separately.