### PR TITLE
Avoid NullPointerException when DeleteFolderOperation is timed out

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
@@ -116,8 +116,9 @@ class DeleteFolderOperation {
     try {
       FolderInfo folderInfo = folderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES);
       if (folderInfo == null) {
-        // Throwing an exception here because client side timeouts can cause
-        throw new InterruptedException("Timed out while getting an folder from blocking queue");
+        // Throwing an InterruptedException here because client side timeouts can cause folderInfo
+        // to be null.
+        throw new InterruptedException("Timed out while getting an folder from blocking queue.");
       }
       return folderInfo;
     } catch (Exception e) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
@@ -125,11 +125,10 @@ class DeleteFolderOperation {
   }
 
   /** Gets the head from the blocking queue */
-  private FolderInfo getElementFromBlockingQueue()
-      throws InterruptedException, IllegalStateException {
+  private FolderInfo getElementFromBlockingQueue() throws InterruptedException {
     try {
       return folderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES);
-    } catch (InterruptedException | IllegalStateException e) {
+    } catch (InterruptedException e) {
       logger.atSevere().log(
           "Encountered exception while getting an element from queue in HN enabled bucket : %s", e);
       throw e;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
@@ -95,11 +95,18 @@ class DeleteFolderOperation {
         // Queue the deletion request
         queueSingleFolderDelete(folderToDelete, /* attempt */ 1);
       }
-    } catch (InterruptedException | IllegalStateException e) {
+    } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException(
           String.format(
-              "Received exception while deletion of folder resource : %s", e.getMessage()),
+              "Received InterruptedException while deletion of folder resource : %s",
+              e.getMessage()),
+          e);
+    } catch (IllegalStateException e) {
+      throw new IOException(
+          String.format(
+              "Received IllegalStateException while deletion of folder resource : %s",
+              e.getMessage()),
           e);
     }
     batchExecutorShutdown();

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
@@ -121,7 +121,7 @@ class DeleteFolderOperation {
         throw new InterruptedException("Timed out while getting an folder from blocking queue.");
       }
       return folderInfo;
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
       logger.atSevere().log(
           "Encountered exception while getting an element from queue in HN enabled bucket : %s", e);
       throw e;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
@@ -94,8 +94,7 @@ class DeleteFolderOperation {
       Thread.currentThread().interrupt();
       throw new IOException(
           String.format(
-              "Recieved thread interruption exception while deletion of folder resource : %s",
-              e.getMessage()),
+              "Received exception while deletion of folder resource : %s", e.getMessage()),
           e);
     }
     batchExecutorShutdown();
@@ -128,7 +127,7 @@ class DeleteFolderOperation {
       if (folderInfo == null) {
         // Throwing an IllegalStateException here because client side timeouts can cause folderInfo
         // to be null.
-        throw new IllegalStateException("Timed out while getting an folder from blocking queue.");
+        throw new IllegalStateException("Timed out while getting a folder from blocking queue.");
       }
       return folderInfo;
     } catch (InterruptedException | IllegalStateException e) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperation.java
@@ -114,8 +114,13 @@ class DeleteFolderOperation {
   /** Gets the head from the blocking queue */
   public FolderInfo getElementFromBlockingQueue() throws InterruptedException {
     try {
-      return folderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES);
-    } catch (InterruptedException e) {
+      FolderInfo folderInfo = folderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES);
+      if (folderInfo == null) {
+        // Throwing an exception here because client side timeouts can cause
+        throw new InterruptedException("Timed out while getting an folder from blocking queue");
+      }
+      return folderInfo;
+    } catch (Exception e) {
       logger.atSevere().log(
           "Encountered exception while getting an element from queue in HN enabled bucket : %s", e);
       throw e;

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -797,15 +797,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
         new DeleteFolderOperation(folders, storageOptions, lazyGetStorageControlClient());
     try (ITraceOperation to = TraceOperation.addToExistingTrace(traceContext)) {
       deleteFolderOperation.performDeleteOperation();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IOException(
-          String.format(
-              "Recieved thread interruption exception while deletion of folder resource : %s",
-              e.getMessage()),
-          e);
     }
-
     if (!deleteFolderOperation.encounteredNoExceptions()) {
       GoogleCloudStorageEventBus.postOnException();
       throw GoogleCloudStorageExceptions.createCompositeException(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
@@ -118,7 +118,7 @@ public class DeleteFolderOperationTest {
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo(
-            "Received exception while deletion of folder resource : Timed out while getting a folder from blocking queue.");
+            "Received IllegalStateException while deletion of folder resource : Timed out while getting a folder from blocking queue.");
   }
 
   private void setMockFolderDeleteBlockingQueue(DeleteFolderOperation deleteFolderOperation)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
@@ -103,25 +103,6 @@ public class DeleteFolderOperationTest {
   }
 
   @Test
-  public void checkExceptionTypeWhenPollTimesOutForGetElementFromBlockingQueue() throws Exception {
-    List<FolderInfo> foldersToDelete = new LinkedList<>();
-    addFolders(foldersToDelete, "test-folder");
-
-    DeleteFolderOperation deleteFolderOperation =
-        new DeleteFolderOperation(foldersToDelete, GoogleCloudStorageOptions.DEFAULT, null);
-    setMockFolderDeleteBlockingQueue(deleteFolderOperation);
-
-    when(mockFolderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES)).thenReturn(null);
-
-    IllegalStateException exception =
-        assertThrows(
-            IllegalStateException.class, () -> deleteFolderOperation.getElementFromBlockingQueue());
-    assertThat(exception)
-        .hasMessageThat()
-        .isEqualTo("Timed out while getting a folder from blocking queue.");
-  }
-
-  @Test
   public void checkExceptionTypeWhenPollTimesOutForPerformDeleteOperation() throws Exception {
     List<FolderInfo> foldersToDelete = new LinkedList<>();
     addFolders(foldersToDelete, "test-folder");

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
@@ -103,7 +103,7 @@ public class DeleteFolderOperationTest {
   }
 
   @Test
-  public void checkExceptionTypeWhenPollTimesOut() throws Exception {
+  public void checkExceptionTypeWhenPollTimesOutForGetElementFromBlockingQueue() throws Exception {
     List<FolderInfo> foldersToDelete = new LinkedList<>();
     addFolders(foldersToDelete, "test-folder");
 
@@ -118,7 +118,26 @@ public class DeleteFolderOperationTest {
             IllegalStateException.class, () -> deleteFolderOperation.getElementFromBlockingQueue());
     assertThat(exception)
         .hasMessageThat()
-        .isEqualTo("Timed out while getting an folder from blocking queue.");
+        .isEqualTo("Timed out while getting a folder from blocking queue.");
+  }
+
+  @Test
+  public void checkExceptionTypeWhenPollTimesOutForPerformDeleteOperation() throws Exception {
+    List<FolderInfo> foldersToDelete = new LinkedList<>();
+    addFolders(foldersToDelete, "test-folder");
+
+    DeleteFolderOperation deleteFolderOperation =
+        new DeleteFolderOperation(foldersToDelete, GoogleCloudStorageOptions.DEFAULT, null);
+    setMockFolderDeleteBlockingQueue(deleteFolderOperation);
+
+    when(mockFolderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES)).thenReturn(null);
+
+    IOException exception =
+        assertThrows(IOException.class, () -> deleteFolderOperation.performDeleteOperation());
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Received exception while deletion of folder resource : Timed out while getting a folder from blocking queue.");
   }
 
   private void setMockFolderDeleteBlockingQueue(DeleteFolderOperation deleteFolderOperation)

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
@@ -121,7 +121,7 @@ public class DeleteFolderOperationTest {
   }
 
   private void setMockFolderDeleteBlockingQueue(DeleteFolderOperation deleteFolderOperation)
-      throws Exception {
+      throws NoSuchFieldException, IllegalAccessException {
     Field queueField = DeleteFolderOperation.class.getDeclaredField("folderDeleteBlockingQueue");
     queueField.setAccessible(true);
     queueField.set(deleteFolderOperation, mockFolderDeleteBlockingQueue);

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/DeleteFolderOperationTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.storage.control.v2.StorageControlClient;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public class DeleteFolderOperationTest {
   }
 
   @Test
-  public void checkDeletionOrderForHnBucketBalancedFolders() throws InterruptedException {
+  public void checkDeletionOrderForHnBucketBalancedFolders() throws IOException {
     String folderString = "test-folder-start/";
     List<FolderInfo> foldersToDelete = new LinkedList<>();
 
@@ -77,7 +78,7 @@ public class DeleteFolderOperationTest {
   }
 
   @Test
-  public void checkDeletionOrderForHnBucketSkewedFolders() throws InterruptedException {
+  public void checkDeletionOrderForHnBucketSkewedFolders() throws IOException {
     String folderString = "test-folder-start/";
     List<FolderInfo> foldersToDelete = new LinkedList<>();
 
@@ -112,9 +113,9 @@ public class DeleteFolderOperationTest {
 
     when(mockFolderDeleteBlockingQueue.poll(1, TimeUnit.MINUTES)).thenReturn(null);
 
-    InterruptedException exception =
+    IllegalStateException exception =
         assertThrows(
-            InterruptedException.class, () -> deleteFolderOperation.getElementFromBlockingQueue());
+            IllegalStateException.class, () -> deleteFolderOperation.getElementFromBlockingQueue());
     assertThat(exception)
         .hasMessageThat()
         .isEqualTo("Timed out while getting an folder from blocking queue.");


### PR DESCRIPTION
In the current Implementation of `DeleteFolderOperation`, client side timeouts can cause `NullPointerException` which is often not caught by underlying Applications(e.g. Spark) and causes it to crash. We should be throwing a transient error in these scenarios i.e. `InterruptedException` in this case which eventually causes `IOexception` in the Hadoop operation.

It helps underlying frameworks/applications to retry in case of these failures instead of crashing with a fatal error.