### PR TITLE
Backport changes to enable Application Default during testing in branch 3.1.x 

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationHelper.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationHelper.java
@@ -48,10 +48,17 @@ public final class GoogleHadoopFileSystemIntegrationHelper {
     TestConfiguration testConf = TestConfiguration.getInstance();
     String projectId = checkNotNull(testConf.getProjectId(), ENV_VAR_MSG_FMT, GCS_TEST_PROJECT_ID);
     config.set("fs.gs.project.id", projectId);
+
+    Boolean isApplicationDefaultModeEnabled =
+        TestConfiguration.getInstance().isApplicationDefaultModeEnabled();
+
     if (testConf.getServiceAccountJsonKeyFile() != null) {
       config.setEnum("fs.gs.auth.type", AuthenticationType.SERVICE_ACCOUNT_JSON_KEYFILE);
       config.set(
           "fs.gs.auth.service.account.json.keyfile", testConf.getServiceAccountJsonKeyFile());
+
+    } else if (isApplicationDefaultModeEnabled) {
+      config.setEnum("fs.gs.auth.type", AuthenticationType.APPLICATION_DEFAULT);
     }
 
     config.setBoolean("fs.gs.grpc.directpath.enable", testConf.isDirectPathPreferred());

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/TestConfiguration.java
@@ -23,6 +23,9 @@ public abstract class TestConfiguration {
 
   public static final String GCS_TEST_DIRECT_PATH_PREFERRED = "GCS_TEST_DIRECT_PATH_PREFERRED";
 
+  public static final String GCS_TEST_APPLICATION_DEFAULT_ENABLE =
+      "GCS_TEST_APPLICATION_DEFAULT_ENABLE";
+
   /** Environment-based test configuration. */
   public static class EnvironmentBasedTestConfiguration extends TestConfiguration {
     @Override
@@ -33,6 +36,15 @@ public abstract class TestConfiguration {
     @Override
     public String getServiceAccountJsonKeyFile() {
       return System.getenv(GCS_TEST_JSON_KEYFILE);
+    }
+
+    @Override
+    public boolean isApplicationDefaultModeEnabled() {
+      String applicationDefaultModeEnable = System.getenv(GCS_TEST_APPLICATION_DEFAULT_ENABLE);
+      if (applicationDefaultModeEnable == null) {
+        return false;
+      }
+      return (Boolean.parseBoolean(applicationDefaultModeEnable));
     }
 
     @Override
@@ -57,6 +69,8 @@ public abstract class TestConfiguration {
   public abstract String getProjectId();
 
   public abstract String getServiceAccountJsonKeyFile();
+
+  public abstract boolean isApplicationDefaultModeEnabled();
 
   public abstract boolean isDirectPathPreferred();
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/integration/GoogleCloudStorageTestHelper.java
@@ -29,6 +29,7 @@ import com.google.api.services.storage.StorageScopes;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageClientImpl;
@@ -101,7 +102,11 @@ public class GoogleCloudStorageTestHelper {
     String serviceAccountJsonKeyFile =
         TestConfiguration.getInstance().getServiceAccountJsonKeyFile();
     if (serviceAccountJsonKeyFile == null) {
-      return ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
+      Boolean isApplicationDefaultModeEnabled =
+          TestConfiguration.getInstance().isApplicationDefaultModeEnabled();
+      return isApplicationDefaultModeEnabled
+          ? GoogleCredentials.getApplicationDefault()
+          : ComputeEngineCredentials.create().createScoped(StorageScopes.CLOUD_PLATFORM);
     }
     try (FileInputStream fis = new FileInputStream(serviceAccountJsonKeyFile)) {
       return ServiceAccountCredentials.fromStream(fis).createScoped(StorageScopes.CLOUD_PLATFORM);


### PR DESCRIPTION
* Enable Application Default Credential for running the integration tests locally.
* Original [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1360) for gcs
* Original [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1361) for gcsio