### PR TITLE
Fixing flaky integration tests

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -219,6 +219,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
           helper);
     } finally {
       googleHadoopFileSystem.delete(new Path(initUri));
+      googleHadoopFileSystem.close();
     }
   }
 
@@ -255,6 +256,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
           helper);
     } finally {
       googleHadoopFileSystem.delete(new Path(initUri));
+      googleHadoopFileSystem.close();
     }
   }
 
@@ -374,10 +376,12 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     fs.initialize(new URI("gs://test/init-uri"), config);
 
     assertThat(fs.getCanonicalServiceName()).isEqualTo(fs.delegationTokens.getService().toString());
+
+    fs.close();
   }
 
   @Test
-  public void open_throwsExceptionWhenHadoopPathNull() {
+  public void open_throwsExceptionWhenHadoopPathNull() throws IOException {
     GoogleHadoopFileSystem myGhfs = new GoogleHadoopFileSystem();
     IllegalArgumentException exception =
         assertThrows(IllegalArgumentException.class, () -> myGhfs.open((Path) null, 1));
@@ -941,6 +945,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     assertThat(fs.getDefaultBlockSize()).isEqualTo(blockSize);
     assertThat(fs.initUri).isEqualTo(initUri);
     assertThat(fs.getWorkingDirectory().toUri().getAuthority()).isEqualTo(rootBucketName);
+
+    fs.close();
   }
 
   @Test
@@ -951,7 +957,10 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     config.unset("fs.gs.project.id");
 
     URI gsUri = new Path("gs://foo").toUri();
-    new GoogleHadoopFileSystem().initialize(gsUri, config);
+    GoogleHadoopFileSystem ghfs = new GoogleHadoopFileSystem();
+    ghfs.initialize(gsUri, config);
+
+    ghfs.close();
   }
 
   @Test
@@ -1062,6 +1071,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     assertThat(fs.initUri).isEqualTo(initUri);
 
     assertThat(fs.getWorkingDirectory().toUri().getAuthority()).isEqualTo(initUri.getAuthority());
+
+    fs.close();
   }
 
   /** Validates success path when there is a root bucket but no system bucket is specified. */
@@ -1081,6 +1092,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     // Verify that config settings were set correctly.
     assertThat(fs.initUri).isEqualTo(initUri);
+
+    fs.close();
   }
 
   @Test
@@ -1633,6 +1646,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     // Cleanup.
     assertThat(ghfs.delete(filePath, /* recursive= */ true)).isTrue();
+
+    myGhfs.close();
   }
 
   /** Test getFileStatus() uses the user reported by UGI */
@@ -1655,6 +1670,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     // Cleanup.
     assertThat(ghfs.delete(filePath, true)).isTrue();
+
+    myGhfs.close();
   }
 
   @Test
@@ -2165,6 +2182,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     } else {
       assertThat(thrown).hasCauseThat().hasMessageThat().contains("Invalid Credentials");
     }
+
+    ghfs.close();
   }
 
   @Test
@@ -2184,6 +2203,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     IOException thrown = assertThrows(IOException.class, () -> ghfs.listStatus(gcsPath));
     HttpResponseException httpException = ApiErrorExtractor.getHttpResponseException(thrown);
     assertThat(httpException).hasMessageThat().startsWith("401 Unauthorized");
+
+    ghfs.close();
   }
 
   @Test
@@ -2206,6 +2227,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     IOException thrown = assertThrows(IOException.class, () -> ghfs.listStatus(gcsPath));
     HttpResponseException httpException = ApiErrorExtractor.getHttpResponseException(thrown);
     assertThat(httpException).hasMessageThat().startsWith("401 Unauthorized");
+
+    ghfs.close();
   }
 
   @Test
@@ -2228,6 +2251,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     IOException thrown = assertThrows(IOException.class, () -> ghfs.listStatus(gcsPath));
     HttpResponseException httpException = ApiErrorExtractor.getHttpResponseException(thrown);
     assertThat(httpException).hasMessageThat().startsWith("401 Unauthorized");
+
+    ghfs.close();
   }
 
   @Test
@@ -2254,6 +2279,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     IOException thrown = assertThrows(IOException.class, () -> ghfs.listStatus(gcsPath));
     HttpResponseException httpException = ApiErrorExtractor.getHttpResponseException(thrown);
     assertThat(httpException).hasMessageThat().startsWith("401 Unauthorized");
+
+    ghfs.close();
   }
 
   @Test
@@ -2281,6 +2308,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     IOException thrown = assertThrows(IOException.class, () -> ghfs.listStatus(gcsPath));
     HttpResponseException httpException = ApiErrorExtractor.getHttpResponseException(thrown);
     assertThat(httpException).hasMessageThat().startsWith("401 Unauthorized");
+
+    ghfs.close();
   }
 
   @Test
@@ -2297,6 +2326,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     URI gsUri = new URI("gs://foobar/");
     GoogleHadoopFileSystem ghfs = new GoogleHadoopFileSystem();
     ghfs.initialize(gsUri, config);
+
+    ghfs.close();
   }
 
   @Test
@@ -2387,6 +2418,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
       assertThat(getSubFolderCount(googleHadoopFileSystem, bucketPath + "/A/")).isEqualTo(0);
     } finally {
       googleHadoopFileSystem.delete(new Path(bucketPath));
+      googleHadoopFileSystem.close();
     }
   }
 
@@ -2416,6 +2448,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
         "The specified bucket does not exist : " + bucketPath,
         com.google.api.gax.rpc.NotFoundException.class,
         () -> assertThat(getSubFolderCount(googleHadoopFileSystem, bucketPath)).isEqualTo(0));
+
+    googleHadoopFileSystem.close();
   }
 
   @Test
@@ -2444,6 +2478,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
       assertThat(getSubFolderCount(googleHadoopFileSystem, bucketPath + "/B/")).isEqualTo(1);
     } finally {
       googleHadoopFileSystem.delete(new Path(bucketPath));
+      googleHadoopFileSystem.close();
     }
   }
 
@@ -2479,6 +2514,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
       assertThat(getSubFolderCount(googleHadoopFileSystem, bucketPath + "/A/")).isEqualTo(0);
     } finally {
       googleHadoopFileSystem.delete(new Path(bucketPath));
+      googleHadoopFileSystem.close();
     }
   }
 
@@ -2664,6 +2700,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
             .build();
 
     verifyMetrics(stats, expected, stopwatch.elapsed().toMillis());
+
+    myghfs.close();
   }
 
   @Test
@@ -2687,6 +2725,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     // tracked.
     // It will be fixed in a separate change
     runTest(subdirPath, myghfs, stats);
+
+    myghfs.close();
   }
 
   @Test
@@ -2707,9 +2747,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
         .parallel()
         .forEach(
             i -> {
-              try {
+              try (GoogleHadoopFileSystem myghfs = new GoogleHadoopFileSystem()) {
                 Path subdirPath = new Path(parentPath, "foo-subdir" + i);
-                GoogleHadoopFileSystem myghfs = new GoogleHadoopFileSystem();
                 myghfs.initialize(subdirPath.toUri(), config);
                 runTest(subdirPath, myghfs, stats);
               } catch (IOException e) {
@@ -2902,6 +2941,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     Set<String> metrics = getDurationConnectorMetrics(stats);
 
     assertEquals(EXPECTED_DURATION_METRICS, metrics);
+
+    myghfs.close();
   }
 
   private Set<String> getDurationConnectorMetrics(GhfsGlobalStorageStatistics stats) {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -381,7 +381,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   @Test
-  public void open_throwsExceptionWhenHadoopPathNull() throws IOException {
+  public void open_throwsExceptionWhenHadoopPathNull() {
     GoogleHadoopFileSystem myGhfs = new GoogleHadoopFileSystem();
     IllegalArgumentException exception =
         assertThrows(IllegalArgumentException.class, () -> myGhfs.open((Path) null, 1));


### PR DESCRIPTION
RCA - 

In many Integration tests in [GoogleHadoopFileSystemIntegrationTest.java](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java), GoogleHadoopFileSystem is initialized but isn't closed properly. This has potential to cause resource leaks. This problem gets amplified significantly in case of HNS because it uses `StorgeControlClient` which  gets instantiated in `lazyGetStorageControlClient` and never gets closed. Since `StorageControlClient` uses  grpc which can create only a limited number of [ManagedChannels](https://github.com/grpc/grpc-java/blob/94532a6b56076c56fb9278e9195bba1190a9260d/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java#L102) and causes [failures](https://screenshot.googleplex.com/5LmqEx5kjHGBR4N) when it cannot create a new channel.