### PR TITLE
Conscrypt jar

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -108,6 +108,10 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.conscrypt</groupId>
+      <artifactId>conscrypt-openjdk-uber</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -168,6 +172,178 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <transformers>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <filter><artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+                <!-- minimizeJar breaks all the dynamic load hacks; add them explicitly -->
+                <filter>
+                  <artifact>com.google.auth:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.grpc:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.opencensus:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>*.json</exclude>
+                    <exclude>google/**</exclude>
+                    <exclude>grpc/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <artifactSet>
+                <includes>
+                  <include>com.google.api</include>
+                  <include>com.google.api-client</include>
+                  <include>com.google.api.grpc</include>
+                  <include>com.google.apis</include>
+                  <include>com.google.auth</include>
+                  <include>com.google.cloud</include>
+                  <include>com.google.cloud.bigdataoss</include>
+                  <include>com.google.cloud.grpc</include>
+                  <include>com.google.cloud.http</include>
+                  <include>com.google.cloud.opentelemetry</include>
+                  <include>com.google.flogger</include>
+                  <include>com.google.code.gson</include>
+                  <include>com.google.guava</include>
+                  <include>com.google.http-client</include>
+                  <include>com.google.oauth-client</include>
+                  <include>com.google.protobuf</include>
+                  <include>com.google.re2j</include>
+                  <include>com.google.storage.v2</include>
+                  <include>com.lmax</include>
+                  <include>io.grpc</include>
+                  <include>org.conscrypt</include>
+                  <include>io.opencensus</include>
+                  <include>io.opentelemetry</include>
+                  <include>io.opentelemetry.contrib</include>
+                  <include>io.opentelemetry.semconv</include>
+                  <include>io.perfmark</include>
+                  <include>org.apache.httpcomponents</include>
+                  <include>org.threeten:threetenbp</include>
+                </includes>
+              </artifactSet>
+              <minimizeJar>true</minimizeJar>
+              <relocations>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.com</shadedPattern>
+                  <includes>
+                    <include>com.google.api.**</include>
+                    <include>com.google.api.gax.**</include>
+                    <include>com.google.auth.**</include>
+                    <include>com.google.cloud.*</include>
+                    <include>com.google.cloud.audit.**</include>
+                    <include>com.google.cloud.grpc.**</include>
+                    <include>com.google.cloud.hadoop.gcsio.**</include>
+                    <include>com.google.cloud.hadoop.util.**</include>
+                    <include>com.google.cloud.http.**</include>
+                    <include>com.google.cloud.monitoring.**</include>
+                    <include>com.google.cloud.opentelemetry.**</include>
+                    <include>com.google.cloud.spi.**</include>
+                    <include>com.google.cloud.storage.**</include>
+                    <include>com.google.common.**</include>
+                    <include>com.google.geo.**</include>
+                    <include>com.google.gson.**</include>
+                    <include>com.google.google.storage.**</include>
+                    <include>com.google.iam.**</include>
+                    <include>com.google.logging.**</include>
+                    <include>com.google.longrunning.**</include>
+                    <include>com.google.monitoring.**</include>
+                    <include>com.google.protobuf.**</include>
+                    <include>com.google.re2j.**</include>
+                    <include>com.google.rpc.**</include>
+                    <include>com.google.storage.**</include>
+                    <include>com.google.thirdparty.**</include>
+                    <include>com.google.type.**</include>
+                    <include>com.lmax.disruptor.**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>com.google.cloud.hadoop.util.AccessTokenProvider</exclude>
+                    <exclude>com.google.cloud.hadoop.util.AccessTokenProvider$AccessToken</exclude>
+                    <exclude>com.google.cloud.hadoop.util.AccessTokenProvider$AccessTokenType</exclude>
+                    <exclude>com.google.cloud.hadoop.util.AccessBoundary</exclude>
+                    <exclude>com.google.cloud.hadoop.util.AccessBoundary$Action</exclude>
+                    <exclude>com.google.cloud.hadoop.util.AutoValue_AccessBoundary</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>org</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.org</shadedPattern>
+                  <includes>
+                    <include>org.apache.http.**</include>
+                    <include>org.conscrypt.**</include>
+                    <include>org.threeten.**</include>
+                  </includes>
+                </relocation>
+                <!-- Take special care of grpc-netty-shaded, it uses the package
+                     io.grpc.netty.shaded.io.grpc.netty, which will cause the
+                     ServicesResourceTransformer to replace both occurrences of io.grpc -->
+                <relocation>
+                  <pattern>io.grpc.netty.shaded</pattern>
+                  <shadedPattern>
+                    com.google.cloud.hadoop.repackaged.gcs.io.grpc.netty.shaded
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io</pattern>
+                  <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.io</shadedPattern>
+                  <includes>
+                    <include>io.grpc.**</include>
+                    <include>io.opencensus.**</include>
+                    <include>io.opentelemetry.**</include>
+                    <include>io.perfmark.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/io_grpc_netty_shaded_</pattern>
+                  <shadedPattern>
+                    META-INF/native/com_google_cloud_hadoop_repackaged_gcs_io_grpc_netty_shaded_
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/libio_grpc_netty_shaded_</pattern>
+                  <shadedPattern>
+                    META-INF/native/libcom_google_cloud_hadoop_repackaged_gcs_io_grpc_netty_shaded_
+                  </shadedPattern>
+                </relocation>
+              </relocations>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+            </configuration>
+          </execution>
+          <execution>
+            <id>shade-without-conscrypt</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedClassifierName>shaded-without-conscrypt</shadedClassifierName>
               <transformers>
                 <transformer
                     implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
@@ -241,36 +417,6 @@
                 <relocation>
                   <pattern>com</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.com</shadedPattern>
-                  <includes>
-                    <include>com.google.api.**</include>
-                    <include>com.google.api.gax.**</include>
-                    <include>com.google.auth.**</include>
-                    <include>com.google.cloud.*</include>
-                    <include>com.google.cloud.audit.**</include>
-                    <include>com.google.cloud.grpc.**</include>
-                    <include>com.google.cloud.hadoop.gcsio.**</include>
-                    <include>com.google.cloud.hadoop.util.**</include>
-                    <include>com.google.cloud.http.**</include>
-                    <include>com.google.cloud.monitoring.**</include>
-                    <include>com.google.cloud.opentelemetry.**</include>
-                    <include>com.google.cloud.spi.**</include>
-                    <include>com.google.cloud.storage.**</include>
-                    <include>com.google.common.**</include>
-                    <include>com.google.geo.**</include>
-                    <include>com.google.gson.**</include>
-                    <include>com.google.google.storage.**</include>
-                    <include>com.google.iam.**</include>
-                    <include>com.google.logging.**</include>
-                    <include>com.google.longrunning.**</include>
-                    <include>com.google.monitoring.**</include>
-                    <include>com.google.protobuf.**</include>
-                    <include>com.google.re2j.**</include>
-                    <include>com.google.rpc.**</include>
-                    <include>com.google.storage.**</include>
-                    <include>com.google.thirdparty.**</include>
-                    <include>com.google.type.**</include>
-                    <include>com.lmax.disruptor.**</include>
-                  </includes>
                   <excludes>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider</exclude>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider$AccessToken</exclude>
@@ -288,36 +434,9 @@
                     <include>org.threeten.**</include>
                   </includes>
                 </relocation>
-                <!-- Take special care of grpc-netty-shaded, it uses the package
-                     io.grpc.netty.shaded.io.grpc.netty, which will cause the
-                     ServicesResourceTransformer to replace both occurrences of io.grpc -->
-                <relocation>
-                  <pattern>io.grpc.netty.shaded</pattern>
-                  <shadedPattern>
-                    com.google.cloud.hadoop.repackaged.gcs.io.grpc.netty.shaded
-                  </shadedPattern>
-                </relocation>
                 <relocation>
                   <pattern>io</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.io</shadedPattern>
-                  <includes>
-                    <include>io.grpc.**</include>
-                    <include>io.opencensus.**</include>
-                    <include>io.opentelemetry.**</include>
-                    <include>io.perfmark.**</include>
-                  </includes>
-                </relocation>
-                <relocation>
-                  <pattern>META-INF/native/io_grpc_netty_shaded_</pattern>
-                  <shadedPattern>
-                    META-INF/native/com_google_cloud_hadoop_repackaged_gcs_io_grpc_netty_shaded_
-                  </shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>META-INF/native/libio_grpc_netty_shaded_</pattern>
-                  <shadedPattern>
-                    META-INF/native/libcom_google_cloud_hadoop_repackaged_gcs_io_grpc_netty_shaded_
-                  </shadedPattern>
                 </relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -108,10 +108,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.conscrypt</groupId>
-      <artifactId>conscrypt-openjdk-uber</artifactId>
-    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -339,7 +339,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedClassifierName>shaded-without-conscrypt</shadedClassifierName>
               <transformers>
                 <transformer
                     implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
@@ -413,6 +412,36 @@
                 <relocation>
                   <pattern>com</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.com</shadedPattern>
+                  <includes>
+                    <include>com.google.api.**</include>
+                    <include>com.google.api.gax.**</include>
+                    <include>com.google.auth.**</include>
+                    <include>com.google.cloud.*</include>
+                    <include>com.google.cloud.audit.**</include>
+                    <include>com.google.cloud.grpc.**</include>
+                    <include>com.google.cloud.hadoop.gcsio.**</include>
+                    <include>com.google.cloud.hadoop.util.**</include>
+                    <include>com.google.cloud.http.**</include>
+                    <include>com.google.cloud.monitoring.**</include>
+                    <include>com.google.cloud.opentelemetry.**</include>
+                    <include>com.google.cloud.spi.**</include>
+                    <include>com.google.cloud.storage.**</include>
+                    <include>com.google.common.**</include>
+                    <include>com.google.geo.**</include>
+                    <include>com.google.gson.**</include>
+                    <include>com.google.google.storage.**</include>
+                    <include>com.google.iam.**</include>
+                    <include>com.google.logging.**</include>
+                    <include>com.google.longrunning.**</include>
+                    <include>com.google.monitoring.**</include>
+                    <include>com.google.protobuf.**</include>
+                    <include>com.google.re2j.**</include>
+                    <include>com.google.rpc.**</include>
+                    <include>com.google.storage.**</include>
+                    <include>com.google.thirdparty.**</include>
+                    <include>com.google.type.**</include>
+                    <include>com.lmax.disruptor.**</include>
+                  </includes>
                   <excludes>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider</exclude>
                     <exclude>com.google.cloud.hadoop.util.AccessTokenProvider$AccessToken</exclude>
@@ -430,9 +459,36 @@
                     <include>org.threeten.**</include>
                   </includes>
                 </relocation>
+                <!-- Take special care of grpc-netty-shaded, it uses the package
+                     io.grpc.netty.shaded.io.grpc.netty, which will cause the
+                     ServicesResourceTransformer to replace both occurrences of io.grpc -->
+                <relocation>
+                  <pattern>io.grpc.netty.shaded</pattern>
+                  <shadedPattern>
+                    com.google.cloud.hadoop.repackaged.gcs.io.grpc.netty.shaded
+                  </shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>io</pattern>
                   <shadedPattern>com.google.cloud.hadoop.repackaged.gcs.io</shadedPattern>
+                  <includes>
+                    <include>io.grpc.**</include>
+                    <include>io.opencensus.**</include>
+                    <include>io.opentelemetry.**</include>
+                    <include>io.perfmark.**</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/io_grpc_netty_shaded_</pattern>
+                  <shadedPattern>
+                    META-INF/native/com_google_cloud_hadoop_repackaged_gcs_io_grpc_netty_shaded_
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/libio_grpc_netty_shaded_</pattern>
+                  <shadedPattern>
+                    META-INF/native/libcom_google_cloud_hadoop_repackaged_gcs_io_grpc_netty_shaded_
+                  </shadedPattern>
                 </relocation>
               </relocations>
               <shadedArtifactAttached>true</shadedArtifactAttached>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <google.protobuf.version>3.25.3</google.protobuf.version>
     <grpc.version>1.68.0</grpc.version>
     <hadoop.version>3.3.6</hadoop.version>
+    <conscrypt.version>2.5.2</conscrypt.version>
     <opencensus.version>0.31.1</opencensus.version>
 
     <!-- Test dependencies -->
@@ -478,6 +479,11 @@
         <artifactId>hadoop-client-runtime</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.conscrypt</groupId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
+        <version>${conscrypt.version}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
This commit enhances the GCS connector's build process to generate two distinct shaded JARs by default.

The primary shaded JAR (-shaded.jar) now bundles and relocates the Conscrypt TLS provider. This provides out-of-the-box performance benefits for gRPC and prevents potential classpath conflicts in the user's Hadoop environment.

A second, alternate JAR (-shaded-without-conscrypt.jar) is also produced. This version explicitly excludes Conscrypt, resulting in a smaller artifact that relies on the standard JVM security providers. This is ideal for environments where Conscrypt is not needed or is provided separately.

This is implemented by adding a second execution to the maven-shade-plugin in the gcs/pom.xml, configured to exclude the Conscrypt dependency and use a distinct classifier.