### PR TITLE
Skip publish to Central Repo before signing the artifacts. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!-- TODO: remove AssertJ dependency when Hadoop will fix transitive test dependencies -->
     <assertj.version>3.14.0</assertj.version>
     <deploy.skip>true</deploy.skip>
-    <central.remote.skip>false</central.remote.skip>
+    <central.publishing.skip>false</central.publishing.skip>
   </properties>
 
   <modules>
@@ -173,7 +173,7 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
-              <skipPublishing>${central.remote.skip}</skipPublishing>
+              <skipPublishing>${central.publishing.skip}</skipPublishing>
               <checksums>all</checksums>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!-- TODO: remove AssertJ dependency when Hadoop will fix transitive test dependencies -->
     <assertj.version>3.14.0</assertj.version>
     <deploy.skip>true</deploy.skip>
-    <nexus.remote.skip>false</nexus.remote.skip>
+    <central.remote.skip>false</central.remote.skip>
   </properties>
 
   <modules>
@@ -173,6 +173,7 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
+              <skipPublishing>${central.remote.skip}</skipPublishing>
               <checksums>all</checksums>
             </configuration>
           </plugin>


### PR DESCRIPTION
* Skip publish to Central Repo before signing the artifacts
* Earlier we were using the `nexus.remote.skip` flag to do the same. 
