### PR TITLE
Cherry-picking to branch-2.2.x: Adding central-publishing-maven-plugin , skip publish and Adding Name Tags

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -10,6 +10,8 @@
     <version>2.2.29-SNAPSHOT</version>
   </parent>
 
+  <name>coverage</name>
+
   <artifactId>coverage</artifactId>
   <version>2.2.29-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -59,17 +59,6 @@
     <url>https://github.com/GoogleCloudDataproc/hadoop-connectors/issues</url>
   </issueManagement>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <argLine/>
 
@@ -261,15 +250,14 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-              <skipRemoteStaging>${nexus.remote.skip}</skipRemoteStaging>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <checksums>all</checksums>
             </configuration>
           </plugin>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <mockito.version>3.11.2</mockito.version>
     <system-lambda.version>1.2.0</system-lambda.version>
     <deploy.skip>true</deploy.skip>
-    <nexus.remote.skip>false</nexus.remote.skip>
+    <central.publishing.skip>false</central.publishing.skip>
   </properties>
 
   <modules>
@@ -257,6 +257,7 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
+              <skipPublishing>${central.publishing.skip}</skipPublishing>
               <checksums>all</checksums>
             </configuration>
           </plugin>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -26,6 +26,8 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <name>util</name>
+
   <artifactId>util</artifactId>
   <version>2.2.29-SNAPSHOT</version>
 


### PR DESCRIPTION
* Original [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1431) for using central-publishing-maven-plugin
* Original [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1440) for skip publish 
* Original [PR](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1438) for adding name Tag