### PR TITLE
Change checksum tags from all to required to include only md5 and sha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
               <skipPublishing>${central.publishing.skip}</skipPublishing>
-              <checksums>all</checksums>
+              <checksums>required</checksums>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
Change checksum tags from `all` to `required` to include only md5 and sha1
[Reference/](https://central.sonatype.org/publish/publish-portal-maven/#checksums)