### PR TITLE
Prevent infinite loop in read channels due to connection loss

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -484,6 +484,13 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
         try {
           int bufferSize = toIntExact(min(skipBuffer.length, seekDistance));
           int bytesRead = byteChannel.read(ByteBuffer.wrap(skipBuffer, 0, bufferSize));
+          if (bytesRead == 0) {
+            GoogleCloudStorageEventBus.postOnException();
+            throw new IOException(
+                String.format(
+                    "Read 0 bytes without blocking while skipping %d bytes from object: '%s'",
+                    seekDistance, resourceId));
+          }
           if (bytesRead < 0) {
             logger.atInfo().log(
                 "Somehow read %d bytes trying to skip %d bytes to seek to position %d, size: %d",

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -1056,6 +1056,10 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             bytesToSkip, contentChannelPosition, currentPosition, resourceId);
         while (bytesToSkip > 0) {
           long skippedBytes = contentStream.skip(bytesToSkip);
+          if (skippedBytes <= 0) {
+            throw new IOException(
+                "contentStream.skip() returned " + skippedBytes + ", potential connection loss");
+          }
           logger.atFiner().log(
               "Skipped %d bytes from %d position for '%s'",
               skippedBytes, contentChannelPosition, resourceId);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -1060,7 +1060,9 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             GoogleCloudStorageEventBus.postOnException();
             // If we skipped 0 bytes, it means that the connection was lost.
             throw new IOException(
-                "contentStream.skip() returned " + skippedBytes + ", potential connection loss");
+                String.format(
+                    "contentStream.skip() returned %d, potential connection loss for object: '%s'",
+                    skippedBytes, resourceId));
           }
           logger.atFiner().log(
               "Skipped %d bytes from %d position for '%s'",

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -1057,6 +1057,8 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         while (bytesToSkip > 0) {
           long skippedBytes = contentStream.skip(bytesToSkip);
           if (skippedBytes <= 0) {
+            GoogleCloudStorageEventBus.postOnException();
+            // If we skipped 0 bytes, it means that the connection was lost.
             throw new IOException(
                 "contentStream.skip() returned " + skippedBytes + ", potential connection loss");
           }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -620,54 +620,6 @@ public class GoogleCloudStorageReadChannelTest {
         .isEqualTo("Cannot read GZIP encoded files - content encoding support is disabled.");
   }
 
-  @Test
-  public void openStream_whenSkipReturnsZero_throwsIOException() throws IOException {
-    // 1. Mock an InputStream that simulates a stalled connection by returning 0 from read().
-    // This will cause the wrapper stream's skip() method to return 0.
-    InputStream faultyStream =
-        new InputStream() {
-          @Override
-          public int read() throws IOException {
-            // A return value of 0 from a blocking read indicates a stream stall.
-            return 0;
-          }
-        };
-
-    // 2. Configure the mock transport with a full metadata response and the faulty stream.
-    MockHttpTransport transport =
-        mockTransport(
-            jsonDataResponse(
-                new StorageObject()
-                    .setBucket(BUCKET_NAME)
-                    .setName(OBJECT_NAME)
-                    .setSize(BigInteger.valueOf(100L))
-                    .setGeneration(1L)
-                    .setMetageneration(1L)),
-            inputStreamResponse(faultyStream));
-
-    // 3. Create the GCS instance and ReadChannel using the test's standard helpers.
-    GoogleCloudStorage gcs = mockedGcsImpl(transport);
-    GoogleCloudStorageReadChannel readChannel =
-        (GoogleCloudStorageReadChannel)
-            gcs.open(
-                new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
-                GoogleCloudStorageReadOptions.builder().setFadvise(Fadvise.SEQUENTIAL).build());
-
-    // 4. Disable retries to isolate the initial failure.
-    setUpAndValidateReadChannelMocksAndSetMaxRetries(readChannel, 0);
-
-    // 5. Position the channel. The next read() will trigger openStream() and the faulty skip().
-    readChannel.position(50);
-
-    // 6. Assert that the specific IOException from your fix is thrown.
-    IOException e =
-        assertThrows(IOException.class, () -> readChannel.read(ByteBuffer.wrap(new byte[10])));
-
-    assertThat(e)
-        .hasMessageThat()
-        .contains("contentStream.skip() returned 0, potential connection loss");
-  }
-
   /**
    * Helper for test cases involving {@code GoogleCloudStorage.open(StorageResourceId)} to set up
    * the shared sleeper/clock/backoff mocks and set {@code maxRetries}. Also checks basic invariants

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <!-- TODO: remove AssertJ dependency when Hadoop will fix transitive test dependencies -->
     <assertj.version>3.14.0</assertj.version>
     <deploy.skip>true</deploy.skip>
-    <nexus.remote.skip>false</nexus.remote.skip>
+    <central.publishing.skip>false</central.publishing.skip>
   </properties>
 
   <modules>
@@ -173,6 +173,7 @@
             <configuration>
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
+              <skipPublishing>${central.publishing.skip}</skipPublishing>
               <checksums>all</checksums>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
               <skipPublishing>${central.publishing.skip}</skipPublishing>
-              <checksums>all</checksums>
+              <checksums>required</checksums>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
This PR addresses a bug where a lost connection during a read operation could cause an infinite loop in GoogleCloudStorageReadChannel and GoogleCloudStorageClientReadChannel.

The problem: The underlying contentStream.skip() can return 0 bytes if the connection to the GCS server is lost while reading a response causing the while loop to spin indefinitely, blocking customer processes.
A similar issue could occur in the gRPC read path.

The solution: This change introduces checks to detect when skip() or read() returns 0.

* In GoogleCloudStorageReadChannel.java, if contentStream.skip(bytesToSkip) returns a value <= 0, an IOException is thrown to prevent the infinite loop
* In GoogleCloudStorageClientReadChannel.java, if byteChannel.read(...) returns 0, an IOException is now thrown
Related bug: https://b.corp.google.com/issues/438790622