### PR TITLE
[Backport Fix to branch-3.1.x]: Prevent Hadoop directory copy failures by correctly setting generation id

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientGrpcTracingInterceptor.java
@@ -266,7 +266,8 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
 
   private class WriteObjectStreamTracer extends TrackingStreamTracer {
 
-    private String streamUploadId = null;
+    private static final String STREAM_UPLOAD_ID_NOT_FOUND = "STREAM_UPLOAD_ID_NOT_FOUND";
+    private String streamUploadId = STREAM_UPLOAD_ID_NOT_FOUND;
 
     WriteObjectStreamTracer(String rpcMethod) {
       super(rpcMethod);
@@ -301,7 +302,7 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
           "%s",
           toJson(
               getResponseTrackingInfo()
-                  .put(GoogleCloudStorageTracingFields.UPLOAD_ID.name, streamUploadId)
+                  .put(GoogleCloudStorageTracingFields.UPLOAD_ID.name, this.streamUploadId)
                   .put(
                       GoogleCloudStorageTracingFields.PERSISTED_SIZE.name,
                       response.getPersistedSize())
@@ -309,7 +310,7 @@ public class GoogleCloudStorageClientGrpcTracingInterceptor implements ClientInt
     }
 
     private void updateUploadId(@Nonnull String uploadId) {
-      if (streamUploadId == null) {
+      if (streamUploadId.equals(STREAM_UPLOAD_ID_NOT_FOUND)) {
         this.streamUploadId = uploadId;
       }
       checkState(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -562,7 +562,7 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       // To get decoded content
       blobReadOptions.add(BlobSourceOption.shouldReturnRawInputStream(false));
 
-      if (blobId.getGeneration() != null) {
+      if (blobId.getGeneration() != null && blobId.getGeneration() > 0) {
         blobReadOptions.add(BlobSourceOption.generationMatch(blobId.getGeneration()));
       }
       if (storageOptions.getEncryptionKey() != null) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -770,7 +770,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     size = gzipEncoded ? Long.MAX_VALUE : sizeFromMetadata;
     checkEncodingAndAccess();
 
-    if (resourceId.hasGenerationId()) {
+    if (resourceId.hasGenerationId() && resourceId.getGenerationId() > 0) {
       checkState(
           resourceId.getGenerationId() == generation,
           "Provided generation (%s) should be equal to fetched generation (%s) for '%s'",
@@ -1130,7 +1130,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     Storage.Objects.Get getData =
         storageRequestFactory.objectsGetData(
             resourceId.getBucketName(), resourceId.getObjectName());
-    if (resourceId.hasGenerationId()) {
+    if (resourceId.hasGenerationId() && resourceId.getGenerationId() > 0) {
       getData.setGeneration(resourceId.getGenerationId());
     }
     return getData;
@@ -1145,7 +1145,7 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
     Storage.Objects.Get getMetadata =
         storageRequestFactory.objectsGetMetadata(
             resourceId.getBucketName(), resourceId.getObjectName());
-    if (resourceId.hasGenerationId()) {
+    if (resourceId.hasGenerationId() && resourceId.getGenerationId() > 0) {
       getMetadata.setGeneration(resourceId.getGenerationId());
     }
     return getMetadata;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -651,6 +651,55 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
+  public void read_withPositiveGeneration_usesGenerationMatchPrecondition() throws IOException {
+    long generation = 12345L;
+    byte[] testData = {0x01, 0x02, 0x03};
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(newStorageObject(BUCKET_NAME, OBJECT_NAME).setGeneration(generation)),
+            dataResponse(testData));
+    List<HttpRequest> requests = new ArrayList<>();
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+    GoogleCloudStorageReadChannel readChannel =
+        createReadChannel(storage, GoogleCloudStorageReadOptions.builder().build(), generation);
+
+    readChannel.read(ByteBuffer.allocate(testData.length));
+
+    // The first request is for metadata, the second is for data.
+    // Verify the data request URL contains the generation parameter.
+    String mediaRequestUrl = getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation);
+    assertThat("GET:" + requests.get(1).getUrl().toString()).isEqualTo(mediaRequestUrl);
+  }
+
+  @Test
+  public void read_withZeroGeneration_doesNotUseGenerationMatchPrecondition() throws IOException {
+    long requestedGeneration = 0L;
+    // The actual object has a real, positive generation ID.
+    long actualGeneration = 54321L;
+    byte[] testData = {0x04, 0x05, 0x06};
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                newStorageObject(BUCKET_NAME, OBJECT_NAME).setGeneration(actualGeneration)),
+            dataResponse(testData));
+    List<HttpRequest> requests = new ArrayList<>();
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+    GoogleCloudStorageReadChannel readChannel =
+        createReadChannel(
+            storage,
+            GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build(),
+            requestedGeneration);
+
+    readChannel.read(ByteBuffer.allocate(testData.length));
+
+    // The data request URL should not contain a generation parameter,
+    // because the requested generation was 0. The generation parameter in getMediaRequestString
+    // will be null when the check for generation > 0 fails.
+    String mediaRequestUrl = getMediaRequestString(BUCKET_NAME, OBJECT_NAME);
+    assertThat("GET:" + requests.get(0).getUrl().toString()).isEqualTo(mediaRequestUrl);
+  }
+
+  @Test
   public void open_gzipContentEncoding_succeeds_whenContentEncodingSupported() throws Exception {
     MockHttpTransport transport =
         mockTransport(


### PR DESCRIPTION
* Origin [PR/](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1363)