### PR TITLE
Backport to master: Support zero-copy readChannel (#1340)

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannel.java
@@ -252,9 +252,15 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
           }
           int bytesRead = byteChannel.read(dst);
 
+          /*
+          As we are using the zero copy implementation of byteChannel, it can return even zero bytes,
+          while reading,
+          we should not treat it as an error scenario anymore.
+          */
           if (bytesRead == 0) {
-            throw new IOException(
-                String.format("Read 0 bytes without blocking from object: '%s'", resourceId));
+            logger.atFiner().log(
+                "Read %d from storage-client's byte channel at position: %d with channel ending at: %d for resourceId: %s of size: %d",
+                bytesRead, currentPosition, contentChannelEnd, resourceId, objectSize);
           }
 
           if (bytesRead < 0) {
@@ -561,6 +567,9 @@ class GoogleCloudStorageClientReadChannel implements SeekableByteChannel {
       try {
         readChannel.seek(seek);
         readChannel.limit(limit);
+        // bypass the storage-client caching layer hence eliminates the need to maintain a copy of
+        // chunk
+        readChannel.setChunkSize(0);
         return readChannel;
       } catch (Exception e) {
         GoogleCloudStorageEventBus.postOnException();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientReadChannelTest.java
@@ -133,6 +133,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     verifyContent(buffer, startPosition, readBytes);
     verify(fakeReadChannel, times(1)).seek(anyLong());
     verify(fakeReadChannel, times(1)).limit(anyLong());
+    verify(fakeReadChannel, times(1)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).read(any());
 
     verifyNoMoreInteractions(fakeReadChannel);
@@ -164,6 +165,7 @@ public class GoogleCloudStorageClientReadChannelTest {
 
     verify(fakeReadChannel, times(1)).seek(anyLong());
     verify(fakeReadChannel, times(1)).limit(anyLong());
+    verify(fakeReadChannel, times(1)).setChunkSize(0);
     verify(fakeReadChannel, times(chunksToRead)).read(any());
 
     verifyNoMoreInteractions(fakeReadChannel);
@@ -188,6 +190,7 @@ public class GoogleCloudStorageClientReadChannelTest {
 
     verify(fakeReadChannel, times(OBJECT_SIZE / chunkSize)).seek(anyLong());
     verify(fakeReadChannel, times(OBJECT_SIZE / chunkSize)).limit(anyLong());
+    verify(fakeReadChannel, times(OBJECT_SIZE / chunkSize)).setChunkSize(0);
     verify(fakeReadChannel, times(OBJECT_SIZE / chunkSize)).close();
     // read will be called two times for every chunk
     // Content channel will be created with size of a CHUNK
@@ -279,6 +282,7 @@ public class GoogleCloudStorageClientReadChannelTest {
 
     verify(fakeReadChannel, times(2)).seek(anyLong());
     verify(fakeReadChannel, times(2)).limit(anyLong());
+    verify(fakeReadChannel, times(2)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).close();
     verify(fakeReadChannel, times(2)).read(any());
     verifyNoMoreInteractions(fakeReadChannel);
@@ -312,6 +316,7 @@ public class GoogleCloudStorageClientReadChannelTest {
 
     verify(fakeReadChannel, times(2)).seek(anyLong());
     verify(fakeReadChannel, times(2)).limit(anyLong());
+    verify(fakeReadChannel, times(2)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).close();
     verify(fakeReadChannel, times(2)).read(any());
     verifyNoMoreInteractions(fakeReadChannel);
@@ -333,6 +338,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     verifyContent(buffer, startPosition, bytesToRead);
     verify(fakeReadChannel, times(1)).seek(anyLong());
     verify(fakeReadChannel, times(1)).limit(anyLong());
+    verify(fakeReadChannel, times(1)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).read(any());
     verify(fakeReadChannel, times(1)).close();
     // another request within the footer will not result into `read` and served via cache
@@ -404,6 +410,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     readChannel.read(buffer);
     verifyContent(buffer, startPosition, bytesToRead);
     verify(fakeReadChannel, times(1)).seek(anyLong());
+    verify(fakeReadChannel, times(1)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).limit(anyLong());
 
     buffer.clear();
@@ -447,6 +454,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     readChannel.close();
     verify(fakeReadChannel, times(1)).seek(anyLong());
     verify(fakeReadChannel, times(1)).limit(anyLong());
+    verify(fakeReadChannel, times(1)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).read(any());
     verify(fakeReadChannel, times(1)).close();
     verifyNoMoreInteractions(fakeReadChannel);
@@ -466,6 +474,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     assertThrows(IOException.class, () -> readChannel.read(buffer));
     verify(fakeReadChannel, times(1)).seek(anyLong());
     verify(fakeReadChannel, times(1)).limit(anyLong());
+    verify(fakeReadChannel, times(1)).setChunkSize(0);
     verify(fakeReadChannel, times(1)).read(any());
     verify(fakeReadChannel, times(1)).close();
     assertThat(buffer.position()).isEqualTo(partialByteRead);
@@ -494,6 +503,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     readChannel.read(buffer);
     verify(fakeReadChannel, times(2)).seek(anyLong());
     verify(fakeReadChannel, times(2)).limit(anyLong());
+    verify(fakeReadChannel, times(2)).setChunkSize(0);
     verify(fakeReadChannel, times(2)).read(any());
     verify(fakeReadChannel, times(1)).close();
     assertThat(buffer.position()).isEqualTo(readBytes);
@@ -560,6 +570,7 @@ public class GoogleCloudStorageClientReadChannelTest {
     ArgumentCaptor<Long> limitValue = ArgumentCaptor.forClass(Long.class);
     verify(fakeReadChannel, times(2)).seek(seekValue.capture());
     verify(fakeReadChannel, times(2)).limit(limitValue.capture());
+    verify(fakeReadChannel, times(2)).setChunkSize(0);
     verify(fakeReadChannel, times(3)).read(any());
     verify(fakeReadChannel, times(2)).close();
     // First request fetched full footer


### PR DESCRIPTION
Backport to master from branch-3.1.x: Support zero-copy readChannel (#1340)