### PR TITLE
Fix infinite loop issue when EOF is reached during a skip operation

### DIFF
--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -55,6 +55,17 @@
     return `null` for that file. Supported checksum types are `NONE`, `CRC32C`
     and `MD5`
 
+*   `fs.gs.cloud.logging.enable` (default: `false`)
+
+    If `true`, exports Cloud Storage Connector logs to the GCP Logging service. The service account
+    used by the connector must have `roles/logging.logWriter` IAM permission in the GCP project
+    for this feature to work.
+
+    The logs will be labelled with the log name `gcs-connector`, which will be suffixed with the
+    value of `fs.gs.application.name.suffix` if set. For example, if
+    `fs.gs.application.name.suffix` is set to `my-app`, the log name will be
+    `gcs-connector-my-app`.
+
 *   `fs.gs.status.parallel.enable` (default: `true`)
 
     If `true`, executes Cloud Storage object requests in `FileSystem`'s
@@ -376,6 +387,8 @@ Knobs configure the vectoredRead API
 
     Suffix that will be added to HTTP `User-Agent` header set in all Cloud
     Storage requests.
+    When `fs.gs.cloud.logging.enable` is set to `true`, this suffix will be appended to the log name `gcs-connector` to
+    form the final log name. For example, if set to `my-app`, log name in GCP Logging will be `gcs-connector-my-app`.
 
 *   `fs.gs.proxy.address` (not set by default)
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -557,30 +557,14 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
   }
 
   private void skipInPlace(long seekDistance) {
-    if (skipBuffer == null) {
-      skipBuffer = new byte[SKIP_BUFFER_SIZE];
-    }
-    while (seekDistance > 0 && contentChannel != null) {
-      try {
-        int bufferSize = toIntExact(min(skipBuffer.length, seekDistance));
-        int bytesRead = contentChannel.read(ByteBuffer.wrap(skipBuffer, 0, bufferSize));
-        if (bytesRead < 0) {
-          // Shouldn't happen since we called validatePosition prior to this loop.
-          logger.atInfo().log(
-              "Somehow read %d bytes trying to skip %d bytes to seek to position %d, size: %d",
-              bytesRead, seekDistance, currentPosition, size);
-          closeContentChannel();
-        } else {
-          seekDistance -= bytesRead;
-          contentChannelPosition += bytesRead;
-        }
-      } catch (IOException e) {
-        GoogleCloudStorageEventBus.postOnException();
-        logger.atInfo().withCause(e).log(
-            "Got an IO exception on contentChannel.read(), a lazy-seek will be pending for '%s'",
-            resourceId);
-        closeContentChannel();
-      }
+    try {
+      contentChannelPosition += skip(contentChannel, seekDistance);
+    } catch (IOException e) {
+      GoogleCloudStorageEventBus.postOnException();
+      logger.atInfo().withCause(e).log(
+          "Got an IO exception on contentChannel.read(), a lazy-seek will be pending for '%s'",
+          resourceId);
+      closeContentChannel();
     }
     checkState(
         contentChannel == null || contentChannelPosition == currentPosition,
@@ -588,6 +572,27 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
             + " after successful in-place skip",
         contentChannelPosition,
         currentPosition);
+  }
+
+  private long skip(ReadableByteChannel channel, long bytesToSkip) throws IOException {
+    if (skipBuffer == null) {
+      skipBuffer = new byte[SKIP_BUFFER_SIZE];
+    }
+    long totalBytesSkipped = 0;
+    while (bytesToSkip > 0) {
+      int bufferSize = toIntExact(min(skipBuffer.length, bytesToSkip));
+      int bytesRead = channel.read(ByteBuffer.wrap(skipBuffer, 0, bufferSize));
+      if (bytesRead < 0) {
+        throw new EOFException(
+            String.format(
+                "Unexpected end of stream trying to skip %d bytes to seek to position %d,"
+                    + " size: %d for '%s'",
+                bytesToSkip, currentPosition, size, resourceId));
+      }
+      bytesToSkip -= bytesRead;
+      totalBytesSkipped += bytesRead;
+    }
+    return totalBytesSkipped;
   }
 
   /**
@@ -1037,23 +1042,9 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
       if (contentChannelPosition < currentPosition) {
         long bytesToSkip = currentPosition - contentChannelPosition;
         logger.atFiner().log(
-            "Skipping %d bytes from %d position to %d position for '%s'",
+            "Skipping %d bytes from %d to %d position for '%s'",
             bytesToSkip, contentChannelPosition, currentPosition, resourceId);
-        if (skipBuffer == null) {
-          skipBuffer = new byte[SKIP_BUFFER_SIZE];
-        }
-        while (bytesToSkip > 0) {
-          int bytesRead =
-              contentStream.read(skipBuffer, 0, toIntExact(min(bytesToSkip, skipBuffer.length)));
-          if (bytesRead < 0) {
-            throw new EOFException(
-                String.format(
-                    "Unexpected end of stream trying to skip %d bytes to seek to position %d, size: %d for '%s'",
-                    bytesToSkip, currentPosition, size, resourceId));
-          }
-          bytesToSkip -= bytesRead;
-          contentChannelPosition += bytesRead;
-        }
+        contentChannelPosition += skip(Channels.newChannel(contentStream), bytesToSkip);
       }
 
       checkState(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannel.java
@@ -574,7 +574,12 @@ public class GoogleCloudStorageReadChannel implements SeekableByteChannel {
         currentPosition);
   }
 
-  private long skip(ReadableByteChannel channel, long bytesToSkip) throws IOException {
+  // Reading into a buffer using `read` is more reliable which has retry logic built around it than
+  // `InputStream.skip()`, which states that it
+  // "may, for a variety of reasons, end up skipping over some smaller number of bytes, possibly 0",
+  // which may or may not be because of EOF.
+  // This implementation is also consistent with gRPC.
+  private long skip(@Nonnull ReadableByteChannel channel, long bytesToSkip) throws IOException {
     if (skipBuffer == null) {
       skipBuffer = new byte[SKIP_BUFFER_SIZE];
     }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -899,7 +899,7 @@ public class GoogleCloudStorageReadChannelTest {
   }
 
   @Test
-  public void openStream_gzipped_throwsEofException_onPrematureEofInSkip() throws IOException {
+  public void openStream_gzipped_onPrematureEofInSkip_throwsEofException() throws IOException {
     // Setup: Mock transport to return an InputStream that immediately signals EOF.
     MockHttpTransport transport =
         mockTransport(

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -47,6 +47,7 @@ import com.google.cloud.hadoop.util.RetryHttpInitializer;
 import com.google.cloud.hadoop.util.RetryHttpInitializerOptions;
 import com.google.cloud.hadoop.util.testing.MockHttpTransportHelper.ErrorResponses;
 import com.google.common.collect.ImmutableMap;
+import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -780,6 +781,43 @@ public class GoogleCloudStorageReadChannelTest {
             getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation),
             getMediaRequestString(BUCKET_NAME, OBJECT_NAME, generation))
         .inOrder();
+  }
+
+  @Test
+  public void openStream_gzipped_throwsEofException_onPrematureEofInSkip() throws IOException {
+    // Setup: Mock transport to return an InputStream that immediately signals EOF.
+    MockHttpTransport transport =
+        mockTransport(
+            jsonDataResponse(
+                newStorageObject(BUCKET_NAME, OBJECT_NAME)
+                    .setContentEncoding("gzip")
+                    .setSize(BigInteger.valueOf(100))),
+            inputStreamResponse(
+                new InputStream() {
+                  @Override
+                  public int read() {
+                    return -1;
+                  }
+                }));
+
+    Storage storage = new Storage(transport, new GsonFactory(), r -> {});
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.builder().setGzipEncodingSupportEnabled(true).build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, readOptions);
+
+    // Position the channel to a non-zero offset to trigger a skip.
+    readChannel.position(10);
+
+    // Attempting to read should trigger the skip, which should then fail with EOFException.
+    EOFException e =
+        assertThrows(EOFException.class, () -> readChannel.read(ByteBuffer.allocate(1)));
+
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo(
+            "Unexpected end of stream trying to skip 10 bytes to seek to position 10,"
+                + " size: 9223372036854775807 for 'gs://foo-bucket/bar-object'");
   }
 
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {


### PR DESCRIPTION
This PR addresses a critical bug in GoogleCloudStorageReadChannel where a skip() operation on the content stream could lead to an infinite loop.

Problem:

As reported in [Issue](https://github.com/GoogleCloudDataproc/hadoop-connectors/issues/1180), the contentStream.skip() method can return 0 bytes. On further investigation it was found that this skip method call returns 0 even when EOF is reached instead of a negative value. This behavior causes an infinite loop as the code repeatedly attempts to skip bytes that lead to EOF, effectively stalling the process.

Solution:

To resolve this, the call to contentStream.skip() has been replaced with contentStream.read() into a skipBuffer. This approach allows for a more reliable detection of the end of the stream. If the stream ends prematurely while attempting to skip bytes (indicated by read() returning a negative value), an EOFException is now thrown. This change ensures that the loop is broken and an error is properly propagated.

Was able to reproduce this manually and verified  proposed changes solves this issue.