### PR TITLE
Implement feature usage tracking header

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -620,7 +620,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setMarkerFilePattern(GCS_MARKER_FILE_PATTERN.get(config, config::get))
         .setPerformanceCacheEnabled(GCS_PERFORMANCE_CACHE_ENABLE.get(config, config::getBoolean))
         .setPerformanceCacheOptions(getPerformanceCachingOptions(config))
-        .setStatusParallelEnabled(GCS_STATUS_PARALLEL_ENABLE.get(config, config::getBoolean));
+        .setStatusParallelEnabled(GCS_STATUS_PARALLEL_ENABLE.get(config, config::getBoolean))
+        .setCloudLoggingEnabled(GCS_CLOUD_LOGGING_ENABLE.get(config, config::getBoolean));
   }
 
   static VectoredReadOptions.Builder getVectoredReadOptionBuilder(Configuration config) {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -500,4 +500,15 @@ public class GoogleHadoopFileSystemConfigurationTest {
     assertThat(readOptions.getBidiThreadCount()).isEqualTo(20);
     assertThat(readOptions.getBidiClientTimeout()).isEqualTo(40);
   }
+
+  @Test
+  public void cloudLoggingEnabled_isSettable() {
+    Configuration config = new Configuration();
+    config.setBoolean("fs.gs.cloud.logging.enable", true);
+
+    GoogleCloudStorageFileSystemOptions options =
+        GoogleHadoopFileSystemConfiguration.getGcsFsOptionsBuilder(config).build();
+
+    assertThat(options.isCloudLoggingEnabled()).isTrue();
+  }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FeatureUsageHeader.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FeatureUsageHeader.java
@@ -1,0 +1,173 @@
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+import org.apache.hadoop.util.functional.CallableRaisingIOE;
+
+/**
+ * Generates the x-goog-storage-hadoop-connector-features header value by combining
+ * configuration-derived and request-specific features.
+ */
+public class FeatureUsageHeader {
+
+  @VisibleForTesting static final int BITMASK_SIZE = 2;
+  @VisibleForTesting static final int HIGH_BITS_INDEX = 0;
+  @VisibleForTesting static final int LOW_BITS_INDEX = 1;
+
+  @VisibleForTesting
+  static final InheritableThreadLocal<long[]> requestFeatures =
+      new InheritableThreadLocal<>() {
+        @Override
+        protected long[] initialValue() {
+          return new long[BITMASK_SIZE];
+        }
+      };
+
+  public static final String NAME = "X-Goog-Storage-Hadoop-Connector-Features";
+  private final long[] configFeatures;
+
+  public FeatureUsageHeader(GoogleCloudStorageFileSystemOptions options) {
+    this.configFeatures = new long[BITMASK_SIZE];
+    populateBitMask(configFeatures, options);
+  }
+
+  /**
+   * Generates the value for the x-goog-storage-hadoop-connector-features header.
+   *
+   * @return The Base64 encoded string for the header, or {@code null} if no features are set.
+   */
+  public String getValue() {
+    long[] features = new long[BITMASK_SIZE];
+    features[HIGH_BITS_INDEX] =
+        configFeatures[HIGH_BITS_INDEX] | requestFeatures.get()[HIGH_BITS_INDEX];
+    features[LOW_BITS_INDEX] =
+        configFeatures[LOW_BITS_INDEX] | requestFeatures.get()[LOW_BITS_INDEX];
+    return encode(features);
+  }
+
+  /**
+   * Executes a block of code with a specific feature tracked. The feature bit is set before
+   * execution and cleared in a finally block, ensuring it doesn't leak to other requests.
+   */
+  public static <B> B track(TrackedFeatures feature, CallableRaisingIOE<B> operation)
+      throws IOException {
+    setBit(requestFeatures.get(), feature.getBitPosition());
+    try {
+      return operation.apply();
+    } finally {
+      clearBit(requestFeatures.get(), feature.getBitPosition());
+    }
+  }
+
+  /** Populates the bitmask with features derived from connector-level options. */
+  private void populateBitMask(long[] features, GoogleCloudStorageFileSystemOptions fsOptions) {
+    GoogleCloudStorageOptions storageOptions = fsOptions.getCloudStorageOptions();
+    // Fadvise options
+    Fadvise fadvise = storageOptions.getReadChannelOptions().getFadvise();
+    if (fadvise != null) {
+      switch (fadvise) {
+        case AUTO:
+          setBit(features, TrackedFeatures.FADVISE_AUTO.getBitPosition());
+          break;
+        case RANDOM:
+          setBit(features, TrackedFeatures.FADVISE_RANDOM.getBitPosition());
+          break;
+        case SEQUENTIAL:
+          setBit(features, TrackedFeatures.FADVISE_SEQUENTIAL.getBitPosition());
+          break;
+      }
+    }
+
+    // Hierarchical Namespace
+    if (storageOptions.isHnBucketRenameEnabled()) {
+      setBit(features, TrackedFeatures.HIERARCHICAL_NAMESPACE_ENABLED.getBitPosition());
+    }
+
+    // Trace Logging
+    if (storageOptions.isTraceLogEnabled()) {
+      setBit(features, TrackedFeatures.TRACE_LOG_ENABLED.getBitPosition());
+    }
+    if (storageOptions.isOperationTraceLogEnabled()) {
+      setBit(features, TrackedFeatures.OPERATION_TRACE_LOG_ENABLED.getBitPosition());
+    }
+
+    // Direct Upload
+    if (storageOptions.getWriteChannelOptions().isDirectUploadEnabled()) {
+      setBit(features, TrackedFeatures.DIRECT_UPLOAD_ENABLED.getBitPosition());
+    }
+
+    // Bidirectional Support
+    if (storageOptions.isBidiEnabled()) {
+      setBit(features, TrackedFeatures.BIDI_ENABLED.getBitPosition());
+    }
+
+    // Performance Cache
+    if (fsOptions.isPerformanceCacheEnabled()) {
+      setBit(features, TrackedFeatures.PERFORMANCE_CACHE_ENABLED.getBitPosition());
+    }
+
+    // Cloud Logging
+    if (fsOptions.isCloudLoggingEnabled()) {
+      setBit(features, TrackedFeatures.CLOUD_LOGGING_ENABLED.getBitPosition());
+    }
+  }
+
+  /**
+   * Base64-encodes the 128-bit feature mask into a string, trimming leading zero bytes. Returns
+   * {@code null} if the bitmask is zero.
+   */
+  @VisibleForTesting
+  static String encode(long[] features) {
+    checkArgument(features.length == BITMASK_SIZE, "Bitmask must be 128 bits (2 longs).");
+    long highBits = features[HIGH_BITS_INDEX];
+    long lowBits = features[LOW_BITS_INDEX];
+
+    if (highBits == 0L && lowBits == 0L) {
+      return null;
+    }
+
+    ByteBuffer buffer = ByteBuffer.allocate(16);
+    buffer.putLong(highBits);
+    buffer.putLong(lowBits);
+    byte[] fullArray = buffer.array();
+
+    int firstNonZeroByte =
+        (highBits != 0L)
+            ? Long.numberOfLeadingZeros(highBits) / 8
+            : 8 + (Long.numberOfLeadingZeros(lowBits) / 8);
+
+    byte[] trimmedArray = Arrays.copyOfRange(fullArray, firstNonZeroByte, fullArray.length);
+
+    return Base64.getEncoder().encodeToString(trimmedArray);
+  }
+
+  /** Sets a specific bit in the 128-bit feature mask. */
+  private static void setBit(long[] features, int bitPosition) {
+    checkArgument(features.length == BITMASK_SIZE, "Bitmask must be 128 bits (2 longs).");
+    checkArgument(
+        bitPosition >= 0 && bitPosition < 128, "Bit position must be in the range [0, 127].");
+    if (bitPosition < 64) {
+      features[LOW_BITS_INDEX] |= (1L << bitPosition);
+    } else {
+      features[HIGH_BITS_INDEX] |= (1L << (bitPosition - 64));
+    }
+  }
+
+  /** Clears a specific bit in the 128-bit feature mask. */
+  private static void clearBit(long[] features, int bitPosition) {
+    checkArgument(features.length == BITMASK_SIZE);
+    checkArgument(
+        bitPosition >= 0 && bitPosition < 128, "Bit position must be in the range [0, 127].");
+    if (bitPosition < 64) {
+      features[LOW_BITS_INDEX] &= ~(1L << bitPosition);
+    } else {
+      features[HIGH_BITS_INDEX] &= ~(1L << (bitPosition - 64));
+    }
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
@@ -41,7 +41,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
         .setMarkerFilePattern((String) null)
         .setPerformanceCacheEnabled(false)
         .setPerformanceCacheOptions(PerformanceCachingGoogleCloudStorageOptions.DEFAULT)
-        .setStatusParallelEnabled(true);
+        .setStatusParallelEnabled(true)
+        .setCloudLoggingEnabled(false);
   }
 
   public abstract Builder toBuilder();
@@ -60,6 +61,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
   public abstract Pattern getMarkerFilePattern();
 
   public abstract boolean isStatusParallelEnabled();
+
+  public abstract boolean isCloudLoggingEnabled();
 
   public abstract boolean isEnsureNoConflictingItems();
 
@@ -94,6 +97,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
      * methods to reduce latency.
      */
     public abstract Builder setStatusParallelEnabled(boolean statusParallelEnabled);
+
+    public abstract Builder setCloudLoggingEnabled(boolean cloudLoggingEnabled);
 
     public abstract Builder setEnsureNoConflictingItems(boolean ensureNoConflictingItems);
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FeatureUsageHeaderTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FeatureUsageHeaderTest.java
@@ -1,0 +1,274 @@
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadOptions.Fadvise;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Unit tests for {@link FeatureUsageHeader}. This class contains non-parameterized tests for the
+ * encoding logic. The parameterized tests for feature flag generation are in the inner class {@link
+ * FeatureFlagGenerationTest}.
+ */
+@RunWith(JUnit4.class)
+public class FeatureUsageHeaderTest {
+
+  @Before
+  public void setUp() {
+    // Clear any request-specific features.
+    FeatureUsageHeader.requestFeatures.set(new long[FeatureUsageHeader.BITMASK_SIZE]);
+  }
+
+  // --- Tests for the encode method ---
+
+  @Test
+  public void encode_withEmptyBitmask_returnsNull() {
+    long[] features = new long[FeatureUsageHeader.BITMASK_SIZE];
+    assertThat(FeatureUsageHeader.encode(features)).isNull();
+  }
+
+  @Test
+  public void encode_withLowBitsSet_returnsCorrectString() {
+    long[] features = new long[FeatureUsageHeader.BITMASK_SIZE];
+    features[FeatureUsageHeader.LOW_BITS_INDEX] = 1L << 1 | 1L << 9; // 514
+    assertThat(FeatureUsageHeader.encode(features)).isEqualTo("AgI=");
+  }
+
+  @Test
+  public void encode_withHighBitsSet_returnsCorrectString() {
+    long[] features = new long[FeatureUsageHeader.BITMASK_SIZE];
+    features[FeatureUsageHeader.HIGH_BITS_INDEX] = 1L << 1; // Bit 65
+    assertThat(FeatureUsageHeader.encode(features)).isEqualTo("AgAAAAAAAAAA");
+  }
+
+  @Test
+  public void encode_withHighAndLowBitsSet_returnsCorrectString() {
+    long[] features = new long[FeatureUsageHeader.BITMASK_SIZE];
+    features[FeatureUsageHeader.HIGH_BITS_INDEX] = 1L; // Bit 64
+    features[FeatureUsageHeader.LOW_BITS_INDEX] = 1L; // Bit 0
+    assertThat(FeatureUsageHeader.encode(features)).isEqualTo("AQAAAAAAAAAB");
+  }
+
+  @Test
+  public void encode_throwsOnInvalidBitmaskSize() {
+    long[] features = new long[1];
+    assertThrows(IllegalArgumentException.class, () -> FeatureUsageHeader.encode(features));
+  }
+
+  // --- Tests for the track method ---
+
+  @Test
+  public void track_withCallable_setsAndClearsFeature() throws IOException {
+    // Initially, the header should be based on default options
+    FeatureUsageHeader header = new FeatureUsageHeader(GoogleCloudStorageFileSystemOptions.DEFAULT);
+    String initialHeader = header.getValue();
+
+    // A feature to track that is not part of the default set
+    TrackedFeatures testFeature = TrackedFeatures.RENAME_API; // bit 11
+
+    String result =
+        FeatureUsageHeader.track( // track is still static for request-level features
+            testFeature,
+            () -> {
+              // Inside track, the header should include the new feature
+              String trackedHeader = header.getValue();
+              assertThat(trackedHeader).isNotNull();
+              byte[] decodedBytes = Base64.getDecoder().decode(trackedHeader);
+              long[] features = bytesToLongs(decodedBytes);
+              assertThat(
+                      (features[FeatureUsageHeader.LOW_BITS_INDEX]
+                          & (1L << testFeature.getBitPosition())))
+                  .isNotEqualTo(0);
+              return "success";
+            });
+
+    assertThat(result).isEqualTo("success");
+
+    // After track, the header should be back to the initial state
+    String finalHeader = header.getValue();
+    assertThat(finalHeader).isEqualTo(initialHeader);
+  }
+
+  @Test
+  public void track_clearsFeatureOnException() {
+    FeatureUsageHeader header = new FeatureUsageHeader(GoogleCloudStorageFileSystemOptions.DEFAULT);
+    String initialHeader = header.getValue();
+    TrackedFeatures testFeature = TrackedFeatures.RENAME_API; // bit 11
+
+    IOException thrown =
+        assertThrows(
+            IOException.class,
+            () ->
+                FeatureUsageHeader.track(
+                    testFeature,
+                    () -> {
+                      throw new IOException("test exception");
+                    }));
+
+    assertThat(thrown).hasMessageThat().isEqualTo("test exception");
+    assertThat(header.getValue()).isEqualTo(initialHeader);
+  }
+
+  /** Parameterized tests for feature flag generation based on GCS options. */
+  @RunWith(Parameterized.class)
+  public static class FeatureFlagGenerationTest {
+
+    String testName;
+    private final GoogleCloudStorageFileSystemOptions options;
+    private final long expectedHighBits;
+    private final long expectedLowBits;
+
+    public FeatureFlagGenerationTest(
+        String testName,
+        GoogleCloudStorageFileSystemOptions options,
+        long expectedHighBits,
+        long expectedLowBits) {
+      this.testName = testName;
+      this.options = options;
+      this.expectedHighBits = expectedHighBits;
+      this.expectedLowBits = expectedLowBits;
+    }
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      final long defaultLowBits = (1L);
+
+      return Arrays.asList(
+          new Object[][] {
+            {"Default Options", GoogleCloudStorageFileSystemOptions.DEFAULT, 0L, defaultLowBits},
+            {
+              "Fadvise Random",
+              buildOptionsWithFadvise(Fadvise.RANDOM),
+              0L,
+              (defaultLowBits & ~(1L)) | (1L << 1)
+            },
+            {
+              "Fadvise Sequential",
+              buildOptionsWithFadvise(Fadvise.SEQUENTIAL),
+              0L,
+              (defaultLowBits & ~(1L)) | (1L << 2)
+            },
+            {
+              "Hierarchical Namespace",
+              GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+                  .setCloudStorageOptions(
+                      GoogleCloudStorageOptions.DEFAULT.toBuilder()
+                          .setHnBucketRenameEnabled(true)
+                          .build())
+                  .build(),
+              0L,
+              defaultLowBits | (1L << 4)
+            },
+            {
+              "Performance Cache",
+              GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+                  .setPerformanceCacheEnabled(true)
+                  .build(),
+              0L,
+              defaultLowBits | (1L << 5)
+            },
+            {
+              "Cloud Logging Enabled",
+              GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+                  .setCloudLoggingEnabled(true)
+                  .build(),
+              0L,
+              defaultLowBits | (1L << 6)
+            },
+            {
+              "Trace Log Enabled",
+              GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+                  .setCloudStorageOptions(
+                      GoogleCloudStorageOptions.DEFAULT.toBuilder()
+                          .setTraceLogEnabled(true)
+                          .build())
+                  .build(),
+              0L,
+              defaultLowBits | (1L << 7)
+            },
+            {
+              "Operation Trace Log Enabled",
+              GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+                  .setCloudStorageOptions(
+                      GoogleCloudStorageOptions.DEFAULT.toBuilder()
+                          .setOperationTraceLogEnabled(true)
+                          .build())
+                  .build(),
+              0L,
+              defaultLowBits | (1L << 8)
+            },
+            {
+              "Direct Upload",
+              GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+                  .setCloudStorageOptions(
+                      GoogleCloudStorageOptions.DEFAULT.toBuilder()
+                          .setWriteChannelOptions(
+                              GoogleCloudStorageOptions.DEFAULT.getWriteChannelOptions().toBuilder()
+                                  .setDirectUploadEnabled(true)
+                                  .build())
+                          .build())
+                  .build(),
+              0L,
+              defaultLowBits | (1L << 9)
+            },
+            {"Bidi Enabled", buildOptionsWithBidi(), 0L, defaultLowBits | (1L << 10)}
+          });
+    }
+
+    @Test
+    public void generatesCorrectHeaderValue() {
+      verifyHeader(options, expectedHighBits, expectedLowBits);
+    }
+  }
+
+  // --- Helper Methods ---
+
+  private static GoogleCloudStorageFileSystemOptions buildOptionsWithFadvise(Fadvise fadvise) {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.DEFAULT.toBuilder().setFadvise(fadvise).build();
+    GoogleCloudStorageOptions storageOptions =
+        GoogleCloudStorageOptions.DEFAULT.toBuilder().setReadChannelOptions(readOptions).build();
+    return GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+        .setCloudStorageOptions(storageOptions)
+        .build();
+  }
+
+  private static GoogleCloudStorageFileSystemOptions buildOptionsWithBidi() {
+    GoogleCloudStorageOptions storageOptions =
+        GoogleCloudStorageOptions.DEFAULT.toBuilder().setBidiEnabled(true).build();
+    return GoogleCloudStorageFileSystemOptions.DEFAULT.toBuilder()
+        .setCloudStorageOptions(storageOptions)
+        .build();
+  }
+
+  private static void verifyHeader(
+      GoogleCloudStorageFileSystemOptions options, long expectedHigh, long expectedLow) {
+    FeatureUsageHeader header = new FeatureUsageHeader(options);
+    String headerValue = header.getValue();
+    assertThat(headerValue).isNotNull();
+    byte[] decodedBytes = Base64.getDecoder().decode(headerValue);
+    long[] actualFeatures = bytesToLongs(decodedBytes);
+    assertThat(actualFeatures[FeatureUsageHeader.HIGH_BITS_INDEX]).isEqualTo(expectedHigh);
+    assertThat(actualFeatures[FeatureUsageHeader.LOW_BITS_INDEX]).isEqualTo(expectedLow);
+  }
+
+  private static long[] bytesToLongs(byte[] bytes) {
+    byte[] fullArray = new byte[16];
+    System.arraycopy(bytes, 0, fullArray, 16 - bytes.length, bytes.length);
+    ByteBuffer buffer = ByteBuffer.wrap(fullArray);
+    long high = buffer.getLong();
+    long low = buffer.getLong();
+    return new long[] {high, low};
+  }
+}


### PR DESCRIPTION
[Based on PR #1487 ] 
The core of this change is the new FeatureUsageHeader class which is responsible for generating the header value. The value is a Base64 encoded bitmask representing enabled features. 
The bitmask is populated from two sources:
- Configuration-based features: These are features enabled in the Hadoop configuration (e.g., fs.gs.cloud.logging.enable).
- Operation-based features: These are features used during a specific Hadoop operation. These are tracked using an InheritableThreadLocal to ensure they are cleared after the request