### PR TITLE
[Integration tests] Add retry for after bucket deletion to handle eventual consistency.

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -64,6 +64,7 @@ import static java.util.Arrays.stream;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_CREDENTIAL_PROVIDER_PATH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem.GcsFileChecksumType;
@@ -132,6 +133,9 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
   private static final String GCS_API_COUNT = "gcsApiCount";
   private static final String HADOOP_API_COUNT = "hadoopApiCount";
+
+  private static final long BUCKET_DELETION_TIMEOUT_MS = 30_000;
+  private static final long RETRY_INTERVAL_MS = 1_000;
 
   @Before
   public void before() throws Exception {
@@ -2443,6 +2447,26 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
                 .getItemInfo(new StorageResourceId(bucketName))
                 .exists())
         .isFalse();
+
+    // Bucket delete is an eventually consistent operation can take upto 30 seconds
+    // More details on consistency https://cloud.google.com/storage/docs/consistency.
+    long deadline = System.currentTimeMillis() + BUCKET_DELETION_TIMEOUT_MS;
+    boolean notFound = false;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        getSubFolderCount(googleHadoopFileSystem, bucketPath);
+        // If the call succeeds, the bucket is not yet fully deleted from this view.
+        // Wait a bit before retrying.
+        Thread.sleep(RETRY_INTERVAL_MS);
+      } catch (com.google.api.gax.rpc.NotFoundException e) {
+        notFound = true;
+        break;
+      }
+    }
+
+    if (!notFound) {
+      fail("getSubFolderCount should have thrown NotFoundException after bucket deletion.");
+    }
 
     googleHadoopFileSystem.close();
   }


### PR DESCRIPTION
Follow up on - https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1483

In the previous PR, we deleted this check to unblock releases and pull requests. In this PR, we are adding back that assertion along with the timeouts to handle eventual consistency.