### PR TITLE
[Backport to branch-3.1.x ] Enable move by default 

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next
 1. PR #1511 - [Feature] Storage Client Caching for downscoped token
+2. Enable move by default.
 
 ## 3.1.7 - 2025-09-10
 1. PR #1484 - [Feature] Enabled write checksum by default

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -128,7 +128,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
           put("fs.gs.fadvise.request.track.count", 3);
-          put("fs.gs.operation.move.enable", false);
+          put("fs.gs.operation.move.enable", true);
           put("fs.gs.write.rolling.checksum.enable", true);
           put("fs.gs.storage.client.cache.enable", false);
         }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -227,13 +227,13 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   @Test
-  public void testRenameWithMoveOperation() throws Exception {
+  public void testRenameWithMoveDisabled() throws Exception {
     String bucketName = this.gcsiHelper.getUniqueBucketName("move");
     GoogleHadoopFileSystem googleHadoopFileSystem = new GoogleHadoopFileSystem();
 
     URI initUri = new URI("gs://" + bucketName);
     Configuration config = loadConfig();
-    config.setBoolean("fs.gs.operation.move.enable", true);
+    config.setBoolean("fs.gs.operation.move.enable", false);
     googleHadoopFileSystem.initialize(initUri, config);
 
     GoogleCloudStorage theGcs = googleHadoopFileSystem.getGcsFs().getGcs();
@@ -2631,10 +2631,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     expected =
         ImmutableMap.<String, Long>builder()
-            .put(
-                GhfsStatistic.ACTION_HTTP_DELETE_REQUEST.getSymbol(),
-                2L) // 1 for file; 1 for directory.
-            .put(GhfsStatistic.ACTION_HTTP_POST_REQUEST.getSymbol(), 1L) // copy file;
+            .put(GhfsStatistic.ACTION_HTTP_DELETE_REQUEST.getSymbol(), 1L) // 1 for directory.
+            .put(GhfsStatistic.ACTION_HTTP_POST_REQUEST.getSymbol(), 1L) // move file;
             .put(
                 GoogleCloudStorageStatistics.GCS_API_CLIENT_NOT_FOUND_RESPONSE_COUNT.getSymbol(),
                 2L) // Check for each parent dirs fails due to NOT FOUND - expected
@@ -2643,7 +2641,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
                 2L) // Check for each parent dirs fails due to NOT FOUND - expected
             .put(
                 GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT.getSymbol(),
-                9L) // 2 delete + 3 metadata + 2 POST + 1 listDir + 3 listFile
+                8L) // 1 delete + 3 metadata + 2 POST + 1 listDir + 3 listFile
             .put(
                 GoogleCloudStorageStatistics.GCS_LIST_DIR_REQUEST.getSymbol(),
                 1L) // list src files to copy/delete
@@ -2781,7 +2779,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     myghfs.rename(testFilePath, dst);
     // TODO: Operations done async in a separate thread are not tracked. This will be fixed in a
     // separate change.
-    verify(metrics, 2L, stats);
+    verify(metrics, 1L, stats);
 
     myghfs.delete(dst);
     verify(metrics, 2L, stats);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
@@ -64,10 +64,6 @@ public class GoogleHadoopFileSystemJavaStorageClientIntegrationTest
 
   @Ignore
   @Test
-  public void testRenameWithMoveOperation() {}
-
-  @Ignore
-  @Test
   public void testGcsJsonAPIMetrics() {
     // TODO: Update this will once gRPC API metrics are added
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -390,7 +390,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   public void testRenameHnBucket() {}
 
   @Override
-  public void testRenameWithMoveOperation() {}
+  public void testRenameWithMoveDisabled() {}
 
   @Override
   public void testGcsJsonAPIMetrics() {}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -67,7 +67,7 @@ public abstract class GoogleCloudStorageOptions {
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setHnBucketRenameEnabled(false)
         .setGrpcWriteEnabled(false)
-        .setMoveOperationEnabled(false)
+        .setMoveOperationEnabled(true)
         .setStorageClientCachingEnabled(false);
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
@@ -118,6 +118,9 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
 
   private static final String GENERATION_MATCH_TOKEN_PARAM_PATTERN = "ifGenerationMatch=[^&]+";
 
+  private static final String SOURCE_GENERATION_MATCH_TOKEN_PARAM_PATTERN =
+      "ifSourceGenerationMatch=[^&]+";
+
   private static final String UPLOAD_ID_PARAM_PATTERN = "upload_id=[^&]+";
 
   private final HttpRequestInitializer delegate;
@@ -167,6 +170,7 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
     AtomicLong pageTokenId = new AtomicLong();
     AtomicLong rewriteTokenId = new AtomicLong();
     AtomicLong generationMatchId = new AtomicLong();
+    AtomicLong sourceGenerationMatchId = new AtomicLong();
     AtomicLong resumableUploadId = new AtomicLong();
     return requests.stream()
         .map(GoogleCloudStorageIntegrationHelper::requestToString)
@@ -174,8 +178,17 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
         .map(r -> replacePageTokenWithId(r, pageTokenId))
         .map(r -> replaceRewriteTokenWithId(r, rewriteTokenId))
         .map(r -> replaceGenerationMatchWithId(r, generationMatchId))
+        .map(r -> replaceSourceGenerationMatchWithId(r, sourceGenerationMatchId))
         .map(r -> replaceResumableUploadIdWithId(r, resumableUploadId))
         .collect(toImmutableList());
+  }
+
+  private String replaceSourceGenerationMatchWithId(String request, AtomicLong generationId) {
+    String idPrefix = "ifSourceGenerationMatch=generationId_";
+    return replaceRequestParams
+        ? replaceWithId(
+            request, SOURCE_GENERATION_MATCH_TOKEN_PARAM_PATTERN, idPrefix, generationId)
+        : request;
   }
 
   public ImmutableList<String> getAllRequestInvocationIds() {
@@ -341,6 +354,27 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
       String bucket, String srcObject, String dstObject, String requestType) {
     return String.format(
         POST_MOVE_REQUEST_FORMAT, bucket, urlEncode(srcObject), requestType, urlEncode(dstObject));
+  }
+
+  public static String moveRequestString(
+      String bucket,
+      String srcObject,
+      String dstObject,
+      String requestType,
+      long generationId,
+      long sourceGenerationId) {
+    String request =
+        String.format(
+            POST_MOVE_REQUEST_FORMAT,
+            bucket,
+            urlEncode(srcObject),
+            requestType,
+            urlEncode(dstObject));
+    return request
+        + "?ifGenerationMatch=generationId_"
+        + generationId
+        + "&ifSourceGenerationMatch=generationId_"
+        + sourceGenerationId;
   }
 
   public static String uploadRequestString(String bucketName, String object, Integer generationId) {


### PR DESCRIPTION
Cherry-picks 
* [Enable move by default](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1417)
* [Enable move test for gRPC](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1502)

