### PR TITLE
[Backport to branch-3.0.x ] Enable move by default 

### DIFF
--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -128,7 +128,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
           put("fs.gs.fadvise.request.track.count", 3);
-          put("fs.gs.operation.move.enable", false);
+          put("fs.gs.operation.move.enable", true);
           put("fs.gs.write.rolling.checksum.enable", true);
         }
       };

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -227,13 +227,13 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   @Test
-  public void testRenameWithMoveOperation() throws Exception {
+  public void testRenameWithMoveDisabled() throws Exception {
     String bucketName = this.gcsiHelper.getUniqueBucketName("move");
     GoogleHadoopFileSystem googleHadoopFileSystem = new GoogleHadoopFileSystem();
 
     URI initUri = new URI("gs://" + bucketName);
     Configuration config = loadConfig();
-    config.setBoolean("fs.gs.operation.move.enable", true);
+    config.setBoolean("fs.gs.operation.move.enable", false);
     googleHadoopFileSystem.initialize(initUri, config);
 
     GoogleCloudStorage theGcs = googleHadoopFileSystem.getGcsFs().getGcs();
@@ -2656,10 +2656,8 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
 
     expected =
         ImmutableMap.<String, Long>builder()
-            .put(
-                GhfsStatistic.ACTION_HTTP_DELETE_REQUEST.getSymbol(),
-                2L) // 1 for file; 1 for directory.
-            .put(GhfsStatistic.ACTION_HTTP_POST_REQUEST.getSymbol(), 1L) // copy file;
+            .put(GhfsStatistic.ACTION_HTTP_DELETE_REQUEST.getSymbol(), 1L) // 1 for directory.
+            .put(GhfsStatistic.ACTION_HTTP_POST_REQUEST.getSymbol(), 1L) // move file;
             .put(
                 GoogleCloudStorageStatistics.GCS_API_CLIENT_NOT_FOUND_RESPONSE_COUNT.getSymbol(),
                 2L) // Check for each parent dirs fails due to NOT FOUND - expected
@@ -2668,7 +2666,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
                 2L) // Check for each parent dirs fails due to NOT FOUND - expected
             .put(
                 GoogleCloudStorageStatistics.GCS_API_REQUEST_COUNT.getSymbol(),
-                9L) // 2 delete + 3 metadata + 2 POST + 1 listDir + 3 listFile
+                8L) // 1 delete + 3 metadata + 2 POST + 1 listDir + 3 listFile
             .put(
                 GoogleCloudStorageStatistics.GCS_LIST_DIR_REQUEST.getSymbol(),
                 1L) // list src files to copy/delete
@@ -2809,7 +2807,7 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
     myghfs.rename(testFilePath, dst);
     // TODO: Operations done async in a separate thread are not tracked. This will be fixed in a
     // separate change.
-    verify(metrics, 2L, stats);
+    verify(metrics, 1L, stats);
 
     myghfs.delete(dst);
     verify(metrics, 2L, stats);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
@@ -64,10 +64,6 @@ public class GoogleHadoopFileSystemJavaStorageClientIntegrationTest
 
   @Ignore
   @Test
-  public void testRenameWithMoveOperation() {}
-
-  @Ignore
-  @Test
   public void testGcsJsonAPIMetrics() {
     // TODO: Update this will once gRPC API metrics are added
   }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -390,7 +390,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   public void testRenameHnBucket() {}
 
   @Override
-  public void testRenameWithMoveOperation() {}
+  public void testRenameWithMoveDisabled() {}
 
   @Override
   public void testGcsJsonAPIMetrics() {}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -67,7 +67,7 @@ public abstract class GoogleCloudStorageOptions {
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setHnBucketRenameEnabled(false)
         .setGrpcWriteEnabled(false)
-        .setMoveOperationEnabled(false);
+        .setMoveOperationEnabled(true);
   }
 
   public abstract Builder toBuilder();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTestBase.java
@@ -22,6 +22,7 @@ import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.delet
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestWithTrailingDelimiter;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.moveRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.uploadRequestString;
 import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getStandardOptionBuilder;
 import static com.google.common.truth.Truth.assertThat;
@@ -904,23 +905,62 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
 
     gcsFs.rename(bucketUri.resolve(dirObject + "/f1"), bucketUri.resolve(dirObject + "/f2"));
 
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getRequestString(bucketName, dirObject + "/f1"),
-            getRequestString(bucketName, dirObject + "/f2"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/"),
-            copyRequestString(
-                bucketName,
-                dirObject + "/f1",
-                bucketName,
-                dirObject + "/f2",
-                "copyTo",
-                /* generationId= */ 1),
-            deleteRequestString(bucketName, dirObject + "/f1", 2));
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getRequestString(bucketName, dirObject + "/f1"),
+              getRequestString(bucketName, dirObject + "/f2"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/"),
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/f1",
+                  dirObject + "/f2",
+                  "moveTo",
+                  /* generationId= */ 1,
+                  /* sourceGenerationId= */ 1));
+
+    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f1"))).isFalse();
+    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f2"))).isTrue();
+  }
+
+  @Test
+  public void rename_file_withMoveDisabled_usesCopyAndDelete() throws Exception {
+    gcsFs =
+        newGcsFs(
+            newGcsFsOptions()
+                .setCloudStorageOptions(
+                    gcsOptions.toBuilder().setMoveOperationEnabled(false).build())
+                .setStatusParallelEnabled(false)
+                .build());
+
+    String bucketName = gcsfsIHelper.sharedBucketName1;
+    URI bucketUri = new URI("gs://" + bucketName + "/");
+    String dirObject = getTestResource();
+
+    gcsfsIHelper.createObjectsWithSubdirs(bucketName, dirObject + "/f1");
+
+    gcsFs.rename(bucketUri.resolve(dirObject + "/f1"), bucketUri.resolve(dirObject + "/f2"));
+
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getRequestString(bucketName, dirObject + "/f1"),
+              getRequestString(bucketName, dirObject + "/f2"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/"),
+              copyRequestString(
+                  bucketName,
+                  dirObject + "/f1",
+                  bucketName,
+                  dirObject + "/f2",
+                  "copyTo",
+                  /* generationId= */ 1),
+              deleteRequestString(bucketName, dirObject + "/f1", 2));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f1"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f2"))).isTrue();
@@ -938,27 +978,26 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
 
     gcsFs.rename(bucketUri.resolve(dirObject + "/f1"), bucketUri.resolve(dirObject + "/f2"));
 
-    // This test performs additional POST request to dirObject when run singly, as result
-    // generationId for delete operation need to be increased for DELETE request.
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getRequestString(bucketName, dirObject + "/f1"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/f1/", /* maxResults= */ 1, /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/f2"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
-            copyRequestString(
-                bucketName,
-                dirObject + "/f1",
-                bucketName,
-                dirObject + "/f2",
-                "copyTo",
-                /* generationId= */ 1),
-            deleteRequestString(bucketName, dirObject + "/f1", /* generationId= */ 2));
+      // This test performs additional POST request to dirObject when run singly, as result
+      // generationId for delete operation need to be increased for DELETE request.
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getRequestString(bucketName, dirObject + "/f1"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f1/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/f2"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/f1",
+                  dirObject + "/f2",
+                  "moveTo",
+                  /* generationId= */ 1,
+                  /* sourceGenerationId= */ 1));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f1"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f2"))).isTrue();
@@ -1039,19 +1078,15 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
                 /* includeTrailingDelimiter= */ null,
                 dirObject + "/srcParent/srcDir/",
                 "bucket,name,generation",
-
-                /* pageToken= */ null),
-            // Copy file
-            copyRequestString(
-                bucketName,
-                dirObject + "/srcParent/srcDir/f",
-                bucketName,
-                dirObject + "/dstParent/dstDir/f",
-                "copyTo"),
-            // Delete src directory and file
-            batchRequestString(),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/f", 1),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 2));
+                  /* pageToken= */ null),
+              // Move file
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/srcParent/srcDir/f",
+                  dirObject + "/dstParent/dstDir/f",
+                  "moveTo"),
+              // Delete src directory
+              deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 1));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir/f"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir"))).isFalse();
@@ -1104,18 +1139,14 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
                 dirObject + "/srcParent/srcDir/",
                 "bucket,name,generation",
 
-                /* pageToken= */ null),
-            // Copy file
-            copyRequestString(
-                bucketName,
-                dirObject + "/srcParent/srcDir/f",
-                bucketName,
-                dirObject + "/dstParent/dstDir/f",
-                "copyTo"),
-            // Delete src directory and file
-            batchRequestString(),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/f", 1),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 2));
+                  /* pageToken= */ null),
+              // Move file
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/srcParent/srcDir/f",
+                  dirObject + "/dstParent/dstDir/f",
+                  "moveTo"),
+              deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 1));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir/f"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir"))).isFalse();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
@@ -118,6 +118,9 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
 
   private static final String GENERATION_MATCH_TOKEN_PARAM_PATTERN = "ifGenerationMatch=[^&]+";
 
+  private static final String SOURCE_GENERATION_MATCH_TOKEN_PARAM_PATTERN =
+      "ifSourceGenerationMatch=[^&]+";
+
   private static final String UPLOAD_ID_PARAM_PATTERN = "upload_id=[^&]+";
 
   private final HttpRequestInitializer delegate;
@@ -167,6 +170,7 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
     AtomicLong pageTokenId = new AtomicLong();
     AtomicLong rewriteTokenId = new AtomicLong();
     AtomicLong generationMatchId = new AtomicLong();
+    AtomicLong sourceGenerationMatchId = new AtomicLong();
     AtomicLong resumableUploadId = new AtomicLong();
     return requests.stream()
         .map(GoogleCloudStorageIntegrationHelper::requestToString)
@@ -174,8 +178,17 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
         .map(r -> replacePageTokenWithId(r, pageTokenId))
         .map(r -> replaceRewriteTokenWithId(r, rewriteTokenId))
         .map(r -> replaceGenerationMatchWithId(r, generationMatchId))
+        .map(r -> replaceSourceGenerationMatchWithId(r, sourceGenerationMatchId))
         .map(r -> replaceResumableUploadIdWithId(r, resumableUploadId))
         .collect(toImmutableList());
+  }
+
+  private String replaceSourceGenerationMatchWithId(String request, AtomicLong generationId) {
+    String idPrefix = "ifSourceGenerationMatch=generationId_";
+    return replaceRequestParams
+        ? replaceWithId(
+            request, SOURCE_GENERATION_MATCH_TOKEN_PARAM_PATTERN, idPrefix, generationId)
+        : request;
   }
 
   public ImmutableList<String> getAllRequestInvocationIds() {
@@ -341,6 +354,27 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
       String bucket, String srcObject, String dstObject, String requestType) {
     return String.format(
         POST_MOVE_REQUEST_FORMAT, bucket, urlEncode(srcObject), requestType, urlEncode(dstObject));
+  }
+
+  public static String moveRequestString(
+      String bucket,
+      String srcObject,
+      String dstObject,
+      String requestType,
+      long generationId,
+      long sourceGenerationId) {
+    String request =
+        String.format(
+            POST_MOVE_REQUEST_FORMAT,
+            bucket,
+            urlEncode(srcObject),
+            requestType,
+            urlEncode(dstObject));
+    return request
+        + "?ifGenerationMatch=generationId_"
+        + generationId
+        + "&ifSourceGenerationMatch=generationId_"
+        + sourceGenerationId;
   }
 
   public static String uploadRequestString(String bucketName, String object, Integer generationId) {


### PR DESCRIPTION
Cherry-picks 
* [Enable move by default](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1417)
* [Enable move test for gRPC](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1502)

