### PR TITLE
[Backport to branch-2.2.x ] Enable move by default 

### DIFF
--- a/gcs/CHANGES.md
+++ b/gcs/CHANGES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Next
+1. Enable move by default
 
 ## 2.2.28 - 2025-05-28
 1. Skip Soft delete using move API during rename

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -154,7 +154,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
           put("fs.gs.fadvise.request.track.count", 3);
-          put("fs.gs.operation.move.enable", false);
+          put("fs.gs.operation.move.enable", true);
         }
       };
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -189,13 +189,13 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   @Test
-  public void testRenameWithMoveOperation() throws Exception {
+  public void testRenameWithMoveDisabled() throws Exception {
     String bucketName = this.gcsiHelper.getUniqueBucketName("move");
     GoogleHadoopFileSystem googleHadoopFileSystem = new GoogleHadoopFileSystem();
 
     URI initUri = new URI("gs://" + bucketName);
     Configuration config = loadConfig();
-    config.setBoolean("fs.gs.operation.move.enable", true);
+    config.setBoolean("fs.gs.operation.move.enable", false);
     googleHadoopFileSystem.initialize(initUri, config);
 
     GoogleCloudStorage theGcs = googleHadoopFileSystem.getGcsFs().getGcs();

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemJavaStorageClientIntegrationTest.java
@@ -61,8 +61,4 @@ public class GoogleHadoopFileSystemJavaStorageClientIntegrationTest
   @Ignore
   @Test
   public void unauthenticatedAccessToPublicBuckets_googleCloudProperties() {}
-
-  @Ignore
-  @Test
-  public void testRenameWithMoveOperation() {}
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -394,7 +394,7 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   public void testRenameHnBucket() {}
 
   @Override
-  public void testRenameWithMoveOperation() {}
+  public void testRenameWithMoveDisabled() {}
 
   @Override
   public void testHnBucketRecursiveDeleteOperationOnDirectory() {}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -142,7 +142,7 @@ public abstract class GoogleCloudStorageOptions {
         .setTraceLogExcludeProperties(ImmutableSet.of())
         .setHnBucketRenameEnabled(SET_HN_BUCKET_CREATE_ENABLED_DEFAULT)
         .setGrpcWriteEnabled(GRPC_WRITE_DEFAULT)
-        .setMoveOperationEnabled(false);
+        .setMoveOperationEnabled(true);
   }
 
   public abstract Builder toBuilder();

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTestBase.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemNewIntegrationTestBase.java
@@ -22,6 +22,7 @@ import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.delet
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestWithTrailingDelimiter;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.moveRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.uploadRequestString;
 import static com.google.cloud.hadoop.gcsio.integration.GoogleCloudStorageTestHelper.getStandardOptionBuilder;
 import static com.google.common.truth.Truth.assertThat;
@@ -831,23 +832,64 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
 
     gcsFs.rename(bucketUri.resolve(dirObject + "/f1"), bucketUri.resolve(dirObject + "/f2"));
 
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getRequestString(bucketName, dirObject + "/f1"),
-            getRequestString(bucketName, dirObject + "/f2"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/"),
-            copyRequestString(
-                bucketName,
-                dirObject + "/f1",
-                bucketName,
-                dirObject + "/f2",
-                "copyTo",
-                /* generationId= */ 1),
-            deleteRequestString(bucketName, dirObject + "/f1", 2));
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getRequestString(bucketName, dirObject + "/f1"),
+              getRequestString(bucketName, dirObject + "/f2"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/"),
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/f1",
+                  dirObject + "/f2",
+                  "moveTo",
+                  /* generationId= */ 1,
+                  /* sourceGenerationId= */ 1));
+
+    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f1"))).isFalse();
+    assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f2"))).isTrue();
+  }
+
+  @Test
+  public void rename_file_withMoveDisabled_usesCopyAndDelete() throws Exception {
+    TrackingHttpRequestInitializer gcsRequestsTracker =
+        new TrackingHttpRequestInitializer(httpRequestsInitializer);
+    gcsFs =
+        newGcsFs(
+            newGcsFsOptions()
+                .setCloudStorageOptions(
+                    gcsOptions.toBuilder().setMoveOperationEnabled(false).build())
+                .setStatusParallelEnabled(false)
+                .build(), gcsRequestsTracker);
+
+    String bucketName = gcsfsIHelper.sharedBucketName1;
+    URI bucketUri = new URI("gs://" + bucketName + "/");
+    String dirObject = getTestResource();
+
+    gcsfsIHelper.createObjectsWithSubdirs(bucketName, dirObject + "/f1");
+
+    gcsFs.rename(bucketUri.resolve(dirObject + "/f1"), bucketUri.resolve(dirObject + "/f2"));
+
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getRequestString(bucketName, dirObject + "/f1"),
+              getRequestString(bucketName, dirObject + "/f2"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/"),
+              copyRequestString(
+                  bucketName,
+                  dirObject + "/f1",
+                  bucketName,
+                  dirObject + "/f2",
+                  "copyTo",
+                  /* generationId= */ 1),
+              deleteRequestString(bucketName, dirObject + "/f1", 2));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f1"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f2"))).isTrue();
@@ -870,27 +912,26 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
 
     gcsFs.rename(bucketUri.resolve(dirObject + "/f1"), bucketUri.resolve(dirObject + "/f2"));
 
-    // This test performs additional POST request to dirObject when run singly, as result
-    // generationId for delete operation need to be increased for DELETE request.
-    assertThat(gcsRequestsTracker.getAllRequestStrings())
-        .containsExactly(
-            getRequestString(bucketName, dirObject + "/f1"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/f1/", /* maxResults= */ 1, /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/f2"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
-            getRequestString(bucketName, dirObject + "/"),
-            listRequestWithTrailingDelimiter(
-                bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
-            copyRequestString(
-                bucketName,
-                dirObject + "/f1",
-                bucketName,
-                dirObject + "/f2",
-                "copyTo",
-                /* generationId= */ 1),
-            deleteRequestString(bucketName, dirObject + "/f1", /* generationId= */ 2));
+      // This test performs additional POST request to dirObject when run singly, as result
+      // generationId for delete operation need to be increased for DELETE request.
+      assertThat(gcsRequestsTracker.getAllRequestStrings())
+          .containsExactly(
+              getRequestString(bucketName, dirObject + "/f1"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f1/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/f2"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/f2/", /* maxResults= */ 1, /* pageToken= */ null),
+              getRequestString(bucketName, dirObject + "/"),
+              listRequestWithTrailingDelimiter(
+                  bucketName, dirObject + "/", /* maxResults= */ 1, /* pageToken= */ null),
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/f1",
+                  dirObject + "/f2",
+                  "moveTo",
+                  /* generationId= */ 1,
+                  /* sourceGenerationId= */ 1));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f1"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/f2"))).isTrue();
@@ -980,19 +1021,15 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
                 /* includeTrailingDelimiter= */ null,
                 dirObject + "/srcParent/srcDir/",
                 "bucket,name,generation",
-
-                /* pageToken= */ null),
-            // Copy file
-            copyRequestString(
-                bucketName,
-                dirObject + "/srcParent/srcDir/f",
-                bucketName,
-                dirObject + "/dstParent/dstDir/f",
-                "copyTo"),
-            // Delete src directory and file
-            batchRequestString(),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/f", 1),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 2));
+                  /* pageToken= */ null),
+              // Move file
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/srcParent/srcDir/f",
+                  dirObject + "/dstParent/dstDir/f",
+                  "moveTo"),
+              // Delete src directory
+              deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 1));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir/f"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir"))).isFalse();
@@ -1049,19 +1086,14 @@ public abstract class GoogleCloudStorageFileSystemNewIntegrationTestBase {
                 /* includeTrailingDelimiter= */ null,
                 dirObject + "/srcParent/srcDir/",
                 "bucket,name,generation",
-
-                /* pageToken= */ null),
-            // Copy file
-            copyRequestString(
-                bucketName,
-                dirObject + "/srcParent/srcDir/f",
-                bucketName,
-                dirObject + "/dstParent/dstDir/f",
-                "copyTo"),
-            // Delete src directory and file
-            batchRequestString(),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/f", 1),
-            deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 2));
+                  /* pageToken= */ null),
+              // Move file
+              moveRequestString(
+                  bucketName,
+                  dirObject + "/srcParent/srcDir/f",
+                  dirObject + "/dstParent/dstDir/f",
+                  "moveTo"),
+              deleteRequestString(bucketName, dirObject + "/srcParent/srcDir/", 1));
 
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir/f"))).isFalse();
     assertThat(gcsFs.exists(bucketUri.resolve(dirObject + "/srcParent/srcDir"))).isFalse();


### PR DESCRIPTION
Cherry-picks 
* [Enable move by default](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1417)
* [Enable move test for gRPC](https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/1502)

