### PR TITLE
Update documentation

### DIFF
--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -151,6 +151,26 @@
     fs.gs.storage.http.headers.another-custom-header=another_custom_value
     ```
 
+*   `fs.gs.application.name.suffix` (not set by default)
+
+    Suffix that will be added to HTTP `User-Agent` header set in all Cloud
+    Storage requests.
+    When `fs.gs.cloud.logging.enable` is set to `true`, this suffix will be appended to the log name `gcs-connector` to
+    form the final log name. For example, if set to `my-app`, log name in GCP Logging will be `gcs-connector-my-app`.
+
+*   `fs.gs.proxy.address` (not set by default)
+
+    Proxy address that connector can use to send Cloud Storage requests. The
+    proxy must be an HTTP proxy and address should be in the `host:port` form.
+
+*   `fs.gs.proxy.username` (not set by default)
+
+    Proxy username that connector can use to send Cloud Storage requests.
+
+*   `fs.gs.proxy.password` (not set by default)
+
+    Proxy password that connector can use to send Cloud Storage requests.
+
 ### Encryption ([CSEK](https://cloud.google.com/storage/docs/encryption/customer-supplied-keys))
 
 *   `fs.gs.encryption.algorithm` (not set by default)
@@ -382,26 +402,6 @@ Knobs configure the vectoredRead API
    is overloaded do consider increasing this value.
 
 ### HTTP transport configuration
-
-*   `fs.gs.application.name.suffix` (not set by default)
-
-    Suffix that will be added to HTTP `User-Agent` header set in all Cloud
-    Storage requests.
-    When `fs.gs.cloud.logging.enable` is set to `true`, this suffix will be appended to the log name `gcs-connector` to
-    form the final log name. For example, if set to `my-app`, log name in GCP Logging will be `gcs-connector-my-app`.
-
-*   `fs.gs.proxy.address` (not set by default)
-
-    Proxy address that connector can use to send Cloud Storage requests. The
-    proxy must be an HTTP proxy and address should be in the `host:port` form.
-
-*   `fs.gs.proxy.username` (not set by default)
-
-    Proxy username that connector can use to send Cloud Storage requests.
-
-*   `fs.gs.proxy.password` (not set by default)
-
-    Proxy password that connector can use to send Cloud Storage requests.
 
 **Note: Retry configuration is only valid for client type=HTTP_API_CLIENT for now.**
 


### PR DESCRIPTION
The following configurations are not specific to JSON and have been moved to a more general section in the documentation for clarity:
- `fs.gs.application.name.suffix` 
- `fs.gs.proxy.address` 
- `fs.gs.proxy.username` 
- `fs.gs.proxy.password`
