### PR TITLE
Bug Fix: Set projectId in Storage client creation

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProvider.java
@@ -174,6 +174,7 @@ public class StorageClientProvider {
             credentials != null ? credentials : getNoCredentials(downscopedAccessTokenFn))
         .setBlobWriteSessionConfig(
             getSessionConfig(storageOptions.getWriteChannelOptions(), pCUExecutorService))
+        .setProjectId(storageOptions.getProjectId())
         .build()
         .getService();
   }


### PR DESCRIPTION
This change fixes a critical bug in `StorageClientProvider` where the projectId from `GoogleCloudStorageOptions` was not being used. This omission led to incorrect client configuration.