### PR TITLE
feat: Add fs.gs.universe.domain support for Google multi-universe (TPC)

### DIFF
--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -427,7 +427,13 @@ Knobs configure the vectoredRead API
 
 *   `fs.gs.storage.root.url` (default: `https://storage.googleapis.com/`)
 
-    Google Cloud Storage root URL.
+    Google Cloud Storage root URL. This only overrides the JSON/REST endpoint and
+    carries no universe semantics (no credential universe-domain validation, and
+    it does not affect the gRPC endpoint). For Trusted Partner Cloud /
+    multi-universe (TPC) deployments, prefer `fs.gs.universe.domain`, which routes
+    both the JSON/REST and gRPC clients and validates the credentials' universe
+    domain. When both are set, this explicit root URL takes precedence over the
+    universe-domain-derived endpoint.
 
 *   `fs.gs.storage.service.path` (default: `storage/v1/`)
 

--- a/gcs/CONFIGURATION.md
+++ b/gcs/CONFIGURATION.md
@@ -433,6 +433,18 @@ Knobs configure the vectoredRead API
 
     Google Cloud Storage service path.
 
+*   `fs.gs.universe.domain` (default: none)
+
+    Universe domain to target, for Trusted Partner Cloud / multi-universe
+    deployments (e.g. `my-partner-universe.com`). When set, both the JSON/REST
+    and gRPC clients route requests to `storage.<universe-domain>` and validate
+    it against the credentials' universe domain. When unset, the
+    `GOOGLE_CLOUD_UNIVERSE_DOMAIN` environment variable is used as a fallback;
+    if that is also unset, the default Google universe (`googleapis.com`) is
+    targeted. An explicitly configured `fs.gs.storage.root.url` takes precedence
+    over the universe-domain-derived endpoint. Direct Google Access (DirectPath)
+    is automatically disabled for non-default universes.
+
 ### Fadvise feature configuration
 
 *   `fs.gs.inputstream.fadvise` (default: `AUTO`)

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -65,7 +65,15 @@ public class GoogleHadoopFileSystemConfiguration {
   // Configuration settings.
   // -----------------------------------------------------------------
 
-  /** Configuration key for the Cloud Storage API endpoint root URL. */
+  /**
+   * Configuration key for the Cloud Storage API endpoint root URL.
+   *
+   * <p>This only overrides the JSON/REST endpoint and carries no universe semantics (no credential
+   * universe-domain validation, and no effect on the gRPC endpoint). For Trusted Partner Cloud /
+   * multi-universe (TPC) deployments, prefer {@link #GCS_UNIVERSE_DOMAIN}, which routes both the
+   * JSON/REST and gRPC clients and validates the credentials' universe domain. When both are set,
+   * this explicit root URL takes precedence over the universe-domain-derived endpoint.
+   */
   public static final HadoopConfigurationProperty<String> GCS_ROOT_URL =
       new HadoopConfigurationProperty<>(
           "fs.gs.storage.root.url", GoogleCloudStorageOptions.DEFAULT.getStorageRootUrl());

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -21,6 +21,7 @@ import static com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.PROXY_
 import static com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.PROXY_USERNAME_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.READ_TIMEOUT_SUFFIX;
 import static com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.getConfigKeyPrefixes;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.Math.toIntExact;
 
@@ -73,6 +74,19 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<String> GCS_SERVICE_PATH =
       new HadoopConfigurationProperty<>(
           "fs.gs.storage.service.path", GoogleCloudStorageOptions.DEFAULT.getStorageServicePath());
+
+  /**
+   * Configuration key for the Cloud Storage universe domain (e.g. for Trusted Partner Cloud /
+   * multi-universe deployments). When unset, the {@value #GOOGLE_CLOUD_UNIVERSE_DOMAIN_ENV_VAR}
+   * environment variable is used; if that is also unset, the default Google universe
+   * ({@code googleapis.com}) is targeted.
+   */
+  public static final HadoopConfigurationProperty<String> GCS_UNIVERSE_DOMAIN =
+      new HadoopConfigurationProperty<>("fs.gs.universe.domain", "");
+
+  /** Environment variable consulted as a fallback for the universe domain. */
+  @VisibleForTesting
+  static final String GOOGLE_CLOUD_UNIVERSE_DOMAIN_ENV_VAR = "GOOGLE_CLOUD_UNIVERSE_DOMAIN";
 
   /**
    * Key for the permissions that we report a file or directory to have. Can either be octal or
@@ -714,6 +728,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setRequesterPaysOptions(getRequesterPaysOptions(config, projectId))
         .setStorageRootUrl(GCS_ROOT_URL.get(config, config::get))
         .setStorageServicePath(GCS_SERVICE_PATH.get(config, config::get))
+        .setUniverseDomain(
+            resolveUniverseDomain(config, System.getenv(GOOGLE_CLOUD_UNIVERSE_DOMAIN_ENV_VAR)))
         .setTraceLogEnabled(GCS_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setOperationTraceLogEnabled(GCS_OPERATION_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setTrafficDirectorEnabled(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.get(config, config::getBoolean))
@@ -724,6 +740,25 @@ public class GoogleHadoopFileSystemConfiguration {
         .setFinalizeBeforeClose(
             GCS_APPENDABLE_OBJECTS_FINALIZE_BEFORE_CLOSE.get(config, config::getBoolean))
         .setHnOptimizationEnabled(GCS_HNS_OPTIMIZATION_ENABLE.get(config, config::getBoolean));
+  }
+
+  /**
+   * Resolves the universe domain to target. Precedence: the {@code fs.gs.universe.domain} property,
+   * then the {@code GOOGLE_CLOUD_UNIVERSE_DOMAIN} environment variable, then {@code null} (the
+   * default Google universe, googleapis.com).
+   *
+   * @param config the Hadoop configuration to read the property from
+   * @param envUniverseDomain the value of the {@code GOOGLE_CLOUD_UNIVERSE_DOMAIN} environment
+   *     variable (passed in for testability), may be {@code null}
+   * @return the resolved universe domain, or {@code null} for the default Google universe
+   */
+  @VisibleForTesting
+  static String resolveUniverseDomain(Configuration config, String envUniverseDomain) {
+    String fromConfig = GCS_UNIVERSE_DOMAIN.get(config, config::get);
+    if (!isNullOrEmpty(fromConfig)) {
+      return fromConfig;
+    }
+    return isNullOrEmpty(envUniverseDomain) ? null : envUniverseDomain;
   }
 
   @VisibleForTesting

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -78,8 +78,8 @@ public class GoogleHadoopFileSystemConfiguration {
   /**
    * Configuration key for the Cloud Storage universe domain (e.g. for Trusted Partner Cloud /
    * multi-universe deployments). When unset, the {@value #GOOGLE_CLOUD_UNIVERSE_DOMAIN_ENV_VAR}
-   * environment variable is used; if that is also unset, the default Google universe
-   * ({@code googleapis.com}) is targeted.
+   * environment variable is used; if that is also unset, the default Google universe ({@code
+   * googleapis.com}) is targeted.
    */
   public static final HadoopConfigurationProperty<String> GCS_UNIVERSE_DOMAIN =
       new HadoopConfigurationProperty<>("fs.gs.universe.domain", "");

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -319,8 +319,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
   public void resolveUniverseDomain_emptyEnv_returnsNull() {
     Configuration config = new Configuration();
 
-    assertThat(GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(config, ""))
-        .isNull();
+    assertThat(GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(config, "")).isNull();
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -122,6 +122,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
           put("fs.gs.storage.http.headers.", ImmutableMap.of());
           put("fs.gs.storage.root.url", "https://storage.googleapis.com/");
           put("fs.gs.storage.service.path", "storage/v1/");
+          put("fs.gs.universe.domain", "");
           put("fs.gs.tracelog.enable", false);
           put("fs.gs.operation.tracelog.enable", false);
           put("fs.gs.working.dir", "/");
@@ -302,6 +303,65 @@ public class GoogleHadoopFileSystemConfigurationTest {
 
     assertThat(options.getStorageRootUrl()).isEqualTo("https://unit-test-storage.googleapis.com/");
     assertThat(options.getStorageServicePath()).isEqualTo("storage/dev_v1/");
+  }
+
+  @Test
+  public void resolveUniverseDomain_unset_returnsNull() {
+    Configuration config = new Configuration();
+
+    assertThat(
+            GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(
+                config, /* envUniverseDomain= */ null))
+        .isNull();
+  }
+
+  @Test
+  public void resolveUniverseDomain_emptyEnv_returnsNull() {
+    Configuration config = new Configuration();
+
+    assertThat(GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(config, ""))
+        .isNull();
+  }
+
+  @Test
+  public void resolveUniverseDomain_fromEnvOnly_returnsEnv() {
+    Configuration config = new Configuration();
+
+    assertThat(
+            GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(config, "env-universe.com"))
+        .isEqualTo("env-universe.com");
+  }
+
+  @Test
+  public void resolveUniverseDomain_fromConfigOnly_returnsConfig() {
+    Configuration config = new Configuration();
+    config.set("fs.gs.universe.domain", "config-universe.com");
+
+    assertThat(
+            GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(
+                config, /* envUniverseDomain= */ null))
+        .isEqualTo("config-universe.com");
+  }
+
+  @Test
+  public void resolveUniverseDomain_configWinsOverEnv() {
+    Configuration config = new Configuration();
+    config.set("fs.gs.universe.domain", "config-universe.com");
+
+    assertThat(
+            GoogleHadoopFileSystemConfiguration.resolveUniverseDomain(config, "env-universe.com"))
+        .isEqualTo("config-universe.com");
+  }
+
+  @Test
+  public void getGcsOptionsBuilder_propagatesConfiguredUniverseDomain() {
+    Configuration config = new Configuration();
+    config.set("fs.gs.universe.domain", "config-universe.com");
+
+    GoogleCloudStorageOptions options =
+        GoogleHadoopFileSystemConfiguration.getGcsOptionsBuilder(config).build();
+
+    assertThat(options.getUniverseDomain()).isEqualTo("config-universe.com");
   }
 
   @Test

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -358,7 +358,8 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
                 options.getProxyAddress(),
                 options.getProxyUsername(),
                 options.getProxyPassword(),
-                options.getHttpRequestReadTimeout())
+                options.getHttpRequestReadTimeout(),
+                /* useSystemDefaultTrustStore= */ usesNonGoogleEndpoint(options))
             : httpTransport;
     this.storage = createApiaryStorage(options, finalHttpTransport, this.httpRequestInitializer);
     this.credential = credentials;
@@ -406,6 +407,20 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
   private static boolean isCustomStorageEndpoint(GoogleCloudStorageOptions options) {
     return !Storage.DEFAULT_ROOT_URL.equals(options.getStorageRootUrl())
         || !Storage.DEFAULT_SERVICE_PATH.equals(options.getStorageServicePath());
+  }
+
+  /**
+   * Returns {@code true} when requests are routed to a non-Google endpoint: either a custom storage
+   * root URL/service path, or a non-default universe domain (which derives a {@code
+   * storage.<universeDomain>} host). Such endpoints present certificates that are not in Google's
+   * bundled trust store, so the transport must fall back to the JVM default trust store.
+   */
+  private static boolean usesNonGoogleEndpoint(GoogleCloudStorageOptions options) {
+    String universeDomain = options.getUniverseDomain();
+    boolean nonDefaultUniverse =
+        !isNullOrEmpty(universeDomain)
+            && !Credentials.GOOGLE_DEFAULT_UNIVERSE.equals(universeDomain);
+    return isCustomStorageEndpoint(options) || nonDefaultUniverse;
   }
 
   private ExecutorService createManualBatchingThreadPool() {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -360,13 +360,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
                 options.getProxyPassword(),
                 options.getHttpRequestReadTimeout())
             : httpTransport;
-    this.storage =
-        new Storage.Builder(
-                finalHttpTransport, GsonFactory.getDefaultInstance(), this.httpRequestInitializer)
-            .setRootUrl(options.getStorageRootUrl())
-            .setServicePath(options.getStorageServicePath())
-            .setApplicationName(options.getAppName())
-            .build();
+    this.storage = createApiaryStorage(options, finalHttpTransport, this.httpRequestInitializer);
     this.credential = credentials;
     this.storageRequestFactory = new StorageRequestFactory(storage);
 
@@ -374,6 +368,45 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
         MetricsSink.CLOUD_MONITORING == options.getMetricsSink()
             ? CloudMonitoringMetricsRecorder.create(options.getProjectId(), finalCredentials)
             : new NoOpMetricsRecorder();
+  }
+
+  /**
+   * Builds the Apiary (JSON/REST) Storage client, honoring the configured universe domain.
+   *
+   * <p>When a universe domain is set, it is passed to the client so it can derive the endpoint
+   * ({@code https://storage.<universeDomain>/}). The endpoint root URL/service path are only set
+   * explicitly when the user configured a custom endpoint, because calling {@code setRootUrl()}
+   * forces the underlying client into "user configured endpoint" mode, which bypasses
+   * universe-domain endpoint construction.
+   */
+  @VisibleForTesting
+  static Storage createApiaryStorage(
+      GoogleCloudStorageOptions options,
+      HttpTransport httpTransport,
+      HttpRequestInitializer httpRequestInitializer) {
+    Storage.Builder storageBuilder =
+        new Storage.Builder(
+                httpTransport, GsonFactory.getDefaultInstance(), httpRequestInitializer)
+            .setApplicationName(options.getAppName());
+    if (!isNullOrEmpty(options.getUniverseDomain())) {
+      storageBuilder.setUniverseDomain(options.getUniverseDomain());
+    }
+    if (isCustomStorageEndpoint(options)) {
+      storageBuilder
+          .setRootUrl(options.getStorageRootUrl())
+          .setServicePath(options.getStorageServicePath());
+    }
+    return storageBuilder.build();
+  }
+
+  /**
+   * Returns {@code true} when the user configured a custom Cloud Storage endpoint (root URL or
+   * service path) that differs from the SDK default. An explicit endpoint takes precedence over any
+   * universe-domain-derived endpoint.
+   */
+  private static boolean isCustomStorageEndpoint(GoogleCloudStorageOptions options) {
+    return !Storage.DEFAULT_ROOT_URL.equals(options.getStorageRootUrl())
+        || !Storage.DEFAULT_SERVICE_PATH.equals(options.getStorageServicePath());
   }
 
   private ExecutorService createManualBatchingThreadPool() {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -385,8 +385,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
       HttpTransport httpTransport,
       HttpRequestInitializer httpRequestInitializer) {
     Storage.Builder storageBuilder =
-        new Storage.Builder(
-                httpTransport, GsonFactory.getDefaultInstance(), httpRequestInitializer)
+        new Storage.Builder(httpTransport, GsonFactory.getDefaultInstance(), httpRequestInitializer)
             .setApplicationName(options.getAppName());
     if (!isNullOrEmpty(options.getUniverseDomain())) {
       storageBuilder.setUniverseDomain(options.getUniverseDomain());

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -90,6 +90,13 @@ public abstract class GoogleCloudStorageOptions {
 
   public abstract String getStorageServicePath();
 
+  /**
+   * Universe domain to target (e.g. for Trusted Partner Cloud / multi-universe deployments). When
+   * {@code null} or empty the client uses the default Google universe ({@code googleapis.com}).
+   */
+  @Nullable
+  public abstract String getUniverseDomain();
+
   public abstract boolean isGrpcWriteEnabled();
 
   @Nullable
@@ -187,6 +194,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setStorageRootUrl(String rootUrl);
 
     public abstract Builder setStorageServicePath(String servicePath);
+
+    public abstract Builder setUniverseDomain(@Nullable String universeDomain);
 
     public abstract Builder setProjectId(String projectId);
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProvider.java
@@ -150,7 +150,7 @@ public class StorageClientProvider {
         .setIsTracingEnabled(storageOptions.isTraceLogEnabled())
         .setWriteChannelOptions(storageOptions.getWriteChannelOptions())
         .setProjectId(storageOptions.getProjectId())
-        .setUniverseDomain(storageOptions.getUniverseDomain())
+        .setUniverseDomain(Strings.emptyToNull(storageOptions.getUniverseDomain()))
         .build();
   }
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProvider.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProvider.java
@@ -22,9 +22,11 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.hadoop.util.AccessBoundary;
+import com.google.cloud.storage.GrpcStorageOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
@@ -148,6 +150,7 @@ public class StorageClientProvider {
         .setIsTracingEnabled(storageOptions.isTraceLogEnabled())
         .setWriteChannelOptions(storageOptions.getWriteChannelOptions())
         .setProjectId(storageOptions.getProjectId())
+        .setUniverseDomain(storageOptions.getUniverseDomain())
         .build();
   }
 
@@ -175,18 +178,32 @@ public class StorageClientProvider {
     final ImmutableMap<String, String> headers =
         getUpdatedHeaders(storageOptions, featureHeaderGenerator);
 
-    return StorageOptions.grpc()
-        .setAttemptDirectPath(storageOptions.isDirectPathPreferred())
-        .setHeaderProvider(() -> headers)
-        .setGrpcInterceptorProvider(
-            () -> getInterceptors(interceptors, storageOptions, downscopedAccessTokenFn))
-        .setCredentials(
-            credentials != null ? credentials : getNoCredentials(downscopedAccessTokenFn))
-        .setBlobWriteSessionConfig(
-            getSessionConfig(storageOptions.getWriteChannelOptions(), pCUExecutorService))
-        .setProjectId(storageOptions.getProjectId())
-        .build()
-        .getService();
+    String universeDomain = storageOptions.getUniverseDomain();
+    boolean nonDefaultUniverse =
+        !Strings.isNullOrEmpty(universeDomain)
+            && !Credentials.GOOGLE_DEFAULT_UNIVERSE.equals(universeDomain);
+    // Direct Google Access (DirectPath) is only available in the default universe
+    // (googleapis.com); disable it for any other universe so requests route through
+    // storage.<universeDomain>.
+    boolean attemptDirectPath = storageOptions.isDirectPathPreferred() && !nonDefaultUniverse;
+
+    GrpcStorageOptions.Builder storageOptionsBuilder =
+        StorageOptions.grpc()
+            .setAttemptDirectPath(attemptDirectPath)
+            .setHeaderProvider(() -> headers)
+            .setGrpcInterceptorProvider(
+                () -> getInterceptors(interceptors, storageOptions, downscopedAccessTokenFn))
+            .setCredentials(
+                credentials != null ? credentials : getNoCredentials(downscopedAccessTokenFn))
+            .setBlobWriteSessionConfig(
+                getSessionConfig(storageOptions.getWriteChannelOptions(), pCUExecutorService))
+            .setProjectId(storageOptions.getProjectId());
+    if (!Strings.isNullOrEmpty(universeDomain)) {
+      // The storage client rewrites the host to https://storage.<universeDomain> when a universe
+      // domain is set, so an explicit setHost() is not required here.
+      storageOptionsBuilder.setUniverseDomain(universeDomain);
+    }
+    return storageOptionsBuilder.build().getService();
   }
 
   private static ImmutableList<ClientInterceptor> getInterceptors(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProviderCacheKey.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/StorageClientProviderCacheKey.java
@@ -50,6 +50,10 @@ public abstract class StorageClientProviderCacheKey {
 
   public abstract boolean getIsDirectPathPreferred();
 
+  /** Universe domain to target, or null for the default Google universe (googleapis.com). */
+  @Nullable
+  public abstract String getUniverseDomain();
+
   public abstract StorageClientProviderCacheKey.Builder toBuilder();
 
   @AutoValue.Builder
@@ -67,6 +71,8 @@ public abstract class StorageClientProviderCacheKey {
     public abstract Builder setProjectId(String value);
 
     public abstract Builder setIsDirectPathPreferred(boolean value);
+
+    public abstract Builder setUniverseDomain(@Nullable String value);
 
     public abstract StorageClientProviderCacheKey build();
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplUniverseDomainTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplUniverseDomainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplUniverseDomainTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplUniverseDomainTest.java
@@ -24,7 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for universe-domain handling in {@link GoogleCloudStorageImpl#createApiaryStorage}. */
+/**
+ * Unit tests for universe-domain handling in {@link GoogleCloudStorageImpl#createApiaryStorage}.
+ */
 @RunWith(JUnit4.class)
 public class GoogleCloudStorageImplUniverseDomainTest {
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplUniverseDomainTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImplUniverseDomainTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.gcsio;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.services.storage.Storage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for universe-domain handling in {@link GoogleCloudStorageImpl#createApiaryStorage}. */
+@RunWith(JUnit4.class)
+public class GoogleCloudStorageImplUniverseDomainTest {
+
+  private static final String APP_NAME = "gcs-connector-test";
+
+  private static GoogleCloudStorageOptions.Builder optionsBuilder() {
+    return GoogleCloudStorageOptions.builder().setAppName(APP_NAME);
+  }
+
+  private static Storage createStorage(GoogleCloudStorageOptions options) {
+    return GoogleCloudStorageImpl.createApiaryStorage(
+        options, new MockHttpTransport(), /* httpRequestInitializer= */ null);
+  }
+
+  @Test
+  public void noUniverseDomain_usesDefaultGoogleEndpoint() {
+    Storage storage = createStorage(optionsBuilder().build());
+
+    assertThat(storage.getUniverseDomain()).isEqualTo("googleapis.com");
+    assertThat(storage.getBaseUrl()).isEqualTo("https://storage.googleapis.com/storage/v1/");
+  }
+
+  @Test
+  public void universeDomain_derivesEndpointFromUniverseDomain() {
+    Storage storage = createStorage(optionsBuilder().setUniverseDomain("my-universe.com").build());
+
+    assertThat(storage.getUniverseDomain()).isEqualTo("my-universe.com");
+    assertThat(storage.getRootUrl()).isEqualTo("https://storage.my-universe.com/");
+    assertThat(storage.getBaseUrl()).isEqualTo("https://storage.my-universe.com/storage/v1/");
+  }
+
+  @Test
+  public void customRootUrl_overridesUniverseDomainEndpoint() {
+    Storage storage =
+        createStorage(
+            optionsBuilder()
+                .setUniverseDomain("my-universe.com")
+                .setStorageRootUrl("https://custom-endpoint.example.com/")
+                .build());
+
+    // An explicitly configured endpoint takes precedence over the universe-domain-derived one,
+    // while the universe domain is still reported (and used for credential validation).
+    assertThat(storage.getUniverseDomain()).isEqualTo("my-universe.com");
+    assertThat(storage.getRootUrl()).isEqualTo("https://custom-endpoint.example.com/");
+  }
+
+  @Test
+  public void customRootUrl_withoutUniverseDomain_isHonored() {
+    Storage storage =
+        createStorage(
+            optionsBuilder().setStorageRootUrl("https://custom-endpoint.example.com/").build());
+
+    assertThat(storage.getRootUrl()).isEqualTo("https://custom-endpoint.example.com/");
+  }
+}

--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -100,9 +100,45 @@ public class HttpTransportFactory {
       @Nullable RedactedString proxyPassword,
       @Nullable Duration readTimeout)
       throws IOException {
+    return createHttpTransport(
+        proxyAddress,
+        proxyUsername,
+        proxyPassword,
+        readTimeout,
+        /* useSystemDefaultTrustStore= */ false);
+  }
+
+  /**
+   * Create an {@link HttpTransport} based on a type class, optional HTTP proxy, optional socket
+   * read timeout and a choice of certificate trust store.
+   *
+   * @param proxyAddress The HTTP proxy to use with the transport. Of the form hostname:port. If
+   *     empty no proxy will be used.
+   * @param proxyUsername The HTTP proxy username to use with the transport. If empty no proxy
+   *     username will be used.
+   * @param proxyPassword The HTTP proxy password to use with the transport. If empty no proxy
+   *     password will be used.
+   * @param readTimeout The socket read timeout to apply immediately on all HTTP requests. If empty,
+   *     no socket read timeout will be applied.
+   * @param useSystemDefaultTrustStore When {@code true}, validate TLS certificates against the
+   *     JVM's default trust store instead of Google's bundled certificate trust store. This is
+   *     required for custom endpoints (e.g. Trusted Partner Cloud / non-default universe domains)
+   *     whose CA is not part of Google's bundle. Default Google endpoints should pass {@code
+   *     false}.
+   * @return The resulting HttpTransport.
+   * @throws IllegalArgumentException If the proxy address is invalid.
+   * @throws IOException If there is an issue connecting to Google's Certification server.
+   */
+  public static HttpTransport createHttpTransport(
+      @Nullable String proxyAddress,
+      @Nullable RedactedString proxyUsername,
+      @Nullable RedactedString proxyPassword,
+      @Nullable Duration readTimeout,
+      boolean useSystemDefaultTrustStore)
+      throws IOException {
     logger.atFiner().log(
-        "createHttpTransport(%s, %s, %s, %s)",
-        proxyAddress, proxyUsername, proxyPassword, readTimeout);
+        "createHttpTransport(%s, %s, %s, %s, %s)",
+        proxyAddress, proxyUsername, proxyPassword, readTimeout, useSystemDefaultTrustStore);
     checkArgument(
         proxyAddress != null || (proxyUsername == null && proxyPassword == null),
         "if proxyAddress is null then proxyUsername and proxyPassword should be null too");
@@ -116,7 +152,7 @@ public class HttpTransportFactory {
               ? new PasswordAuthentication(
                   proxyUsername.value(), proxyPassword.value().toCharArray())
               : null;
-      return createNetHttpTransport(proxyUri, proxyAuth, readTimeout);
+      return createNetHttpTransport(proxyUri, proxyAuth, readTimeout, useSystemDefaultTrustStore);
     } catch (GeneralSecurityException e) {
       throw new IOException(e);
     }
@@ -136,6 +172,29 @@ public class HttpTransportFactory {
       @Nullable URI proxyUri,
       @Nullable PasswordAuthentication proxyAuth,
       @Nullable Duration readTimeout)
+      throws IOException, GeneralSecurityException {
+    return createNetHttpTransport(
+        proxyUri, proxyAuth, readTimeout, /* useSystemDefaultTrustStore= */ false);
+  }
+
+  /**
+   * Create an {@link NetHttpTransport} for calling Google APIs with an optional HTTP proxy and a
+   * choice of certificate trust store.
+   *
+   * @param proxyUri Optional HTTP proxy URI to use with the transport.
+   * @param proxyAuth Optional HTTP proxy credentials to authenticate with the transport proxy.
+   * @param readTimeout Optional socket read timeout to apply immediately on all HTTP requests.
+   * @param useSystemDefaultTrustStore When {@code true}, validate TLS certificates against the
+   *     JVM's default trust store instead of Google's bundled certificate trust store.
+   * @return The resulting HttpTransport.
+   * @throws IOException If there is an issue connecting to Google's certification server.
+   * @throws GeneralSecurityException If there is a security issue with the keystore.
+   */
+  public static NetHttpTransport createNetHttpTransport(
+      @Nullable URI proxyUri,
+      @Nullable PasswordAuthentication proxyAuth,
+      @Nullable Duration readTimeout,
+      boolean useSystemDefaultTrustStore)
       throws IOException, GeneralSecurityException {
     checkArgument(
         proxyUri != null || proxyAuth == null,
@@ -158,14 +217,28 @@ public class HttpTransportFactory {
             }
           });
     }
-    return createNetHttpTransportBuilder(proxyUri, readTimeout).build();
+    return createNetHttpTransportBuilder(proxyUri, readTimeout, useSystemDefaultTrustStore).build();
   }
 
   @VisibleForTesting
   static NetHttpTransport.Builder createNetHttpTransportBuilder(
       @Nullable URI proxyUri, @Nullable Duration readTimeout)
       throws IOException, GeneralSecurityException {
+    return createNetHttpTransportBuilder(
+        proxyUri, readTimeout, /* useSystemDefaultTrustStore= */ false);
+  }
+
+  @VisibleForTesting
+  static NetHttpTransport.Builder createNetHttpTransportBuilder(
+      @Nullable URI proxyUri, @Nullable Duration readTimeout, boolean useSystemDefaultTrustStore)
+      throws IOException, GeneralSecurityException {
+    // Default Google endpoints pin to Google's bundled certificate trust store. Custom endpoints
+    // (e.g. Trusted Partner Cloud / non-default universe domains) use a CA that is not part of that
+    // bundle, so fall back to the JVM's default trust store for them.
     NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
+    if (!useSystemDefaultTrustStore) {
+      builder.trustCertificates(GoogleUtils.getCertificateTrustStore());
+    }
     SSLSocketFactory wrappedSslSocketFactory =
         requireNonNullElseGet(
             builder.getSslSocketFactory(), HttpsURLConnection::getDefaultSSLSocketFactory);

--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNullElseGet;
 
-import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.common.annotations.VisibleForTesting;
@@ -166,8 +165,7 @@ public class HttpTransportFactory {
   static NetHttpTransport.Builder createNetHttpTransportBuilder(
       @Nullable URI proxyUri, @Nullable Duration readTimeout)
       throws IOException, GeneralSecurityException {
-    NetHttpTransport.Builder builder =
-        new NetHttpTransport.Builder().trustCertificates(GoogleUtils.getCertificateTrustStore());
+    NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
     SSLSocketFactory wrappedSslSocketFactory =
         requireNonNullElseGet(
             builder.getSslSocketFactory(), HttpsURLConnection::getDefaultSSLSocketFactory);

--- a/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
+++ b/util/src/main/java/com/google/cloud/hadoop/util/HttpTransportFactory.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNullElseGet;
 
+import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.common.annotations.VisibleForTesting;

--- a/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
+++ b/util/src/test/java/com/google/cloud/hadoop/util/HttpTransportFactoryTest.java
@@ -23,12 +23,14 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.cloud.hadoop.util.HttpTransportFactory.CustomSslSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -146,6 +148,43 @@ public class HttpTransportFactoryTest {
             /* proxyUri= */ null, /* readTimeout= */ null);
 
     assertThat(builder.getSslSocketFactory()).isInstanceOf(CustomSslSocketFactory.class);
+  }
+
+  @Test
+  public void createNetHttpTransportBuilder_defaultTrustStore_doesNotUseSystemDefault()
+      throws GeneralSecurityException, IOException {
+    NetHttpTransport.Builder builder =
+        HttpTransportFactory.createNetHttpTransportBuilder(
+            /* proxyUri= */ null, /* readTimeout= */ null, /* useSystemDefaultTrustStore= */ false);
+
+    // Google's bundled trust store yields a dedicated SSLSocketFactory, not the JVM default.
+    assertThat(builder.getSslSocketFactory()).isInstanceOf(CustomSslSocketFactory.class);
+    assertThat(unwrap((CustomSslSocketFactory) builder.getSslSocketFactory()))
+        .isNotSameInstanceAs(HttpsURLConnection.getDefaultSSLSocketFactory());
+  }
+
+  @Test
+  public void createNetHttpTransportBuilder_systemDefaultTrustStore_usesSystemDefault()
+      throws GeneralSecurityException, IOException {
+    NetHttpTransport.Builder builder =
+        HttpTransportFactory.createNetHttpTransportBuilder(
+            /* proxyUri= */ null, /* readTimeout= */ null, /* useSystemDefaultTrustStore= */ true);
+
+    // For custom/TPC endpoints we fall back to the JVM's default trust store.
+    assertThat(builder.getSslSocketFactory()).isInstanceOf(CustomSslSocketFactory.class);
+    assertThat(unwrap((CustomSslSocketFactory) builder.getSslSocketFactory()))
+        .isSameInstanceAs(HttpsURLConnection.getDefaultSSLSocketFactory());
+  }
+
+  /** Returns the {@link SSLSocketFactory} wrapped inside a {@link CustomSslSocketFactory}. */
+  private static SSLSocketFactory unwrap(CustomSslSocketFactory factory) {
+    try {
+      Field field = CustomSslSocketFactory.class.getDeclaredField("wrappedSockedFactory");
+      field.setAccessible(true);
+      return (SSLSocketFactory) field.get(factory);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Failed to read wrapped SSLSocketFactory", e);
+    }
   }
 
   @Test


### PR DESCRIPTION
Add support for targeting a non-default Google universe (Trusted Partner Cloud / sovereign clouds) from both the JSON/REST and gRPC clients. A new `fs.gs.universe.domain` property is resolved with precedence: fs.gs.universe.domain > GOOGLE_CLOUD_UNIVERSE_DOMAIN env var > googleapis.com (default), and propagated via GoogleCloudStorageOptions.getUniverseDomain().

- JSON/REST: pass the universe domain to the Apiary client and only call setRootUrl()/setServicePath() when a custom endpoint is explicitly set, so the client derives https://storage.<universe>/ by default. An explicit fs.gs.storage.root.url still takes precedence.

- gRPC: call setUniverseDomain() on GrpcStorageOptions, auto-disable DirectPath for non-default universes (DirectPath is googleapis.com-only), and include the universe domain in the storage client cache key. Backward compatible: with no universe configured, both paths resolve to storage.googleapis.com as before.
Add unit tests for the resolution precedence and the Apiary endpoint derivation, and document the new property in CONFIGURATION.md.

Closes #1751