### PR TITLE
Fix AUTO fadvise one-way latch causing excessive HTTP requests for Parquet reads

### DIFF
--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileAccessPatternManager.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/FileAccessPatternManager.java
@@ -65,7 +65,8 @@ class FileAccessPatternManager {
       return;
     }
     updateSeekFlags(currentPosition);
-    if (readOptions.getFadvise() == Fadvise.AUTO_RANDOM) {
+    if (readOptions.getFadvise() == Fadvise.AUTO_RANDOM
+        || readOptions.getFadvise() == Fadvise.AUTO) {
       if (randomAccess) {
         if (shouldAdaptToSequential(currentPosition)) {
           unsetRandomAccess();
@@ -74,10 +75,6 @@ class FileAccessPatternManager {
         if (shouldAdaptToRandomAccess(currentPosition)) {
           setRandomAccess();
         }
-      }
-    } else if (readOptions.getFadvise() == Fadvise.AUTO) {
-      if (shouldAdaptToRandomAccess(currentPosition)) {
-        setRandomAccess();
       }
     }
   }
@@ -140,10 +137,14 @@ class FileAccessPatternManager {
   }
 
   private boolean shouldDetectSequentialAccess() {
-    return randomAccess
-        && !isBackwardOrForwardSeekRequested()
-        && consecutiveSequentialCount >= readOptions.getFadviseRequestTrackCount()
-        && readOptions.getFadvise() == Fadvise.AUTO_RANDOM;
+    if (!randomAccess) {
+      return false;
+    }
+    if (readOptions.getFadvise() == Fadvise.AUTO) {
+      return true;
+    }
+    return readOptions.getFadvise() == Fadvise.AUTO_RANDOM
+        && !isBackwardOrForwardSeekRequested();
   }
 
   private boolean shouldDetectRandomAccess() {
@@ -154,10 +155,14 @@ class FileAccessPatternManager {
 
   private void setRandomAccess() {
     randomAccess = true;
+    consecutiveSequentialCount = 0;
   }
 
   private void unsetRandomAccess() {
     randomAccess = false;
+    consecutiveSequentialCount = 0;
+    isBackwardSeekRequested = false;
+    isForwardSeekRequested = false;
   }
 
   private boolean isBackwardOrForwardSeekRequested() {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptions.java
@@ -252,6 +252,10 @@ public abstract class GoogleCloudStorageReadOptions {
           options.getInplaceSeekLimit() >= 0,
           "inplaceSeekLimit must be non-negative! Got %s",
           options.getInplaceSeekLimit());
+      checkState(
+          options.getFadviseRequestTrackCount() > 0,
+          "fadviseRequestTrackCount must be greater than 0! Got %s",
+          options.getFadviseRequestTrackCount());
       return options;
     }
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FileAccessPatternManagerTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/FileAccessPatternManagerTest.java
@@ -125,6 +125,24 @@ public class FileAccessPatternManagerTest {
   }
 
   @Test
+  public void testAutoMode_staysSequentialAfterRecovery_untilNewSeek() {
+    GoogleCloudStorageReadOptions readOptions =
+        GoogleCloudStorageReadOptions.DEFAULT.toBuilder()
+            .setFadvise(Fadvise.AUTO)
+            .setFadviseRequestTrackCount(3)
+            .setInplaceSeekLimit(10)
+            .build();
+    FileAccessPatternManager fileAccessPattern =
+        new FileAccessPatternManager(RESOURCE_ID, readOptions);
+
+    long[] readIndexes = new long[] {5, 0, 1, 2, 3, 4, 5, 6, 0};
+    boolean[] expectedRandomAccess =
+        new boolean[] {false, true, true, true, false, false, false, false, true};
+
+    verifyAccessPattern(fileAccessPattern, readIndexes, expectedRandomAccess);
+  }
+
+  @Test
   public void testAutoRandomMode() {
 
     GoogleCloudStorageReadOptions readOptions =

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadChannelTest.java
@@ -1116,6 +1116,133 @@ public class GoogleCloudStorageReadChannelTest {
     assertThat(buffer3.array()).isEqualTo(Arrays.copyOfRange(testData, 12, 17));
   }
 
+  @Test
+  public void fadviseAuto_parquetReadPattern_recoversToSequentialAfterFooterRead()
+      throws IOException {
+    byte[] testData = new byte[100];
+    for (int i = 0; i < testData.length; i++) {
+      testData[i] = (byte) i;
+    }
+
+    int footerSize = 10;
+    int footerStart = testData.length - footerSize;
+    int rowGroupSize = 5;
+    int trackCount = 3;
+
+    MockHttpTransport transport =
+        mockTransport(
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, footerStart, testData.length),
+                footerStart,
+                testData.length),
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, 0, rowGroupSize), 0, testData.length),
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, rowGroupSize, rowGroupSize * 2),
+                rowGroupSize,
+                testData.length),
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, rowGroupSize * 2, rowGroupSize * 3),
+                rowGroupSize * 2,
+                testData.length),
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, rowGroupSize * 3, testData.length),
+                rowGroupSize * 3,
+                testData.length));
+
+    List<HttpRequest> requests = new ArrayList<>();
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadOptions options =
+        newLazyReadOptionsBuilder()
+            .setFadvise(Fadvise.AUTO)
+            .setMinRangeRequestSize(rowGroupSize)
+            .setInplaceSeekLimit(2)
+            .setFadviseRequestTrackCount(trackCount)
+            .build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
+
+    readChannel.position(footerStart);
+    byte[] footerBytes = new byte[footerSize];
+    assertThat(readChannel.read(ByteBuffer.wrap(footerBytes))).isEqualTo(footerSize);
+    assertThat(readChannel.randomAccessStatus()).isFalse();
+
+    readChannel.position(0);
+    byte[] buf = new byte[rowGroupSize];
+    readChannel.read(ByteBuffer.wrap(buf));
+    assertThat(readChannel.randomAccessStatus()).isTrue();
+
+    for (int i = 1; i < trackCount; i++) {
+      readChannel.position(rowGroupSize * i);
+      readChannel.read(ByteBuffer.wrap(buf));
+      assertThat(readChannel.randomAccessStatus()).isTrue();
+    }
+
+    readChannel.position(rowGroupSize * trackCount);
+    readChannel.read(ByteBuffer.wrap(buf));
+    assertThat(readChannel.randomAccessStatus()).isFalse();
+
+    List<String> rangeHeaders =
+        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
+
+    assertThat(rangeHeaders)
+        .containsExactly("bytes=90-", "bytes=0-4", "bytes=5-9", "bytes=10-14", "bytes=15-")
+        .inOrder();
+  }
+
+  @Test
+  public void fadviseSequential_parquetReadPattern_neverSwitchesToRandom() throws IOException {
+    byte[] testData = new byte[100];
+    for (int i = 0; i < testData.length; i++) {
+      testData[i] = (byte) i;
+    }
+
+    int footerSize = 10;
+    int footerStart = testData.length - footerSize;
+    int rowGroupSize = 5;
+
+    MockHttpTransport transport =
+        mockTransport(
+            dataRangeResponse(
+                Arrays.copyOfRange(testData, footerStart, testData.length),
+                footerStart,
+                testData.length),
+            dataRangeResponse(testData, 0, testData.length));
+
+    List<HttpRequest> requests = new ArrayList<>();
+    Storage storage = new Storage(transport, GsonFactory.getDefaultInstance(), requests::add);
+
+    GoogleCloudStorageReadOptions options =
+        newLazyReadOptionsBuilder()
+            .setFadvise(Fadvise.SEQUENTIAL)
+            .setMinRangeRequestSize(rowGroupSize)
+            .setInplaceSeekLimit(2)
+            .build();
+
+    GoogleCloudStorageReadChannel readChannel = createReadChannel(storage, options);
+
+    readChannel.position(footerStart);
+    byte[] footerBytes = new byte[footerSize];
+    assertThat(readChannel.read(ByteBuffer.wrap(footerBytes))).isEqualTo(footerSize);
+    assertThat(readChannel.randomAccessStatus()).isFalse();
+
+    readChannel.position(0);
+    byte[] rowGroup1 = new byte[rowGroupSize];
+    assertThat(readChannel.read(ByteBuffer.wrap(rowGroup1))).isEqualTo(rowGroupSize);
+    assertThat(readChannel.randomAccessStatus()).isFalse();
+
+    readChannel.position(rowGroupSize);
+    byte[] rowGroup2 = new byte[rowGroupSize];
+    assertThat(readChannel.read(ByteBuffer.wrap(rowGroup2))).isEqualTo(rowGroupSize);
+    assertThat(readChannel.randomAccessStatus()).isFalse();
+
+    List<String> rangeHeaders =
+        requests.stream().map(r -> r.getHeaders().getRange()).collect(toList());
+
+    assertThat(rangeHeaders).containsExactly("bytes=90-", "bytes=0-").inOrder();
+  }
+
   private static GoogleCloudStorageReadOptions.Builder newLazyReadOptionsBuilder() {
     return GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false);
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptionsTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageReadOptionsTest.java
@@ -38,4 +38,16 @@ public class GoogleCloudStorageReadOptionsTest {
         .hasMessageThat()
         .isEqualTo("inplaceSeekLimit must be non-negative! Got " + inplaceSeekLimit);
   }
+
+  @Test
+  public void build_throwsException_whenFadviseRequestTrackCountNotPositive() {
+    GoogleCloudStorageReadOptions.Builder builder =
+        GoogleCloudStorageReadOptions.builder().setFadviseRequestTrackCount(0);
+
+    IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+
+    assertThat(e)
+        .hasMessageThat()
+        .isEqualTo("fadviseRequestTrackCount must be greater than 0! Got 0");
+  }
 }


### PR DESCRIPTION
AUTO fadvise mode permanently switched to random-access (bounded 2MB range
requests) after detecting a backward seek, and never recovered. Parquet reads
always trigger this because the format requires reading the footer at the end
of the file before reading row groups sequentially from the beginning.

For a 1GB file this meant ~500 HTTP requests instead of ~2, causing Dataflow
worker timeouts on batch Parquet read+join stages after Beam 2.74 bumped
gcs-connector from v2.2.26 (default SEQUENTIAL) to v3.1.16 (default AUTO).

Changes:
- Let AUTO mode recover to sequential after fadviseRequestTrackCount (default 3)
  consecutive sequential reads
- Reset consecutiveSequentialCount and seek flags on mode transitions to prevent
  oscillation
- Validate fadviseRequestTrackCount > 0 at build time

AUTO_RANDOM behavior is unchanged — it still uses sticky seek flags as a
permanent latch, which is preserved because unsetRandomAccess() is only
reachable from AUTO_RANDOM when both flags are already false.

Tested against a real 36MB Parquet file on GCS:
- Unpatched AUTO: 11 data requests (all bounded), random=true
- Patched AUTO: 5 data requests (3 bounded, then streaming), random=false
- SEQUENTIAL: 2 data requests (unchanged)