### PR TITLE
feat: Integrate Analytics Core write path into GoogleHadoopOutputStream

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.hadoop.fs.gcs;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
@@ -33,8 +35,7 @@ class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
   private final GoogleCloudStorageOutputStream delegate;
 
   public GcsAnalyticsCoreOutputStreamWrapper(GoogleCloudStorageOutputStream delegate) {
-    this.delegate = delegate;
-    logger.atInfo().log("GcsAnalyticsCoreOutputStreamWrapper created");
+    this.delegate = checkNotNull(delegate, "delegate cannot be null");
   }
 
   @Override
@@ -51,10 +52,8 @@ class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
 
   @Override
   public synchronized void close() throws IOException {
-    logger.atInfo().log("Closing GcsAnalyticsCoreOutputStreamWrapper");
     try {
       delegate.close();
-      logger.atInfo().log("Closed GcsAnalyticsCoreOutputStreamWrapper successfully");
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Failed to close GcsAnalyticsCoreOutputStreamWrapper");
       throw e;

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
+import com.google.common.flogger.GoogleLogger;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A synchronized wrapper around the non-thread-safe GoogleCloudStorageOutputStream.
+ *
+ * <p>TODO(user): Implement GoogleCloudStorageItemInfo.Provider once gcs-analytics-core exposes the
+ * finalized generation ID upon close.
+ */
+class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private final GoogleCloudStorageOutputStream delegate;
+
+  public GcsAnalyticsCoreOutputStreamWrapper(GoogleCloudStorageOutputStream delegate) {
+    this.delegate = delegate;
+    logger.atInfo().log("GcsAnalyticsCoreOutputStreamWrapper created");
+  }
+
+  @Override
+  public synchronized void write(int b) throws IOException {
+    logger.atFiner().log("write(int)");
+    delegate.write(b);
+  }
+
+  @Override
+  public synchronized void write(byte[] b, int off, int len) throws IOException {
+    logger.atFine().log("write(byte[], off=%d, len=%d)", off, len);
+    delegate.write(b, off, len);
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    logger.atInfo().log("Closing GcsAnalyticsCoreOutputStreamWrapper");
+    try {
+      delegate.close();
+      logger.atInfo().log("Closed GcsAnalyticsCoreOutputStreamWrapper successfully");
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("Failed to close GcsAnalyticsCoreOutputStreamWrapper");
+      throw e;
+    }
+  }
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
@@ -33,6 +33,7 @@ class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private final GoogleCloudStorageOutputStream delegate;
+  private boolean closed = false;
 
   public GcsAnalyticsCoreOutputStreamWrapper(GoogleCloudStorageOutputStream delegate) {
     this.delegate = checkNotNull(delegate, "delegate cannot be null");
@@ -52,11 +53,14 @@ class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
 
   @Override
   public synchronized void close() throws IOException {
+    if (closed) {
+      logger.atFiner().log("close(): Stream already closed, ignoring.");
+      return;
+    }
     try {
       delegate.close();
-    } catch (IOException e) {
-      logger.atWarning().withCause(e).log("Failed to close GcsAnalyticsCoreOutputStreamWrapper");
-      throw e;
+    } finally {
+      closed = true;
     }
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
@@ -41,7 +41,6 @@ class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
 
   @Override
   public synchronized void write(int b) throws IOException {
-    logger.atFiner().log("write(int)");
     delegate.write(b);
   }
 

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -414,7 +414,7 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
       }
       // TODO(user): Initialize analyticsCoreGcsFs lazily when GCS_LAZY_INITIALIZATION_ENABLE is
       // true, to avoid eager initialization.
-      if (isAnalyticsCoreEnabled() || isAnalyticsWriteEnabled()) {
+      if (isAnalyticsCoreEnabled() || isAnalyticsCoreWriteEnabled()) {
         analyticsCoreGcsFs = createAnalyticsGcsFs(config);
       }
     }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -44,7 +44,10 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemImpl;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
+import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.cloud.hadoop.fs.gcs.auth.GcsDelegationTokens;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.FeatureHeaderGenerator;
@@ -409,7 +412,7 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
       } else {
         initializeGcsFs(createGcsFs(config));
       }
-      if (isAnalyticsCoreEnabled()) {
+      if (isAnalyticsCoreEnabled() || isAnalyticsWriteEnabled()) {
         analyticsCoreGcsFs = createAnalyticsGcsFs(config);
       }
     }
@@ -1802,6 +1805,11 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
   GoogleCloudStorageInputStream createAnalyticsCoreInputStream(GcsFileInfo gcsFileInfo)
       throws IOException {
     return GoogleCloudStorageInputStream.create(analyticsCoreGcsFs, gcsFileInfo);
+  }
+
+  GoogleCloudStorageOutputStream createAnalyticsCoreOutputStream(
+      GcsItemId gcsItemId, GcsWriteOptions writeOptions) throws IOException {
+    return GoogleCloudStorageOutputStream.create(analyticsCoreGcsFs, gcsItemId, writeOptions);
   }
 
   /** Checks if Analytics Core is enabled. */

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -412,6 +412,8 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
       } else {
         initializeGcsFs(createGcsFs(config));
       }
+      // TODO(user): Initialize analyticsCoreGcsFs lazily (e.g. using a Supplier) when
+      // GCS_LAZY_INITIALIZATION_ENABLE is true, to avoid eager credential loading.
       if (isAnalyticsCoreEnabled() || isAnalyticsWriteEnabled()) {
         analyticsCoreGcsFs = createAnalyticsGcsFs(config);
       }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -412,8 +412,8 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
       } else {
         initializeGcsFs(createGcsFs(config));
       }
-      // TODO(user): Initialize analyticsCoreGcsFs lazily (e.g. using a Supplier) when
-      // GCS_LAZY_INITIALIZATION_ENABLE is true, to avoid eager credential loading.
+      // TODO(user): Initialize analyticsCoreGcsFs lazily when GCS_LAZY_INITIALIZATION_ENABLE is
+      // true, to avoid eager initialization.
       if (isAnalyticsCoreEnabled() || isAnalyticsWriteEnabled()) {
         analyticsCoreGcsFs = createAnalyticsGcsFs(config);
       }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -50,7 +50,6 @@ import java.nio.channels.WritableByteChannel;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -237,7 +236,7 @@ class GoogleHadoopOutputStream extends OutputStream
         GoogleCloudStorageEventBus.postOnException();
         throw new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath));
       }
-      generation = ((Optional<Long>) fileInfo.getItemInfo().getContentGeneration()).orElse(0L);
+      generation = fileInfo.getItemInfo().getContentGeneration().orElse(0L);
     } catch (IOException e) {
       // TODO(user): Remove this exception message check once analytics-core throws a specific
       // FileNotFoundException / NoSuchFileException for non-existent objects.

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -239,6 +239,8 @@ class GoogleHadoopOutputStream extends OutputStream
       }
       generation = ((Optional<Long>) fileInfo.getItemInfo().getContentGeneration()).orElse(0L);
     } catch (IOException e) {
+      // TODO(user): Remove this exception message check once analytics-core throws a specific
+      // FileNotFoundException / NoSuchFileException for non-existent objects.
       if (e.getMessage() != null && e.getMessage().startsWith("Object not found:")) {
         // If file does not exist, set the generation as 0.
         generation = 0L;

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -201,69 +201,79 @@ class GoogleHadoopOutputStream extends OutputStream
 
   private static OutputStream createOutputStream(
       GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
-    if (ghfs.isAnalyticsCoreWriteEnabled()) {
-      GcsFileSystem analyticsGcsFs = ghfs.getAnalyticsCoreGcsFs();
-      if (analyticsGcsFs == null) {
-        throw new IOException(
-            String.format(
-                "Analytics write path is enabled, but the analytics filesystem is not initialized"
-                    + " (getAnalyticsCoreGcsFs() returned null). Cannot write to %s",
-                gcsPath));
-      }
-      GcsWriteOptions baseWriteOptions =
-          analyticsGcsFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
-      boolean overwrite = options.getWriteMode() == CreateFileOptions.WriteMode.OVERWRITE;
-      StorageResourceId resourceId =
-          StorageResourceId.fromUriPath(gcsPath, /* allowEmptyObjectName= */ false);
-      GcsItemId.Builder itemIdBuilder =
-          GcsItemId.builder()
-              .setBucketName(resourceId.getBucketName())
-              .setObjectName(resourceId.getObjectName());
-      long generation = StorageResourceId.UNKNOWN_GENERATION_ID;
-      try {
-        GcsFileInfo fileInfo = analyticsGcsFs.getFileInfo(itemIdBuilder.build());
-        // If we reach here, the file exists.
-        if (!overwrite) {
-          GoogleCloudStorageEventBus.postOnException();
-          throw new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath));
-        }
-        generation = ((Optional<Long>) fileInfo.getItemInfo().getContentGeneration()).orElse(0L);
-      } catch (IOException e) {
-        if (e.getMessage() != null && e.getMessage().startsWith("Object not found:")) {
-          // If file does not exist, set the generation as 0.
-          generation = 0L;
-        } else {
-          throw e;
-        }
-      }
-      GcsItemId itemId;
-      if (generation == StorageResourceId.UNKNOWN_GENERATION_ID) {
-        itemId = itemIdBuilder.build();
-      } else {
-        itemId = itemIdBuilder.setContentGeneration(generation).build();
-      }
+    OutputStream outputStream =
+        ghfs.isAnalyticsCoreWriteEnabled()
+            ? createAnalyticsCoreOutputStream(ghfs, gcsPath, options)
+            : createLegacyOutputStream(ghfs, gcsPath, options);
+    return maybeWrapInBufferedOutputStream(ghfs, outputStream);
+  }
 
-      GcsWriteOptions writeOptions =
-          baseWriteOptions.toBuilder().setOverwriteExisting(overwrite).build();
-
-      GoogleCloudStorageOutputStream rawStream =
-          ghfs.createAnalyticsCoreOutputStream(itemId, writeOptions);
-      OutputStream outputStream = new GcsAnalyticsCoreOutputStreamWrapper(rawStream);
-      return maybeWrapInBufferedOutputStream(ghfs, outputStream);
-    } else {
-      GoogleCloudStorageFileSystem gcsfs = ghfs.getGcsFs();
-      WritableByteChannel channel;
-      try {
-        channel = gcsfs.create(gcsPath, options);
-      } catch (java.nio.file.FileAlreadyExistsException e) {
-        GoogleCloudStorageEventBus.postOnException();
-        throw (FileAlreadyExistsException)
-            new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath))
-                .initCause(e);
-      }
-      OutputStream outputStream = Channels.newOutputStream(channel);
-      return maybeWrapInBufferedOutputStream(ghfs, outputStream);
+  private static OutputStream createAnalyticsCoreOutputStream(
+      GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
+    GcsFileSystem analyticsGcsFs = ghfs.getAnalyticsCoreGcsFs();
+    if (analyticsGcsFs == null) {
+      throw new IOException(
+          String.format(
+              "Analytics write path is enabled, but the analytics filesystem is not initialized"
+                  + " (getAnalyticsCoreGcsFs() returned null). Cannot write to %s",
+              gcsPath));
     }
+    GcsWriteOptions baseWriteOptions =
+        analyticsGcsFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
+    boolean overwrite = options.getWriteMode() == CreateFileOptions.WriteMode.OVERWRITE;
+    StorageResourceId resourceId =
+        StorageResourceId.fromUriPath(gcsPath, /* allowEmptyObjectName= */ false);
+    GcsItemId.Builder itemIdBuilder =
+        GcsItemId.builder()
+            .setBucketName(resourceId.getBucketName())
+            .setObjectName(resourceId.getObjectName());
+    long generation = StorageResourceId.UNKNOWN_GENERATION_ID;
+    // TODO(user): Check if FileAlreadyExistsException can be thrown during stream creation in
+    // Analytics Core rather than doing an explicit getFileInfo check here.
+    try {
+      GcsFileInfo fileInfo = analyticsGcsFs.getFileInfo(itemIdBuilder.build());
+      // If we reach here, the file exists.
+      if (!overwrite) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath));
+      }
+      generation = ((Optional<Long>) fileInfo.getItemInfo().getContentGeneration()).orElse(0L);
+    } catch (IOException e) {
+      if (e.getMessage() != null && e.getMessage().startsWith("Object not found:")) {
+        // If file does not exist, set the generation as 0.
+        generation = 0L;
+      } else {
+        throw e;
+      }
+    }
+    GcsItemId itemId;
+    if (generation == StorageResourceId.UNKNOWN_GENERATION_ID) {
+      itemId = itemIdBuilder.build();
+    } else {
+      itemId = itemIdBuilder.setContentGeneration(generation).build();
+    }
+
+    GcsWriteOptions writeOptions =
+        baseWriteOptions.toBuilder().setOverwriteExisting(overwrite).build();
+
+    GoogleCloudStorageOutputStream rawStream =
+        ghfs.createAnalyticsCoreOutputStream(itemId, writeOptions);
+    return new GcsAnalyticsCoreOutputStreamWrapper(rawStream);
+  }
+
+  private static OutputStream createLegacyOutputStream(
+      GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
+    GoogleCloudStorageFileSystem gcsfs = ghfs.getGcsFs();
+    WritableByteChannel channel;
+    try {
+      channel = gcsfs.create(gcsPath, options);
+    } catch (java.nio.file.FileAlreadyExistsException e) {
+      GoogleCloudStorageEventBus.postOnException();
+      throw (FileAlreadyExistsException)
+          new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath))
+              .initCause(e);
+    }
+    return Channels.newOutputStream(channel);
   }
 
   private static OutputStream maybeWrapInBufferedOutputStream(

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -41,7 +41,6 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.BufferedOutputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -229,9 +228,13 @@ class GoogleHadoopOutputStream extends OutputStream
           throw new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath));
         }
         generation = ((Optional<Long>) fileInfo.getItemInfo().getContentGeneration()).orElse(0L);
-      } catch (FileNotFoundException e) {
-        // If file does not exist, set the generation as 0.
-        generation = 0L;
+      } catch (IOException e) {
+        if (e.getMessage() != null && e.getMessage().startsWith("Object not found:")) {
+          // If file does not exist, set the generation as 0.
+          generation = 0L;
+        } else {
+          throw e;
+        }
       }
       GcsItemId itemId;
       if (generation == StorageResourceId.UNKNOWN_GENERATION_ID) {

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration;
 
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
@@ -40,6 +41,7 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.BufferedOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -49,6 +51,7 @@ import java.nio.channels.WritableByteChannel;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -213,11 +216,29 @@ class GoogleHadoopOutputStream extends OutputStream
       boolean overwrite = options.getWriteMode() == CreateFileOptions.WriteMode.OVERWRITE;
       StorageResourceId resourceId =
           StorageResourceId.fromUriPath(gcsPath, /* allowEmptyObjectName= */ false);
-      GcsItemId itemId =
+      GcsItemId.Builder itemIdBuilder =
           GcsItemId.builder()
               .setBucketName(resourceId.getBucketName())
-              .setObjectName(resourceId.getObjectName())
-              .build();
+              .setObjectName(resourceId.getObjectName());
+      long generation = StorageResourceId.UNKNOWN_GENERATION_ID;
+      try {
+        GcsFileInfo fileInfo = analyticsGcsFs.getFileInfo(itemIdBuilder.build());
+        // If we reach here, the file exists.
+        if (!overwrite) {
+          GoogleCloudStorageEventBus.postOnException();
+          throw new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath));
+        }
+        generation = ((Optional<Long>) fileInfo.getItemInfo().getContentGeneration()).orElse(0L);
+      } catch (FileNotFoundException e) {
+        // If file does not exist, set the generation as 0.
+        generation = 0L;
+      }
+      GcsItemId itemId;
+      if (generation == StorageResourceId.UNKNOWN_GENERATION_ID) {
+        itemId = itemIdBuilder.build();
+      } else {
+        itemId = itemIdBuilder.setContentGeneration(generation).build();
+      }
 
       GcsWriteOptions writeOptions =
           baseWriteOptions.toBuilder().setOverwriteExisting(overwrite).build();

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -199,7 +199,7 @@ class GoogleHadoopOutputStream extends OutputStream
 
   private static OutputStream createOutputStream(
       GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
-    if (ghfs.isAnalyticsWriteEnabled()) {
+    if (ghfs.isAnalyticsCoreWriteEnabled()) {
       GcsFileSystem analyticsGcsFs = ghfs.getAnalyticsCoreGcsFs();
       if (analyticsGcsFs == null) {
         throw new IOException(

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -224,7 +224,8 @@ class GoogleHadoopOutputStream extends OutputStream
 
       GoogleCloudStorageOutputStream rawStream =
           ghfs.createAnalyticsCoreOutputStream(itemId, writeOptions);
-      return new GcsAnalyticsCoreOutputStreamWrapper(rawStream);
+      OutputStream outputStream = new GcsAnalyticsCoreOutputStreamWrapper(rawStream);
+      return maybeWrapInBufferedOutputStream(ghfs, outputStream);
     } else {
       GoogleCloudStorageFileSystem gcsfs = ghfs.getGcsFs();
       WritableByteChannel channel;
@@ -237,10 +238,19 @@ class GoogleHadoopOutputStream extends OutputStream
                 .initCause(e);
       }
       OutputStream outputStream = Channels.newOutputStream(channel);
-      int bufferSize =
-          gcsfs.getOptions().getCloudStorageOptions().getWriteChannelOptions().getBufferSize();
-      return bufferSize > 0 ? new BufferedOutputStream(outputStream, bufferSize) : outputStream;
+      return maybeWrapInBufferedOutputStream(ghfs, outputStream);
     }
+  }
+
+  private static OutputStream maybeWrapInBufferedOutputStream(
+      GoogleHadoopFileSystem ghfs, OutputStream outputStream) {
+    int bufferSize =
+        ghfs.getGcsFs()
+            .getOptions()
+            .getCloudStorageOptions()
+            .getWriteChannelOptions()
+            .getBufferSize();
+    return bufferSize > 0 ? new BufferedOutputStream(outputStream, bufferSize) : outputStream;
   }
 
   @Override

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -200,8 +200,14 @@ class GoogleHadoopOutputStream extends OutputStream
   private static OutputStream createOutputStream(
       GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
     if (ghfs.isAnalyticsWriteEnabled()) {
-      logger.atInfo().log("Using Analytics Core write path for %s", gcsPath);
       GcsFileSystem analyticsGcsFs = ghfs.getAnalyticsCoreGcsFs();
+      if (analyticsGcsFs == null) {
+        throw new IOException(
+            String.format(
+                "Analytics write path is enabled, but the analytics filesystem is not initialized"
+                    + " (getAnalyticsCoreGcsFs() returned null). Cannot write to %s",
+                gcsPath));
+      }
       GcsWriteOptions baseWriteOptions =
           analyticsGcsFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
       boolean overwrite = options.getWriteMode() == CreateFileOptions.WriteMode.OVERWRITE;

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -21,6 +21,10 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration;
 
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
@@ -188,29 +192,49 @@ class GoogleHadoopOutputStream extends OutputStream
 
     this.tmpOut =
         createOutputStream(
-            ghfs.getGcsFs(),
-            tmpGcsPath,
-            tmpIndex == 0 ? createFileOptions : TMP_FILE_CREATE_OPTIONS);
+            ghfs, tmpGcsPath, tmpIndex == 0 ? createFileOptions : TMP_FILE_CREATE_OPTIONS);
     this.dstGenerationId = StorageResourceId.UNKNOWN_GENERATION_ID;
     this.traceFactory = ghfs.getTraceFactory();
   }
 
   private static OutputStream createOutputStream(
-      GoogleCloudStorageFileSystem gcsfs, URI gcsPath, CreateFileOptions options)
-      throws IOException {
-    WritableByteChannel channel;
-    try {
-      channel = gcsfs.create(gcsPath, options);
-    } catch (java.nio.file.FileAlreadyExistsException e) {
-      GoogleCloudStorageEventBus.postOnException();
-      throw (FileAlreadyExistsException)
-          new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath))
-              .initCause(e);
+      GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
+    if (ghfs.isAnalyticsWriteEnabled()) {
+      logger.atInfo().log("Using Analytics Core write path for %s", gcsPath);
+      GcsFileSystem analyticsGcsFs = ghfs.getAnalyticsCoreGcsFs();
+      GcsWriteOptions baseWriteOptions =
+          analyticsGcsFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
+      boolean overwrite = options.getWriteMode() == CreateFileOptions.WriteMode.OVERWRITE;
+      StorageResourceId resourceId =
+          StorageResourceId.fromUriPath(gcsPath, /* allowEmptyObjectName= */ false);
+      GcsItemId itemId =
+          GcsItemId.builder()
+              .setBucketName(resourceId.getBucketName())
+              .setObjectName(resourceId.getObjectName())
+              .build();
+
+      GcsWriteOptions writeOptions =
+          baseWriteOptions.toBuilder().setOverwriteExisting(overwrite).build();
+
+      GoogleCloudStorageOutputStream rawStream =
+          ghfs.createAnalyticsCoreOutputStream(itemId, writeOptions);
+      return new GcsAnalyticsCoreOutputStreamWrapper(rawStream);
+    } else {
+      GoogleCloudStorageFileSystem gcsfs = ghfs.getGcsFs();
+      WritableByteChannel channel;
+      try {
+        channel = gcsfs.create(gcsPath, options);
+      } catch (java.nio.file.FileAlreadyExistsException e) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw (FileAlreadyExistsException)
+            new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath))
+                .initCause(e);
+      }
+      OutputStream outputStream = Channels.newOutputStream(channel);
+      int bufferSize =
+          gcsfs.getOptions().getCloudStorageOptions().getWriteChannelOptions().getBufferSize();
+      return bufferSize > 0 ? new BufferedOutputStream(outputStream, bufferSize) : outputStream;
     }
-    OutputStream outputStream = Channels.newOutputStream(channel);
-    int bufferSize =
-        gcsfs.getOptions().getCloudStorageOptions().getWriteChannelOptions().getBufferSize();
-    return bufferSize > 0 ? new BufferedOutputStream(outputStream, bufferSize) : outputStream;
   }
 
   @Override
@@ -339,7 +363,7 @@ class GoogleHadoopOutputStream extends OutputStream
 
     logger.atFiner().log(
         "hsync(): Opening next temporary tail file %s at %d index", tmpGcsPath, tmpIndex);
-    tmpOut = createOutputStream(ghfs.getGcsFs(), tmpGcsPath, TMP_FILE_CREATE_OPTIONS);
+    tmpOut = createOutputStream(ghfs, tmpGcsPath, TMP_FILE_CREATE_OPTIONS);
 
     long finishMs = System.currentTimeMillis();
     logger.atFiner().log("Took %dms to sync() for %s", finishMs - startMs, dstGcsPath);
@@ -349,6 +373,8 @@ class GoogleHadoopOutputStream extends OutputStream
     // TODO(user): return early when 0 bytes have been written in the temp files
     tmpOut.close();
 
+    // TODO(user): Support generation ID retrieval for GcsAnalyticsCoreOutputStreamWrapper once
+    // gcs-analytics-core exposes it. Currently falls back to UNKNOWN_GENERATION_ID.
     long tmpGenerationId =
         tmpOut instanceof GoogleCloudStorageItemInfo.Provider
             ? ((GoogleCloudStorageItemInfo.Provider) tmpOut).getItemInfo().getContentGeneration()

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 Google Inc.
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.hadoop.fs.gcs;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.verify;
 
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
@@ -39,6 +40,14 @@ public class GcsAnalyticsCoreOutputStreamWrapperTest {
   @Before
   public void setUp() {
     adapter = new GcsAnalyticsCoreOutputStreamWrapper(mockOutputStream);
+  }
+
+  @Test
+  public void constructor_nullDelegate_throwsException() {
+    NullPointerException exception =
+        assertThrows(
+            NullPointerException.class, () -> new GcsAnalyticsCoreOutputStreamWrapper(null));
+    assertThat(exception).hasMessageThat().contains("delegate cannot be null");
   }
 
   @Test

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GcsAnalyticsCoreOutputStreamWrapperTest {
+
+  @Mock private GoogleCloudStorageOutputStream mockOutputStream;
+
+  private GcsAnalyticsCoreOutputStreamWrapper adapter;
+
+  @Before
+  public void setUp() {
+    adapter = new GcsAnalyticsCoreOutputStreamWrapper(mockOutputStream);
+  }
+
+  @Test
+  public void write_int_delegatesToOutputStream() throws IOException {
+    adapter.write(1);
+    verify(mockOutputStream).write(1);
+  }
+
+  @Test
+  public void write_bytes_delegatesToOutputStream() throws IOException {
+    byte[] bytes = new byte[] {1, 2, 3};
+    adapter.write(bytes, 1, 2);
+    verify(mockOutputStream).write(bytes, 1, 2);
+  }
+
+  @Test
+  public void close_delegatesToOutputStream() throws IOException {
+    adapter.close();
+    verify(mockOutputStream).close();
+  }
+
+  @Test
+  public void methodsAreSynchronized() throws NoSuchMethodException {
+    verifyMethodIsSynchronized(GcsAnalyticsCoreOutputStreamWrapper.class, "write", int.class);
+    verifyMethodIsSynchronized(
+        GcsAnalyticsCoreOutputStreamWrapper.class, "write", byte[].class, int.class, int.class);
+    verifyMethodIsSynchronized(GcsAnalyticsCoreOutputStreamWrapper.class, "close");
+  }
+
+  private void verifyMethodIsSynchronized(
+      Class<?> clazz, String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+    Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
+    assertThat(Modifier.isSynchronized(method.getModifiers())).isTrue();
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
@@ -35,11 +35,11 @@ public class GcsAnalyticsCoreOutputStreamWrapperTest {
 
   @Mock private GoogleCloudStorageOutputStream mockOutputStream;
 
-  private GcsAnalyticsCoreOutputStreamWrapper adapter;
+  private GcsAnalyticsCoreOutputStreamWrapper outputStreamWrapper;
 
   @Before
   public void setUp() {
-    adapter = new GcsAnalyticsCoreOutputStreamWrapper(mockOutputStream);
+    outputStreamWrapper = new GcsAnalyticsCoreOutputStreamWrapper(mockOutputStream);
   }
 
   @Test
@@ -52,20 +52,20 @@ public class GcsAnalyticsCoreOutputStreamWrapperTest {
 
   @Test
   public void write_int_delegatesToOutputStream() throws IOException {
-    adapter.write(1);
+    outputStreamWrapper.write(1);
     verify(mockOutputStream).write(1);
   }
 
   @Test
   public void write_bytes_delegatesToOutputStream() throws IOException {
     byte[] bytes = new byte[] {1, 2, 3};
-    adapter.write(bytes, 1, 2);
+    outputStreamWrapper.write(bytes, 1, 2);
     verify(mockOutputStream).write(bytes, 1, 2);
   }
 
   @Test
   public void close_delegatesToOutputStream() throws IOException {
-    adapter.close();
+    outputStreamWrapper.close();
     verify(mockOutputStream).close();
   }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -386,6 +386,40 @@ public class GoogleHadoopOutputStreamTest {
     verify(mockStream, atLeastOnce()).close();
   }
 
+  @Test
+  public void write_withAnalyticsWriteEnabledButFsNull_throwsException() throws Exception {
+    GoogleHadoopFileSystem analyticsGhfs =
+        new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
+          @Override
+          boolean isAnalyticsWriteEnabled() {
+            return true;
+          }
+
+          @Override
+          GcsFileSystem getAnalyticsCoreGcsFs() {
+            return null;
+          }
+        };
+    analyticsGhfs.initialize(ghfs.getUri(), ghfs.getConf());
+
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_null_fs.txt"));
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                new GoogleHadoopOutputStream(
+                    analyticsGhfs,
+                    analyticsGhfs.getGcsPath(objectPath),
+                    CreateFileOptions.DEFAULT,
+                    new FileSystem.Statistics(analyticsGhfs.getScheme())));
+
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "Analytics write path is enabled, but the analytics filesystem is not initialized");
+  }
+
   private GoogleHadoopFileSystem createAnalyticsEnabledGhfs(
       GoogleCloudStorageOutputStream mockStream) throws IOException {
     GoogleHadoopFileSystem analyticsGhfs =

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -26,6 +26,7 @@ import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -443,8 +444,8 @@ public class GoogleHadoopOutputStreamTest {
             when(mockFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions())
                 .thenReturn(GcsWriteOptions.builder().build());
             try {
-              when(mockFs.getFileInfo(org.mockito.ArgumentMatchers.any(GcsItemId.class)))
-                  .thenThrow(new java.io.FileNotFoundException("File not found (mocked)"));
+              when(mockFs.getFileInfo(any(GcsItemId.class)))
+                  .thenThrow(new IOException("Object not found: (mocked)"));
             } catch (IOException e) {
               logger.atWarning().withCause(e).log("Failed to stub getFileInfo");
             }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -26,7 +26,17 @@ import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.gcs.analyticscore.client.GcsClientOptions;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
+import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
@@ -337,5 +347,72 @@ public class GoogleHadoopOutputStreamTest {
       }
     }
     return allReadBytes.toByteArray();
+  }
+
+  @Test
+  public void write_withAnalyticsWriteEnabled_delegatesToAnalyticsOutputStream() throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_write.txt"));
+    GoogleHadoopOutputStream fout =
+        new GoogleHadoopOutputStream(
+            analyticsGhfs,
+            analyticsGhfs.getGcsPath(objectPath),
+            CreateFileOptions.DEFAULT,
+            new FileSystem.Statistics(analyticsGhfs.getScheme()));
+
+    byte[] data = {0x0f, 0x0e, 0x0e, 0x0d};
+    fout.write(data, 0, data.length);
+
+    verify(mockStream).write(data, 0, data.length);
+  }
+
+  @Test
+  public void close_withAnalyticsWriteEnabled_closesAnalyticsOutputStream() throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_close.txt"));
+    GoogleHadoopOutputStream fout =
+        new GoogleHadoopOutputStream(
+            analyticsGhfs,
+            analyticsGhfs.getGcsPath(objectPath),
+            CreateFileOptions.DEFAULT,
+            new FileSystem.Statistics(analyticsGhfs.getScheme()));
+
+    fout.close();
+
+    verify(mockStream, atLeastOnce()).close();
+  }
+
+  private GoogleHadoopFileSystem createAnalyticsEnabledGhfs(
+      GoogleCloudStorageOutputStream mockStream) throws IOException {
+    GoogleHadoopFileSystem analyticsGhfs =
+        new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
+          @Override
+          boolean isAnalyticsWriteEnabled() {
+            return true;
+          }
+
+          @Override
+          GcsFileSystem getAnalyticsCoreGcsFs() {
+            GcsFileSystem mockFs = mock(GcsFileSystem.class);
+            GcsFileSystemOptions options = mock(GcsFileSystemOptions.class);
+            GcsClientOptions clientOptions = mock(GcsClientOptions.class);
+            when(mockFs.getFileSystemOptions()).thenReturn(options);
+            when(options.getGcsClientOptions()).thenReturn(clientOptions);
+            when(clientOptions.getGcsWriteOptions()).thenReturn(GcsWriteOptions.builder().build());
+            return mockFs;
+          }
+
+          @Override
+          GoogleCloudStorageOutputStream createAnalyticsCoreOutputStream(
+              GcsItemId gcsItemId, GcsWriteOptions writeOptions) {
+            return mockStream;
+          }
+        };
+    analyticsGhfs.initialize(ghfs.getUri(), ghfs.getConf());
+    return analyticsGhfs;
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -41,6 +41,7 @@ import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
+import com.google.common.flogger.GoogleLogger;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
@@ -63,6 +64,8 @@ import org.junit.runners.JUnit4;
 /** Unittests for fine-grained edge cases in {@link GoogleHadoopOutputStream}. */
 @RunWith(JUnit4.class)
 public class GoogleHadoopOutputStreamTest {
+
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private GoogleHadoopFileSystem ghfs;
 
@@ -439,6 +442,12 @@ public class GoogleHadoopOutputStreamTest {
             GcsFileSystem mockFs = mock(GcsFileSystem.class, RETURNS_DEEP_STUBS);
             when(mockFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions())
                 .thenReturn(GcsWriteOptions.builder().build());
+            try {
+              when(mockFs.getFileInfo(org.mockito.ArgumentMatchers.any(GcsItemId.class)))
+                  .thenThrow(new java.io.FileNotFoundException("File not found (mocked)"));
+            } catch (IOException e) {
+              logger.atWarning().withCause(e).log("Failed to stub getFileInfo");
+            }
             return mockFs;
           }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -397,7 +397,7 @@ public class GoogleHadoopOutputStreamTest {
     GoogleHadoopFileSystem analyticsGhfs =
         new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
           @Override
-          boolean isAnalyticsWriteEnabled() {
+          boolean isAnalyticsCoreWriteEnabled() {
             return true;
           }
 
@@ -430,7 +430,7 @@ public class GoogleHadoopOutputStreamTest {
     GoogleHadoopFileSystem analyticsGhfs =
         new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
           @Override
-          boolean isAnalyticsWriteEnabled() {
+          boolean isAnalyticsCoreWriteEnabled() {
             return true;
           }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -26,14 +26,15 @@ import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.gcs.analyticscore.client.GcsClientOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
-import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
 import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
@@ -43,6 +44,7 @@ import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -353,7 +355,6 @@ public class GoogleHadoopOutputStreamTest {
   public void write_withAnalyticsWriteEnabled_delegatesToAnalyticsOutputStream() throws Exception {
     GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
     GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
-
     Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_write.txt"));
     GoogleHadoopOutputStream fout =
         new GoogleHadoopOutputStream(
@@ -361,18 +362,23 @@ public class GoogleHadoopOutputStreamTest {
             analyticsGhfs.getGcsPath(objectPath),
             CreateFileOptions.DEFAULT,
             new FileSystem.Statistics(analyticsGhfs.getScheme()));
-
     byte[] data = {0x0f, 0x0e, 0x0e, 0x0d};
-    fout.write(data, 0, data.length);
 
-    verify(mockStream).write(data, 0, data.length);
+    fout.write(data, 0, data.length);
+    fout.close();
+
+    // Verify that write was called on the GoogleCloudStorageOutputStream with the same arguments
+    verify(mockStream)
+        .write(
+            argThat(buf -> Arrays.equals(Arrays.copyOfRange(buf, 0, data.length), data)),
+            eq(0),
+            eq(data.length));
   }
 
   @Test
   public void close_withAnalyticsWriteEnabled_closesAnalyticsOutputStream() throws Exception {
     GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
     GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
-
     Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_close.txt"));
     GoogleHadoopOutputStream fout =
         new GoogleHadoopOutputStream(
@@ -413,7 +419,6 @@ public class GoogleHadoopOutputStreamTest {
                     analyticsGhfs.getGcsPath(objectPath),
                     CreateFileOptions.DEFAULT,
                     new FileSystem.Statistics(analyticsGhfs.getScheme())));
-
     assertThat(exception)
         .hasMessageThat()
         .contains(
@@ -431,12 +436,9 @@ public class GoogleHadoopOutputStreamTest {
 
           @Override
           GcsFileSystem getAnalyticsCoreGcsFs() {
-            GcsFileSystem mockFs = mock(GcsFileSystem.class);
-            GcsFileSystemOptions options = mock(GcsFileSystemOptions.class);
-            GcsClientOptions clientOptions = mock(GcsClientOptions.class);
-            when(mockFs.getFileSystemOptions()).thenReturn(options);
-            when(options.getGcsClientOptions()).thenReturn(clientOptions);
-            when(clientOptions.getGcsWriteOptions()).thenReturn(GcsWriteOptions.builder().build());
+            GcsFileSystem mockFs = mock(GcsFileSystem.class, RETURNS_DEEP_STUBS);
+            when(mockFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions())
+                .thenReturn(GcsWriteOptions.builder().build());
             return mockFs;
           }
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsItemId;
 import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
@@ -48,9 +49,11 @@ import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -69,10 +72,12 @@ public class GoogleHadoopOutputStreamTest {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private GoogleHadoopFileSystem ghfs;
+  private GcsItemId lastCreatedAnalyticsItemId;
 
   @Before
   public void setUp() throws IOException {
     ghfs = GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem();
+    lastCreatedAnalyticsItemId = null;
   }
 
   @After
@@ -429,8 +434,89 @@ public class GoogleHadoopOutputStreamTest {
             "Analytics write path is enabled, but the analytics filesystem is not initialized");
   }
 
+  @Test
+  public void create_withAnalyticsWriteEnabled_overwriteFalse_fileAlreadyExists_throwsException()
+      throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    GcsFileSystem mockFs = analyticsGhfs.getAnalyticsCoreGcsFs();
+    // Stub getFileInfo to return a valid GcsFileInfo (simulating file exists)
+    GcsFileInfo mockFileInfo = mock(GcsFileInfo.class, RETURNS_DEEP_STUBS);
+    when(mockFs.getFileInfo(any(GcsItemId.class))).thenReturn(mockFileInfo);
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_exists_error.txt"));
+
+    assertThrows(
+        FileAlreadyExistsException.class,
+        () ->
+            new GoogleHadoopOutputStream(
+                analyticsGhfs,
+                analyticsGhfs.getGcsPath(objectPath),
+                CreateFileOptions.DEFAULT, // overwrite is false by default
+                new FileSystem.Statistics(analyticsGhfs.getScheme())));
+  }
+
+  @Test
+  public void create_withAnalyticsWriteEnabled_overwriteTrue_fileAlreadyExists_resolvesGeneration()
+      throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    GcsFileSystem mockFs = analyticsGhfs.getAnalyticsCoreGcsFs();
+    // Stub getFileInfo to return info with generation 123L
+    GcsFileInfo mockFileInfo = mock(GcsFileInfo.class, RETURNS_DEEP_STUBS);
+    when(mockFileInfo.getItemInfo().getContentGeneration()).thenReturn(Optional.of(123L));
+    when(mockFs.getFileInfo(any(GcsItemId.class))).thenReturn(mockFileInfo);
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_overwrite_gen.txt"));
+    CreateFileOptions overwriteOptions =
+        CreateFileOptions.builder().setWriteMode(CreateFileOptions.WriteMode.OVERWRITE).build();
+    GoogleHadoopOutputStream fout =
+        new GoogleHadoopOutputStream(
+            analyticsGhfs,
+            analyticsGhfs.getGcsPath(objectPath),
+            overwriteOptions,
+            new FileSystem.Statistics(analyticsGhfs.getScheme()));
+
+    fout.close();
+
+    assertThat(lastCreatedAnalyticsItemId).isNotNull();
+    assertThat(lastCreatedAnalyticsItemId.getContentGeneration().isPresent()).isTrue();
+    assertThat(lastCreatedAnalyticsItemId.getContentGeneration().get()).isEqualTo(123L);
+  }
+
+  @Test
+  public void create_withAnalyticsWriteEnabled_otherIOException_propagatesException()
+      throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    GcsFileSystem mockFs = analyticsGhfs.getAnalyticsCoreGcsFs();
+    // Stub getFileInfo to throw some other IOException (e.g. Permission Denied)
+    when(mockFs.getFileInfo(any(GcsItemId.class)))
+        .thenThrow(new IOException("Permission denied (mocked)"));
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_other_io_error.txt"));
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                new GoogleHadoopOutputStream(
+                    analyticsGhfs,
+                    analyticsGhfs.getGcsPath(objectPath),
+                    CreateFileOptions.DEFAULT,
+                    new FileSystem.Statistics(analyticsGhfs.getScheme())));
+    assertThat(exception).hasMessageThat().contains("Permission denied (mocked)");
+  }
+
   private GoogleHadoopFileSystem createAnalyticsEnabledGhfs(
       GoogleCloudStorageOutputStream mockStream) throws IOException {
+    GcsFileSystem mockFs = mock(GcsFileSystem.class, RETURNS_DEEP_STUBS);
+    when(mockFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions())
+        .thenReturn(GcsWriteOptions.builder().build());
+    try {
+      when(mockFs.getFileInfo(any(GcsItemId.class)))
+          .thenThrow(new IOException("Object not found: (mocked)"));
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("Failed to stub getFileInfo");
+    }
+
     GoogleHadoopFileSystem analyticsGhfs =
         new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
           @Override
@@ -440,21 +526,13 @@ public class GoogleHadoopOutputStreamTest {
 
           @Override
           GcsFileSystem getAnalyticsCoreGcsFs() {
-            GcsFileSystem mockFs = mock(GcsFileSystem.class, RETURNS_DEEP_STUBS);
-            when(mockFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions())
-                .thenReturn(GcsWriteOptions.builder().build());
-            try {
-              when(mockFs.getFileInfo(any(GcsItemId.class)))
-                  .thenThrow(new IOException("Object not found: (mocked)"));
-            } catch (IOException e) {
-              logger.atWarning().withCause(e).log("Failed to stub getFileInfo");
-            }
             return mockFs;
           }
 
           @Override
           GoogleCloudStorageOutputStream createAnalyticsCoreOutputStream(
               GcsItemId gcsItemId, GcsWriteOptions writeOptions) {
+            lastCreatedAnalyticsItemId = gcsItemId;
             return mockStream;
           }
         };


### PR DESCRIPTION
## Description
This PR integrates the GCS Analytics Core write path into the connector when `fs.gs.analytics.core.write.enable` is active (part 2 of the Analytics Core write migration stack).

### Key Changes
* **Stream Routing:** Delegates write stream creation to Analytics Core with legacy fallback.
* **Stream Wrapper:** Added `GcsAnalyticsCoreOutputStreamWrapper` for synchronized delegation around `GoogleCloudStorageOutputStream`.
* **Overwrite & Generation:** Enforces `FileAlreadyExistsException` on `overwrite=false` and resolves generation IDs for overwrites.
* **Buffering:** Wraps streams in `BufferedOutputStream` matching configured buffer size.

### Testing
* Added `GcsAnalyticsCoreOutputStreamWrapperTest` covering stream delegation, close, and synchronization.
* Added unit tests in `GoogleHadoopOutputStreamTest` covering write delegation, overwrite checks, and generation resolution.
* Verified all unit tests and spotless checks pass cleanly.


### Style Guide Compliance Checklist
- [x] Conventional Commit title (`feat: ...`)
- [x] Apache 2.0 license headers verified on all new files
