### PR TITLE
feat: Integrate Analytics-core write path into hadoop-connector, fadvise integration and other library upgrades

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -201,6 +201,12 @@
                   </includes>
                 </filter>
                 <filter>
+                  <artifact>com.github.ben-manes.caffeine:caffeine</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>*.json</exclude>
@@ -239,6 +245,7 @@
                   <include>io.opentelemetry.semconv</include>
                   <include>io.perfmark</include>
                   <include>org.apache.httpcomponents</include>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
                   <include>org.threeten:threetenbp</include>
                 </includes>
               </artifactSet>
@@ -277,6 +284,7 @@
                     <include>com.google.storage.**</include>
                     <include>com.google.thirdparty.**</include>
                     <include>com.google.type.**</include>
+                    <include>com.github.benmanes.caffeine.**</include>
                     <include>com.lmax.disruptor.**</include>
                   </includes>
                   <excludes>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapper.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.hadoop.fs.gcs;
 
+import com.google.cloud.hadoop.util.RequesterPaysOptions.RequesterPaysMode;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -24,15 +25,31 @@ final class AnalyticsCoreConfigMapper {
 
   static final String PROJECT_ID_KEY = "project-id";
   static final String USER_PROJECT_KEY = "user-project";
+  static final String SERVICE_HOST_KEY = "service.host";
   static final String READ_THREAD_COUNT_KEY = "analytics-core.read.thread.count";
   static final String MAX_MERGE_GAP_KEY = "analytics-core.read.vectored.range.merge-gap.max-bytes";
   static final String MAX_MERGE_SIZE_KEY =
       "analytics-core.read.vectored.range.merged-size.max-bytes";
   static final String USER_AGENT_KEY = "user-agent";
+  static final String FILE_ACCESS_PATTERN_KEY = "analytics-core.read.file-access-pattern";
+  static final String INPLACE_SEEK_LIMIT_KEY = "analytics-core.read.inplace-seek-limit-bytes";
+  static final String RANDOM_READ_MIN_REQ_SIZE_KEY = "analytics-core.random-read.min-request-size";
+  static final String ADAPTIVE_READ_SEQ_THRESHOLD_KEY =
+      "analytics-core.adaptive-read.sequential-read-threshold";
+  static final String UPLOAD_CHUNK_SIZE_KEY = "channel.write.chunk-size-bytes";
+  static final String UPLOAD_TYPE_KEY = "channel.write.upload-type";
+  static final String TEMPORARY_PATHS_KEY = "channel.write.temporary-paths";
+  static final String PCU_BUFFER_COUNT_KEY = "channel.write.pcu.buffer.count";
+  static final String PCU_BUFFER_CAPACITY_KEY = "channel.write.pcu.buffer.capacity-bytes";
+  static final String PCU_PART_FILE_CLEANUP_TYPE_KEY = "channel.write.pcu.part-file.cleanup-type";
+  static final String PCU_PART_FILE_NAME_PREFIX_KEY = "channel.write.pcu.part-file.name-prefix";
+  static final String ENCRYPTION_KEY_KEY = "encryption-key";
+  static final String CHECKSUM_VALIDATION_ENABLED_KEY = "channel.write.checksum-validation.enabled";
 
   private static final ImmutableMap<String, String> HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS =
       ImmutableMap.<String, String>builder()
           .put(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(), PROJECT_ID_KEY)
+          .put(GoogleHadoopFileSystemConfiguration.GCS_ROOT_URL.getKey(), SERVICE_HOST_KEY)
           .put(
               GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(),
               USER_PROJECT_KEY)
@@ -45,6 +62,38 @@ final class AnalyticsCoreConfigMapper {
           .put(
               GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
               MAX_MERGE_SIZE_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey(),
+              INPLACE_SEEK_LIMIT_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.getKey(),
+              RANDOM_READ_MIN_REQ_SIZE_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_FADVISE_REQUEST_TRACK_COUNT.getKey(),
+              ADAPTIVE_READ_SEQ_THRESHOLD_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(),
+              FILE_ACCESS_PATTERN_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_UPLOAD_CHUNK_SIZE.getKey(),
+              UPLOAD_CHUNK_SIZE_KEY)
+          .put(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey(), UPLOAD_TYPE_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_PCU_BUFFER_COUNT.getKey(),
+              PCU_BUFFER_COUNT_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_PCU_BUFFER_CAPACITY.getKey(),
+              PCU_BUFFER_CAPACITY_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey(),
+              PCU_PART_FILE_CLEANUP_TYPE_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_NAME_PREFIX.getKey(),
+              PCU_PART_FILE_NAME_PREFIX_KEY)
+          .put(GoogleHadoopFileSystemConfiguration.GCS_ENCRYPTION_KEY.getKey(), ENCRYPTION_KEY_KEY)
+          .put(
+              GoogleHadoopFileSystemConfiguration.GCS_WRITE_ROLLING_CHECKSUM_ENABLE.getKey(),
+              CHECKSUM_VALIDATION_ENABLED_KEY)
           .build();
 
   private AnalyticsCoreConfigMapper() {
@@ -62,14 +111,48 @@ final class AnalyticsCoreConfigMapper {
   static Map<String, String> mapConfigs(Configuration config, String prefix) {
     Map<String, String> mappedProperties = config.getValByRegex("^" + prefix.replace(".", "\\."));
 
-    // Direct 1:1 mappings from Connector to Analytics Core
+    // Direct mappings from Connector to Analytics Core
     HADOOP_TO_ANALYTICS_CORE_KEY_MAPPINGS.forEach(
         (hadoopKey, analyticsKey) ->
             mapAndRemoveSource(hadoopKey, mappedProperties, prefix + analyticsKey));
 
+    // Handle requester pays project ID: when enabled, use fs.gs.requester.pays.project.id if set,
+    // otherwise fallback to fs.gs.project.id
+    String requesterPaysMode =
+        config.get(
+            GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(),
+            GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getDefault().name());
+    String requesterPaysProjectId =
+        mappedProperties.remove(
+            GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey());
+    if (!RequesterPaysMode.DISABLED.name().equalsIgnoreCase(requesterPaysMode)) {
+      if (requesterPaysProjectId == null || requesterPaysProjectId.isEmpty()) {
+        requesterPaysProjectId =
+            config.get(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey());
+      }
+      if (requesterPaysProjectId != null && !requesterPaysProjectId.isEmpty()) {
+        mappedProperties.put(prefix + USER_PROJECT_KEY, requesterPaysProjectId);
+      }
+    }
+
+    // Handle temporary paths: use fs.gs.write.temporary.dirs if set, otherwise fallback to
+    // hadoop.tmp.dir
+    String tempPaths =
+        mappedProperties.remove(
+            GoogleHadoopFileSystemConfiguration.GCS_WRITE_TEMPORARY_FILES_PATH.getKey());
+    if (tempPaths == null || tempPaths.isEmpty()) {
+      tempPaths = config.get("hadoop.tmp.dir");
+    }
+    if (tempPaths != null && !tempPaths.isEmpty()) {
+      mappedProperties.put(prefix + TEMPORARY_PATHS_KEY, tempPaths);
+    }
+
     // User agent is computed from GHFS_ID and an optional suffix, not a simple 1:1 mapping.
     mappedProperties.put(
         prefix + USER_AGENT_KEY, GoogleHadoopFileSystemConfiguration.getApplicationName(config));
+
+    // Ensure client.type is explicitly removed from mapped properties to prevent crashes
+    mappedProperties.remove(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_TYPE.getKey());
 
     return mappedProperties;
   }
@@ -78,7 +161,58 @@ final class AnalyticsCoreConfigMapper {
       String hadoopKey, Map<String, String> map, String analyticsCoreKey) {
     String value = map.remove(hadoopKey);
     if (value != null) {
+      if (hadoopKey.equals(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey())) {
+        value = toFileAccessPattern(value);
+      } else if (hadoopKey.equals(
+          GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey())) {
+        value = toUploadType(value);
+      } else if (hadoopKey.equals(
+          GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey())) {
+        value = toPartFileCleanupType(value);
+      }
       map.put(analyticsCoreKey, value);
+    }
+  }
+
+  private static String toUploadType(String uploadType) {
+    String normalized = uploadType.replace('-', '_').toUpperCase();
+    switch (normalized) {
+      case "CHUNK_UPLOAD":
+      case "WRITE_TO_DISK_THEN_UPLOAD":
+      case "JOURNALING":
+      case "PARALLEL_COMPOSITE_UPLOAD":
+        return normalized;
+      default:
+        return GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getDefault().name();
+    }
+  }
+
+  private static String toPartFileCleanupType(String cleanupType) {
+    String normalized = cleanupType.replace('-', '_').toUpperCase();
+    switch (normalized) {
+      case "ALWAYS":
+      case "NEVER":
+      case "ON_SUCCESS":
+        return normalized;
+      default:
+        return GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE
+            .getDefault()
+            .name();
+    }
+  }
+
+  private static String toFileAccessPattern(String fadvise) {
+    switch (fadvise.toUpperCase()) {
+      case "AUTO":
+        return "AUTO_SEQUENTIAL";
+      case "AUTO_RANDOM":
+        return "AUTO_RANDOM";
+      case "SEQUENTIAL":
+        return "SEQUENTIAL";
+      case "RANDOM":
+        return "RANDOM";
+      default:
+        return "AUTO_SEQUENTIAL";
     }
   }
 }

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
+import com.google.common.flogger.GoogleLogger;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A synchronized wrapper around the non-thread-safe GoogleCloudStorageOutputStream.
+ *
+ * <p>TODO(user): Implement GoogleCloudStorageItemInfo.Provider once gcs-analytics-core exposes the
+ * finalized generation ID upon close.
+ */
+class GcsAnalyticsCoreOutputStreamWrapper extends OutputStream {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private final GoogleCloudStorageOutputStream delegate;
+  private boolean closed = false;
+
+  public GcsAnalyticsCoreOutputStreamWrapper(GoogleCloudStorageOutputStream delegate) {
+    this.delegate = checkNotNull(delegate, "delegate cannot be null");
+  }
+
+  @Override
+  public synchronized void write(int b) throws IOException {
+    delegate.write(b);
+  }
+
+  @Override
+  public synchronized void write(byte[] b, int off, int len) throws IOException {
+    logger.atFine().log("write(byte[], off=%d, len=%d)", off, len);
+    delegate.write(b, off, len);
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    if (closed) {
+      logger.atFiner().log("close(): Stream already closed, ignoring.");
+      return;
+    }
+    try {
+      delegate.close();
+    } finally {
+      closed = true;
+    }
+  }
+}

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystem.java
@@ -19,6 +19,7 @@ package com.google.cloud.hadoop.fs.gcs;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.BLOCK_SIZE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.DELEGATION_TOKEN_BINDING_CLASS;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ANALYTICS_CORE_ENABLE;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ANALYTICS_CORE_WRITE_ENABLE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_APPLICATION_NAME_SUFFIX;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_CLOUD_LOGGING_ENABLE;
 import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_CONFIG_PREFIX;
@@ -409,7 +410,9 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
       } else {
         initializeGcsFs(createGcsFs(config));
       }
-      if (isAnalyticsCoreEnabled()) {
+      // TODO(user): Initialize analyticsCoreGcsFs lazily when GCS_LAZY_INITIALIZATION_ENABLE is
+      // true, to avoid eager initialization.
+      if (isAnalyticsCoreEnabled() || isAnalyticsCoreWriteEnabled()) {
         analyticsCoreGcsFs = createAnalyticsGcsFs(config);
       }
     }
@@ -1859,9 +1862,19 @@ public class GoogleHadoopFileSystem extends FileSystem implements IOStatisticsSo
     return GoogleCloudStorageInputStream.create(analyticsCoreGcsFs, gcsFileInfo);
   }
 
+  GoogleCloudStorageOutputStream createAnalyticsCoreOutputStream(
+      GcsItemId gcsItemId, GcsWriteOptions writeOptions) throws IOException {
+    return GoogleCloudStorageOutputStream.create(analyticsCoreGcsFs, gcsItemId, writeOptions);
+  }
+
   /** Checks if Analytics Core is enabled. */
   boolean isAnalyticsCoreEnabled() {
     return GCS_ANALYTICS_CORE_ENABLE.get(getConf(), getConf()::getBoolean);
+  }
+
+  /** Checks if Analytics Core write path is enabled. */
+  boolean isAnalyticsCoreWriteEnabled() {
+    return GCS_ANALYTICS_CORE_WRITE_ENABLE.get(getConf(), getConf()::getBoolean);
   }
 
   public Supplier<VectoredIOImpl> getVectoredIOSupplier() {

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -669,6 +669,10 @@ public class GoogleHadoopFileSystemConfiguration {
   public static final HadoopConfigurationProperty<Boolean> GCS_ANALYTICS_CORE_ENABLE =
       new HadoopConfigurationProperty<>("fs.gs.analytics.core.enable", false);
 
+  /** Configuration key for enabling GCS Analytics Core write path. */
+  public static final HadoopConfigurationProperty<Boolean> GCS_ANALYTICS_CORE_WRITE_ENABLE =
+      new HadoopConfigurationProperty<>("fs.gs.analytics.core.write.enable", false);
+
   static GoogleCloudStorageFileSystemOptions.Builder getGcsFsOptionsBuilder(Configuration config) {
     return GoogleCloudStorageFileSystemOptions.builder()
         .setBucketDeleteEnabled(GCE_BUCKET_DELETE_ENABLE.get(config, config::getBoolean))
@@ -681,7 +685,9 @@ public class GoogleHadoopFileSystemConfiguration {
         .setPerformanceCacheOptions(getPerformanceCachingOptions(config))
         .setStatusParallelEnabled(GCS_STATUS_PARALLEL_ENABLE.get(config, config::getBoolean))
         .setCloudLoggingEnabled(GCS_CLOUD_LOGGING_ENABLE.get(config, config::getBoolean))
-        .setAnalyticsCoreEnabled(GCS_ANALYTICS_CORE_ENABLE.get(config, config::getBoolean));
+        .setAnalyticsCoreEnabled(GCS_ANALYTICS_CORE_ENABLE.get(config, config::getBoolean))
+        .setAnalyticsCoreWriteEnabled(
+            GCS_ANALYTICS_CORE_WRITE_ENABLE.get(config, config::getBoolean));
   }
 
   static VectoredReadOptions.Builder getVectoredReadOptionBuilder(Configuration config) {

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStream.java
@@ -21,6 +21,11 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.trackDuration;
 
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.CreateObjectOptions;
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorage;
@@ -188,16 +193,78 @@ class GoogleHadoopOutputStream extends OutputStream
 
     this.tmpOut =
         createOutputStream(
-            ghfs.getGcsFs(),
-            tmpGcsPath,
-            tmpIndex == 0 ? createFileOptions : TMP_FILE_CREATE_OPTIONS);
+            ghfs, tmpGcsPath, tmpIndex == 0 ? createFileOptions : TMP_FILE_CREATE_OPTIONS);
     this.dstGenerationId = StorageResourceId.UNKNOWN_GENERATION_ID;
     this.traceFactory = ghfs.getTraceFactory();
   }
 
   private static OutputStream createOutputStream(
-      GoogleCloudStorageFileSystem gcsfs, URI gcsPath, CreateFileOptions options)
-      throws IOException {
+      GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
+    OutputStream outputStream =
+        ghfs.isAnalyticsCoreWriteEnabled()
+            ? createAnalyticsCoreOutputStream(ghfs, gcsPath, options)
+            : createLegacyOutputStream(ghfs, gcsPath, options);
+    return maybeWrapInBufferedOutputStream(ghfs, outputStream);
+  }
+
+  private static OutputStream createAnalyticsCoreOutputStream(
+      GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
+    GcsFileSystem analyticsGcsFs = ghfs.getAnalyticsCoreGcsFs();
+    if (analyticsGcsFs == null) {
+      throw new IOException(
+          String.format(
+              "Analytics write path is enabled, but the analytics filesystem is not initialized"
+                  + " (getAnalyticsCoreGcsFs() returned null). Cannot write to %s",
+              gcsPath));
+    }
+    GcsWriteOptions baseWriteOptions =
+        analyticsGcsFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions();
+    boolean overwrite = options.getWriteMode() == CreateFileOptions.WriteMode.OVERWRITE;
+    StorageResourceId resourceId =
+        StorageResourceId.fromUriPath(gcsPath, /* allowEmptyObjectName= */ false);
+    GcsItemId.Builder itemIdBuilder =
+        GcsItemId.builder()
+            .setBucketName(resourceId.getBucketName())
+            .setObjectName(resourceId.getObjectName());
+    long generation = StorageResourceId.UNKNOWN_GENERATION_ID;
+    // TODO(user): Check if FileAlreadyExistsException can be thrown during stream creation in
+    // Analytics Core rather than doing an explicit getFileInfo check here.
+    try {
+      GcsFileInfo fileInfo = analyticsGcsFs.getFileInfo(itemIdBuilder.build());
+      // If we reach here, the file exists.
+      if (!overwrite) {
+        GoogleCloudStorageEventBus.postOnException();
+        throw new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath));
+      }
+      generation = fileInfo.getItemInfo().getContentGeneration().orElse(0L);
+    } catch (IOException e) {
+      // TODO(user): Remove this exception message check once analytics-core throws a specific
+      // FileNotFoundException / NoSuchFileException for non-existent objects.
+      if (e.getMessage() != null && e.getMessage().startsWith("Object not found:")) {
+        // If file does not exist, set the generation as 0.
+        generation = 0L;
+      } else {
+        throw e;
+      }
+    }
+    GcsItemId itemId;
+    if (generation == StorageResourceId.UNKNOWN_GENERATION_ID) {
+      itemId = itemIdBuilder.build();
+    } else {
+      itemId = itemIdBuilder.setContentGeneration(generation).build();
+    }
+
+    GcsWriteOptions writeOptions =
+        baseWriteOptions.toBuilder().setOverwriteExisting(overwrite).build();
+
+    GoogleCloudStorageOutputStream rawStream =
+        ghfs.createAnalyticsCoreOutputStream(itemId, writeOptions);
+    return new GcsAnalyticsCoreOutputStreamWrapper(rawStream);
+  }
+
+  private static OutputStream createLegacyOutputStream(
+      GoogleHadoopFileSystem ghfs, URI gcsPath, CreateFileOptions options) throws IOException {
+    GoogleCloudStorageFileSystem gcsfs = ghfs.getGcsFs();
     WritableByteChannel channel;
     try {
       channel = gcsfs.create(gcsPath, options);
@@ -207,9 +274,17 @@ class GoogleHadoopOutputStream extends OutputStream
           new FileAlreadyExistsException(String.format("'%s' already exists", gcsPath))
               .initCause(e);
     }
-    OutputStream outputStream = Channels.newOutputStream(channel);
+    return Channels.newOutputStream(channel);
+  }
+
+  private static OutputStream maybeWrapInBufferedOutputStream(
+      GoogleHadoopFileSystem ghfs, OutputStream outputStream) {
     int bufferSize =
-        gcsfs.getOptions().getCloudStorageOptions().getWriteChannelOptions().getBufferSize();
+        ghfs.getGcsFs()
+            .getOptions()
+            .getCloudStorageOptions()
+            .getWriteChannelOptions()
+            .getBufferSize();
     return bufferSize > 0 ? new BufferedOutputStream(outputStream, bufferSize) : outputStream;
   }
 
@@ -339,7 +414,7 @@ class GoogleHadoopOutputStream extends OutputStream
 
     logger.atFiner().log(
         "hsync(): Opening next temporary tail file %s at %d index", tmpGcsPath, tmpIndex);
-    tmpOut = createOutputStream(ghfs.getGcsFs(), tmpGcsPath, TMP_FILE_CREATE_OPTIONS);
+    tmpOut = createOutputStream(ghfs, tmpGcsPath, TMP_FILE_CREATE_OPTIONS);
 
     long finishMs = System.currentTimeMillis();
     logger.atFiner().log("Took %dms to sync() for %s", finishMs - startMs, dstGcsPath);
@@ -349,6 +424,8 @@ class GoogleHadoopOutputStream extends OutputStream
     // TODO(user): return early when 0 bytes have been written in the temp files
     tmpOut.close();
 
+    // TODO(user): Support generation ID retrieval for GcsAnalyticsCoreOutputStreamWrapper once
+    // gcs-analytics-core exposes it. Currently falls back to UNKNOWN_GENERATION_ID.
     long tmpGenerationId =
         tmpOut instanceof GoogleCloudStorageItemInfo.Provider
             ? ((GoogleCloudStorageItemInfo.Provider) tmpOut).getItemInfo().getContentGeneration()

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/AnalyticsCoreConfigMapperTest.java
@@ -40,12 +40,38 @@ public class AnalyticsCoreConfigMapperTest {
         .isEqualTo("my-project");
     assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
         .isEqualTo("user-project");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.SERVICE_HOST_KEY))
+        .isEqualTo("http://emulator:8080/");
     assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.READ_THREAD_COUNT_KEY))
         .isEqualTo("10");
     assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.MAX_MERGE_GAP_KEY))
         .isEqualTo("1024");
     assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.MAX_MERGE_SIZE_KEY))
         .isEqualTo("2048");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("RANDOM");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.INPLACE_SEEK_LIMIT_KEY))
+        .isEqualTo("50");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.RANDOM_READ_MIN_REQ_SIZE_KEY))
+        .isEqualTo("100");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.ADAPTIVE_READ_SEQ_THRESHOLD_KEY))
+        .isEqualTo("5");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.UPLOAD_CHUNK_SIZE_KEY))
+        .isEqualTo("33554432");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.UPLOAD_TYPE_KEY))
+        .isEqualTo("CHUNK_UPLOAD");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.PCU_BUFFER_COUNT_KEY))
+        .isEqualTo("5");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.PCU_BUFFER_CAPACITY_KEY))
+        .isEqualTo("16777216");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.PCU_PART_FILE_CLEANUP_TYPE_KEY))
+        .isEqualTo("ALWAYS");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.PCU_PART_FILE_NAME_PREFIX_KEY))
+        .isEqualTo("prefix-");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.ENCRYPTION_KEY_KEY))
+        .isEqualTo("my-csek-key");
+    assertThat(mapped.get("fs.gs." + AnalyticsCoreConfigMapper.CHECKSUM_VALIDATION_ENABLED_KEY))
+        .isEqualTo("true");
     assertThat(mapped).containsAtLeastEntriesIn(EXPECTED_MANDATORY_MAPPINGS);
   }
 
@@ -56,6 +82,8 @@ public class AnalyticsCoreConfigMapperTest {
     Map<String, String> mapped = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
 
     assertThat(mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey()))
+        .isFalse();
+    assertThat(mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_ROOT_URL.getKey()))
         .isFalse();
     assertThat(
             mapped.containsKey(
@@ -74,6 +102,83 @@ public class AnalyticsCoreConfigMapperTest {
                 GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE
                     .getKey()))
         .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE
+                    .getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_FADVISE_REQUEST_TRACK_COUNT.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_UPLOAD_CHUNK_SIZE.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_PCU_BUFFER_COUNT.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_PCU_BUFFER_CAPACITY.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_NAME_PREFIX.getKey()))
+        .isFalse();
+    assertThat(mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_ENCRYPTION_KEY.getKey()))
+        .isFalse();
+    assertThat(
+            mapped.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_WRITE_ROLLING_CHECKSUM_ENABLE.getKey()))
+        .isFalse();
+    assertThat(mapped.containsKey(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_TYPE.getKey()))
+        .isFalse();
+  }
+
+  @Test
+  public void mapConfigs_mapsFadviseModesCorrectly() {
+    Configuration config = new Configuration();
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "SEQUENTIAL");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("SEQUENTIAL");
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "RANDOM");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("RANDOM");
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "AUTO");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("AUTO_SEQUENTIAL");
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "AUTO_RANDOM");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.FILE_ACCESS_PATTERN_KEY))
+        .isEqualTo("AUTO_RANDOM");
   }
 
   @Test
@@ -121,12 +226,191 @@ public class AnalyticsCoreConfigMapperTest {
     config.set(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(), "my-project");
     config.set(
         GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(), "user-project");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "AUTO");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_ROOT_URL.getKey(), "http://emulator:8080/");
     config.set(GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_THREADS.getKey(), "10");
     config.set(
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_RANGE_MIN_SEEK.getKey(), "1024");
     config.set(
         GoogleHadoopFileSystemConfiguration.GCS_VECTORED_READ_MERGED_RANGE_MAX_SIZE.getKey(),
         "2048");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_FADVISE.getKey(), "RANDOM");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_INPLACE_SEEK_LIMIT.getKey(), "50");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_INPUT_STREAM_MIN_RANGE_REQUEST_SIZE.getKey(),
+        "100");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_FADVISE_REQUEST_TRACK_COUNT.getKey(), "5");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_UPLOAD_CHUNK_SIZE.getKey(),
+        "33554432");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey(), "CHUNK_UPLOAD");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_PCU_BUFFER_COUNT.getKey(), "5");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_PCU_BUFFER_CAPACITY.getKey(), "16777216");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey(), "ALWAYS");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_NAME_PREFIX.getKey(), "prefix-");
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_ENCRYPTION_KEY.getKey(), "my-csek-key");
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_WRITE_ROLLING_CHECKSUM_ENABLE.getKey(), "true");
+    config.set("fs.gs.client.type", "STORAGE_CLIENT");
     return config;
+  }
+
+  @Test
+  public void mapConfigs_mapsChecksumValidationEnabled() {
+    Configuration config = new Configuration();
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_WRITE_ROLLING_CHECKSUM_ENABLE.getKey(), "false");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.CHECKSUM_VALIDATION_ENABLED_KEY))
+        .isEqualTo("false");
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_WRITE_ROLLING_CHECKSUM_ENABLE.getKey(), "true");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.CHECKSUM_VALIDATION_ENABLED_KEY))
+        .isEqualTo("true");
+  }
+
+  @Test
+  public void mapConfigs_mapsTemporaryPathsOrFallback() {
+    Configuration config = new Configuration();
+
+    // Fallback to hadoop.tmp.dir
+    config.set("hadoop.tmp.dir", "/hadoop/tmp");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.TEMPORARY_PATHS_KEY))
+        .isEqualTo("/hadoop/tmp");
+
+    // Override with fs.gs.write.temporary.dirs
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_WRITE_TEMPORARY_FILES_PATH.getKey(),
+        "/gcs/tmp1,/gcs/tmp2");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.TEMPORARY_PATHS_KEY))
+        .isEqualTo("/gcs/tmp1,/gcs/tmp2");
+  }
+
+  @Test
+  public void mapConfigs_normalizesUploadType() {
+    Configuration config = new Configuration();
+
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey(), "chunk-upload");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.UPLOAD_TYPE_KEY))
+        .isEqualTo("CHUNK_UPLOAD");
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey(),
+        "parallel-composite-upload");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.UPLOAD_TYPE_KEY))
+        .isEqualTo("PARALLEL_COMPOSITE_UPLOAD");
+
+    // Invalid value falls back to default CHUNK_UPLOAD
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_CLIENT_UPLOAD_TYPE.getKey(), "invalid-type");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.UPLOAD_TYPE_KEY))
+        .isEqualTo("CHUNK_UPLOAD");
+  }
+
+  @Test
+  public void mapConfigs_mapsRequesterPaysProjectIdConditionally() {
+    Configuration config = new Configuration();
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey(), "user-project");
+
+    // Mode is not set (defaults to DISABLED) -> should NOT map project ID
+    Map<String, String> mappedDefault = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+    assertThat(mappedDefault.containsKey("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isFalse();
+    // But it should still remove the source key from result if it was there
+    assertThat(
+            mappedDefault.containsKey(
+                GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_PROJECT_ID.getKey()))
+        .isFalse();
+
+    // Mode is DISABLED explicitly -> should NOT map project ID
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "DISABLED");
+    Map<String, String> mappedDisabled = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+    assertThat(mappedDisabled.containsKey("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isFalse();
+
+    // Mode is AUTO -> should map project ID
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "AUTO");
+    Map<String, String> mappedAuto = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+    assertThat(mappedAuto.get("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isEqualTo("user-project");
+
+    // Mode is ENABLED -> should map project ID
+    config.set(GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "ENABLED");
+    Map<String, String> mappedEnabled = AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.");
+    assertThat(mappedEnabled.get("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isEqualTo("user-project");
+
+    // Fallback to fs.gs.project.id when fs.gs.requester.pays.project.id is not set
+    Configuration fallbackConfig = new Configuration();
+    fallbackConfig.set(GoogleHadoopFileSystemConfiguration.GCS_PROJECT_ID.getKey(), "my-project");
+
+    fallbackConfig.set(
+        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "AUTO");
+    Map<String, String> mappedFallbackAuto =
+        AnalyticsCoreConfigMapper.mapConfigs(fallbackConfig, "fs.gs.");
+    assertThat(mappedFallbackAuto.get("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isEqualTo("my-project");
+
+    fallbackConfig.set(
+        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "ENABLED");
+    Map<String, String> mappedFallbackEnabled =
+        AnalyticsCoreConfigMapper.mapConfigs(fallbackConfig, "fs.gs.");
+    assertThat(mappedFallbackEnabled.get("fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isEqualTo("my-project");
+
+    fallbackConfig.set(
+        GoogleHadoopFileSystemConfiguration.GCS_REQUESTER_PAYS_MODE.getKey(), "DISABLED");
+    Map<String, String> mappedFallbackDisabled =
+        AnalyticsCoreConfigMapper.mapConfigs(fallbackConfig, "fs.gs.");
+    assertThat(
+            mappedFallbackDisabled.containsKey(
+                "fs.gs." + AnalyticsCoreConfigMapper.USER_PROJECT_KEY))
+        .isFalse();
+  }
+
+  @Test
+  public void mapConfigs_normalizesPcuPartFileCleanupType() {
+    Configuration config = new Configuration();
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey(), "on-success");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.PCU_PART_FILE_CLEANUP_TYPE_KEY))
+        .isEqualTo("ON_SUCCESS");
+
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey(), "always");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.PCU_PART_FILE_CLEANUP_TYPE_KEY))
+        .isEqualTo("ALWAYS");
+
+    // Invalid value falls back to default ALWAYS
+    config.set(
+        GoogleHadoopFileSystemConfiguration.GCS_PCU_PART_FILE_CLEANUP_TYPE.getKey(),
+        "invalid-cleanup");
+    assertThat(
+            AnalyticsCoreConfigMapper.mapConfigs(config, "fs.gs.")
+                .get("fs.gs." + AnalyticsCoreConfigMapper.PCU_PART_FILE_CLEANUP_TYPE_KEY))
+        .isEqualTo("ALWAYS");
   }
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GcsAnalyticsCoreOutputStreamWrapperTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GcsAnalyticsCoreOutputStreamWrapperTest {
+
+  @Mock private GoogleCloudStorageOutputStream mockOutputStream;
+
+  private GcsAnalyticsCoreOutputStreamWrapper outputStreamWrapper;
+
+  @Before
+  public void setUp() {
+    outputStreamWrapper = new GcsAnalyticsCoreOutputStreamWrapper(mockOutputStream);
+  }
+
+  @Test
+  public void constructor_nullDelegate_throwsException() {
+    NullPointerException exception =
+        assertThrows(
+            NullPointerException.class, () -> new GcsAnalyticsCoreOutputStreamWrapper(null));
+    assertThat(exception).hasMessageThat().contains("delegate cannot be null");
+  }
+
+  @Test
+  public void write_int_delegatesToOutputStream() throws IOException {
+    outputStreamWrapper.write(1);
+    verify(mockOutputStream).write(1);
+  }
+
+  @Test
+  public void write_bytes_delegatesToOutputStream() throws IOException {
+    byte[] bytes = new byte[] {1, 2, 3};
+    outputStreamWrapper.write(bytes, 1, 2);
+    verify(mockOutputStream).write(bytes, 1, 2);
+  }
+
+  @Test
+  public void close_delegatesToOutputStream() throws IOException {
+    outputStreamWrapper.close();
+    verify(mockOutputStream).close();
+  }
+
+  @Test
+  public void methodsAreSynchronized() throws NoSuchMethodException {
+    verifyMethodIsSynchronized(GcsAnalyticsCoreOutputStreamWrapper.class, "write", int.class);
+    verifyMethodIsSynchronized(
+        GcsAnalyticsCoreOutputStreamWrapper.class, "write", byte[].class, int.class, int.class);
+    verifyMethodIsSynchronized(GcsAnalyticsCoreOutputStreamWrapper.class, "close");
+  }
+
+  private void verifyMethodIsSynchronized(
+      Class<?> clazz, String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+    Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
+    assertThat(Modifier.isSynchronized(method.getModifiers())).isTrue();
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -57,6 +57,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
       new HashMap<>() {
         {
           put("fs.gs.analytics.core.enable", false);
+          put("fs.gs.analytics.core.write.enable", false);
           put("fs.gs.application.name.suffix", "");
           put("fs.gs.batch.threads", 15);
           put("fs.gs.block.size", 64 * 1024 * 1024L);

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamAnalyticsIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamAnalyticsIntegrationTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ANALYTICS_CORE_ENABLE;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_ANALYTICS_CORE_WRITE_ENABLE;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_BUFFER_SIZE;
+import static com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemConfiguration.GCS_OUTPUT_STREAM_SYNC_MIN_INTERVAL;
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.hadoop.gcsio.CreateFileOptions;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationHelper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Random;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for GoogleHadoopOutputStream with Analytics Core write path enabled.
+ *
+ * <p>TODO: In a follow-up task, consolidate this suite with GoogleHadoopOutputStreamIntegrationTest
+ * by parameterizing the test matrix to cover both default and analytics core write paths.
+ */
+@RunWith(JUnit4.class)
+public class GoogleHadoopOutputStreamAnalyticsIntegrationTest {
+
+  private static GoogleCloudStorageFileSystemIntegrationHelper gcsFsIHelper;
+  private static GoogleHadoopFileSystem sharedGhfs;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    gcsFsIHelper = GoogleCloudStorageFileSystemIntegrationHelper.create();
+    gcsFsIHelper.beforeAllTests();
+    URI initUri =
+        gcsFsIHelper.getUniqueObjectUri(
+            GoogleHadoopOutputStreamAnalyticsIntegrationTest.class, "init");
+    sharedGhfs = GoogleHadoopFileSystemIntegrationHelper.createGhfs(initUri, getTestConfig());
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    if (sharedGhfs != null) {
+      sharedGhfs.close();
+    }
+    if (gcsFsIHelper != null) {
+      gcsFsIHelper.afterAllTests();
+    }
+  }
+
+  private static Configuration getTestConfig() {
+    Configuration conf = GoogleHadoopFileSystemIntegrationHelper.getTestConfig();
+    conf.setBoolean(GCS_ANALYTICS_CORE_ENABLE.getKey(), true);
+    conf.setBoolean(GCS_ANALYTICS_CORE_WRITE_ENABLE.getKey(), true);
+    return conf;
+  }
+
+  @Test
+  public void write_singleByte_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_singleByte");
+    Path hadoopPath = new Path(path);
+    byte[] expected = "hello analytics core write".getBytes(UTF_8);
+
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath)) {
+      for (byte b : expected) {
+        out.write(b);
+      }
+    }
+
+    assertThat(sharedGhfs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+  }
+
+  @Test
+  public void write_byteArray_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_byteArray");
+    Path hadoopPath = new Path(path);
+    byte[] expected = "hello analytics core write array".getBytes(UTF_8);
+
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath)) {
+      out.write(expected, 0, expected.length);
+    }
+
+    assertThat(sharedGhfs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+  }
+
+  @Test
+  public void write_byteArrayWithOffsetAndLength_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_byteArrayWithOffsetAndLength");
+    Path hadoopPath = new Path(path);
+    byte[] source = "hello analytics core write slice".getBytes(UTF_8);
+    int offset = 6;
+    int length = 14;
+    byte[] expected = Arrays.copyOfRange(source, offset, offset + length);
+
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath)) {
+      out.write(source, offset, length);
+    }
+
+    assertThat(sharedGhfs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+  }
+
+  @Test
+  public void write_largeData_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_largeData");
+    Path hadoopPath = new Path(path);
+    byte[] expected = new byte[2 * 1024 * 1024]; // 2 MiB
+    new Random().nextBytes(expected);
+
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath)) {
+      out.write(expected);
+    }
+
+    assertThat(sharedGhfs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+  }
+
+  @Test
+  public void write_withZeroBufferSize_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_withZeroBufferSize");
+    Path hadoopPath = new Path(path);
+    Configuration config = getTestConfig();
+    config.setInt(GCS_OUTPUT_STREAM_BUFFER_SIZE.getKey(), 0);
+    byte[] expected = "hello analytics core unbuffered write".getBytes(UTF_8);
+
+    try (FileSystem fs = GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, config)) {
+      try (FSDataOutputStream out = fs.create(hadoopPath)) {
+        out.write(expected);
+      }
+
+      assertThat(fs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+    }
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+  }
+
+  @Test
+  public void hsync_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "hsync");
+    Path hadoopPath = new Path(path);
+    Configuration config = getTestConfig();
+    config.setTimeDuration(GCS_OUTPUT_STREAM_SYNC_MIN_INTERVAL.getKey(), 1, SECONDS);
+
+    byte[] part1 = "hello ".getBytes(UTF_8);
+    byte[] part2 = "world".getBytes(UTF_8);
+    byte[] expected = "hello world".getBytes(UTF_8);
+
+    try (FileSystem fs = GoogleHadoopFileSystemIntegrationHelper.createGhfs(path, config)) {
+      try (FSDataOutputStream fout = fs.create(hadoopPath)) {
+        fout.write(part1);
+        fout.hsync();
+
+        assertThat(fs.getFileStatus(hadoopPath).getLen()).isEqualTo(part1.length);
+        assertThat(gcsFsIHelper.readFile(path)).isEqualTo(part1);
+
+        fout.write(part2);
+        fout.hsync();
+
+        assertThat(fs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+        assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+      }
+
+      assertThat(fs.getFileStatus(hadoopPath).getLen()).isEqualTo(expected.length);
+      assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void overwrite_true_overwritesExistingFile() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "overwrite_true");
+    Path hadoopPath = new Path(path);
+    byte[] initialContent = "initial content".getBytes(UTF_8);
+
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath, true)) {
+      out.write(initialContent);
+    }
+
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(initialContent);
+
+    byte[] newContent = "overwritten content".getBytes(UTF_8);
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath, true)) {
+      out.write(newContent);
+    }
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(newContent);
+  }
+
+  @Test
+  public void overwrite_false_throwsExceptionWhenFileExists() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "overwrite_false");
+    Path hadoopPath = new Path(path);
+    byte[] initialContent = "initial content".getBytes(UTF_8);
+
+    try (FSDataOutputStream out = sharedGhfs.create(hadoopPath, false)) {
+      out.write(initialContent);
+    }
+
+    assertThrows(FileAlreadyExistsException.class, () -> sharedGhfs.create(hadoopPath, false));
+  }
+
+  @Test
+  public void write_directOutputStream_writesContentCorrectly() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_directOutputStream");
+
+    byte[] expected = "hello analytics core direct stream write".getBytes(UTF_8);
+    try (GoogleHadoopOutputStream out =
+        createGhfsOutputStream(sharedGhfs, path, CreateFileOptions.DEFAULT)) {
+      out.write(expected);
+    }
+
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(expected);
+  }
+
+  @Test
+  public void write_zeroBytes_createsEmptyFile() throws Exception {
+    URI path = gcsFsIHelper.getUniqueObjectUri(getClass(), "write_zeroBytes");
+
+    try (GoogleHadoopOutputStream out =
+        createGhfsOutputStream(sharedGhfs, path, CreateFileOptions.DEFAULT)) {
+      out.write(new byte[0], 0, 0);
+    }
+
+    assertThat(gcsFsIHelper.readFile(path)).isEqualTo(new byte[0]);
+  }
+
+  private static GoogleHadoopOutputStream createGhfsOutputStream(
+      GoogleHadoopFileSystem ghfs, URI path, CreateFileOptions options) throws IOException {
+    FileSystem.Statistics statistics = new FileSystem.Statistics(ghfs.getScheme());
+    return new GoogleHadoopOutputStream(ghfs, path, options, statistics);
+  }
+}

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopOutputStreamTest.java
@@ -26,17 +26,34 @@ import static java.lang.Math.toIntExact;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageOutputStream;
 import com.google.cloud.hadoop.gcsio.CreateFileOptions;
 import com.google.cloud.hadoop.gcsio.StorageResourceId;
 import com.google.cloud.hadoop.gcsio.testing.InMemoryGoogleCloudStorage;
+import com.google.common.flogger.GoogleLogger;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -52,11 +69,15 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GoogleHadoopOutputStreamTest {
 
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
   private GoogleHadoopFileSystem ghfs;
+  private GcsItemId lastCreatedAnalyticsItemId;
 
   @Before
   public void setUp() throws IOException {
     ghfs = GoogleHadoopFileSystemTestHelper.createInMemoryGoogleHadoopFileSystem();
+    lastCreatedAnalyticsItemId = null;
   }
 
   @After
@@ -337,5 +358,185 @@ public class GoogleHadoopOutputStreamTest {
       }
     }
     return allReadBytes.toByteArray();
+  }
+
+  @Test
+  public void write_withAnalyticsWriteEnabled_delegatesToAnalyticsOutputStream() throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_write.txt"));
+    GoogleHadoopOutputStream fout =
+        new GoogleHadoopOutputStream(
+            analyticsGhfs,
+            analyticsGhfs.getGcsPath(objectPath),
+            CreateFileOptions.DEFAULT,
+            new FileSystem.Statistics(analyticsGhfs.getScheme()));
+    byte[] data = {0x0f, 0x0e, 0x0e, 0x0d};
+
+    fout.write(data, 0, data.length);
+    fout.close();
+
+    // Verify that write was called on the GoogleCloudStorageOutputStream with the same arguments
+    verify(mockStream)
+        .write(
+            argThat(buf -> Arrays.equals(Arrays.copyOfRange(buf, 0, data.length), data)),
+            eq(0),
+            eq(data.length));
+  }
+
+  @Test
+  public void close_withAnalyticsWriteEnabled_closesAnalyticsOutputStream() throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_close.txt"));
+    GoogleHadoopOutputStream fout =
+        new GoogleHadoopOutputStream(
+            analyticsGhfs,
+            analyticsGhfs.getGcsPath(objectPath),
+            CreateFileOptions.DEFAULT,
+            new FileSystem.Statistics(analyticsGhfs.getScheme()));
+
+    fout.close();
+
+    verify(mockStream, atLeastOnce()).close();
+  }
+
+  @Test
+  public void write_withAnalyticsWriteEnabledButFsNull_throwsException() throws Exception {
+    GoogleHadoopFileSystem analyticsGhfs =
+        new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
+          @Override
+          boolean isAnalyticsCoreWriteEnabled() {
+            return true;
+          }
+
+          @Override
+          GcsFileSystem getAnalyticsCoreGcsFs() {
+            return null;
+          }
+        };
+    analyticsGhfs.initialize(ghfs.getUri(), ghfs.getConf());
+
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_null_fs.txt"));
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                new GoogleHadoopOutputStream(
+                    analyticsGhfs,
+                    analyticsGhfs.getGcsPath(objectPath),
+                    CreateFileOptions.DEFAULT,
+                    new FileSystem.Statistics(analyticsGhfs.getScheme())));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "Analytics write path is enabled, but the analytics filesystem is not initialized");
+  }
+
+  @Test
+  public void create_withAnalyticsWriteEnabled_overwriteFalse_fileAlreadyExists_throwsException()
+      throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    GcsFileSystem mockFs = analyticsGhfs.getAnalyticsCoreGcsFs();
+    // Stub getFileInfo to return a valid GcsFileInfo (simulating file exists)
+    GcsFileInfo mockFileInfo = mock(GcsFileInfo.class, RETURNS_DEEP_STUBS);
+    when(mockFs.getFileInfo(any(GcsItemId.class))).thenReturn(mockFileInfo);
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_exists_error.txt"));
+
+    assertThrows(
+        FileAlreadyExistsException.class,
+        () ->
+            new GoogleHadoopOutputStream(
+                analyticsGhfs,
+                analyticsGhfs.getGcsPath(objectPath),
+                CreateFileOptions.DEFAULT, // overwrite is false by default
+                new FileSystem.Statistics(analyticsGhfs.getScheme())));
+  }
+
+  @Test
+  public void create_withAnalyticsWriteEnabled_overwriteTrue_fileAlreadyExists_resolvesGeneration()
+      throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    GcsFileSystem mockFs = analyticsGhfs.getAnalyticsCoreGcsFs();
+    // Stub getFileInfo to return info with generation 123L
+    GcsFileInfo mockFileInfo = mock(GcsFileInfo.class, RETURNS_DEEP_STUBS);
+    when(mockFileInfo.getItemInfo().getContentGeneration()).thenReturn(Optional.of(123L));
+    when(mockFs.getFileInfo(any(GcsItemId.class))).thenReturn(mockFileInfo);
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_overwrite_gen.txt"));
+    CreateFileOptions overwriteOptions =
+        CreateFileOptions.builder().setWriteMode(CreateFileOptions.WriteMode.OVERWRITE).build();
+    GoogleHadoopOutputStream fout =
+        new GoogleHadoopOutputStream(
+            analyticsGhfs,
+            analyticsGhfs.getGcsPath(objectPath),
+            overwriteOptions,
+            new FileSystem.Statistics(analyticsGhfs.getScheme()));
+
+    fout.close();
+
+    assertThat(lastCreatedAnalyticsItemId).isNotNull();
+    assertThat(lastCreatedAnalyticsItemId.getContentGeneration().isPresent()).isTrue();
+    assertThat(lastCreatedAnalyticsItemId.getContentGeneration().get()).isEqualTo(123L);
+  }
+
+  @Test
+  public void create_withAnalyticsWriteEnabled_otherIOException_propagatesException()
+      throws Exception {
+    GoogleCloudStorageOutputStream mockStream = mock(GoogleCloudStorageOutputStream.class);
+    GoogleHadoopFileSystem analyticsGhfs = createAnalyticsEnabledGhfs(mockStream);
+    GcsFileSystem mockFs = analyticsGhfs.getAnalyticsCoreGcsFs();
+    // Stub getFileInfo to throw some other IOException (e.g. Permission Denied)
+    when(mockFs.getFileInfo(any(GcsItemId.class)))
+        .thenThrow(new IOException("Permission denied (mocked)"));
+    Path objectPath = new Path(analyticsGhfs.getUri().resolve("/analytics_other_io_error.txt"));
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () ->
+                new GoogleHadoopOutputStream(
+                    analyticsGhfs,
+                    analyticsGhfs.getGcsPath(objectPath),
+                    CreateFileOptions.DEFAULT,
+                    new FileSystem.Statistics(analyticsGhfs.getScheme())));
+    assertThat(exception).hasMessageThat().contains("Permission denied (mocked)");
+  }
+
+  private GoogleHadoopFileSystem createAnalyticsEnabledGhfs(
+      GoogleCloudStorageOutputStream mockStream) throws IOException {
+    GcsFileSystem mockFs = mock(GcsFileSystem.class, RETURNS_DEEP_STUBS);
+    when(mockFs.getFileSystemOptions().getGcsClientOptions().getGcsWriteOptions())
+        .thenReturn(GcsWriteOptions.builder().build());
+    try {
+      when(mockFs.getFileInfo(any(GcsItemId.class)))
+          .thenThrow(new IOException("Object not found: (mocked)"));
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("Failed to stub getFileInfo");
+    }
+
+    GoogleHadoopFileSystem analyticsGhfs =
+        new GoogleHadoopFileSystem(ghfs.getGcsFs()) {
+          @Override
+          boolean isAnalyticsCoreWriteEnabled() {
+            return true;
+          }
+
+          @Override
+          GcsFileSystem getAnalyticsCoreGcsFs() {
+            return mockFs;
+          }
+
+          @Override
+          GoogleCloudStorageOutputStream createAnalyticsCoreOutputStream(
+              GcsItemId gcsItemId, GcsWriteOptions writeOptions) {
+            lastCreatedAnalyticsItemId = gcsItemId;
+            return mockStream;
+          }
+        };
+    analyticsGhfs.initialize(ghfs.getUri(), ghfs.getConf());
+    return analyticsGhfs;
   }
 }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemOptions.java
@@ -43,12 +43,15 @@ public abstract class GoogleCloudStorageFileSystemOptions {
         .setPerformanceCacheOptions(PerformanceCachingGoogleCloudStorageOptions.DEFAULT)
         .setStatusParallelEnabled(true)
         .setCloudLoggingEnabled(false)
-        .setAnalyticsCoreEnabled(false);
+        .setAnalyticsCoreEnabled(false)
+        .setAnalyticsCoreWriteEnabled(false);
   }
 
   public abstract Builder toBuilder();
 
   public abstract boolean isAnalyticsCoreEnabled();
+
+  public abstract boolean isAnalyticsCoreWriteEnabled();
 
   public abstract boolean isPerformanceCacheEnabled();
 
@@ -80,6 +83,8 @@ public abstract class GoogleCloudStorageFileSystemOptions {
     public abstract Builder setClientType(ClientType clientType);
 
     public abstract Builder setAnalyticsCoreEnabled(boolean enabled);
+
+    public abstract Builder setAnalyticsCoreWriteEnabled(boolean enabled);
 
     public abstract Builder setPerformanceCacheEnabled(boolean performanceCacheEnabled);
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <gpg.skip>true</gpg.skip>
 
     <bigdataoss.version>4.0.0-SNAPSHOT</bigdataoss.version>
-    <google.analyticscore.version>1.2.3</google.analyticscore.version>
+    <google.analyticscore.version>1.5.0</google.analyticscore.version>
 
     <google.auto-value.version>1.10.4</google.auto-value.version>
     <google.cloud.library.bom.version>26.73.0</google.cloud.library.bom.version>


### PR DESCRIPTION
### PR Description:

```markdown
## Purpose & Summary
This PR integrates `google-analyticscore` library into the GCS Connector for both read and write paths, replacing legacy direct storage channels when the feature flag is enabled.

## Key Changes
- **Dependency & Shading:** Upgraded `google-analyticscore` and added necessary shaded artifacts (including Caffeine).
- **Configuration & Mapping:** Updated `AnalyticsCoreConfigMapper` and feature flag properties (`fs.gs.analytics.core.write.enabled`, write flags).
- **Write Path Migration:** Integrated Analytics Core write path into `GoogleHadoopOutputStream`.
- integrated fadvice from analytics-core. 
- **Testing:** Added comprehensive unit tests and integration tests for read and write path operations.
```