### PR TITLE
docs: Add skill for running integration tests in hadoop-connector

### DIFF
--- a/.gemini/skills/running-integration-test.md
+++ b/.gemini/skills/running-integration-test.md
@@ -20,16 +20,15 @@ gcloud auth application-default login
 *(Verify your active token anytime using `gcloud auth application-default print-access-token`)*.
 
 ### Configure Google Cloud Project ID
-Verify that the `GCS_TEST_PROJECT_ID` environment variable is set:
+Set the `GCS_TEST_PROJECT_ID` environment variable (default: `gcs-hyd-connector-benchmarks`):
 ```bash
-export GCS_TEST_PROJECT_ID="<your-gcp-project-id>"
+export GCS_TEST_PROJECT_ID="${GCS_TEST_PROJECT_ID:-gcs-hyd-connector-benchmarks}"
 ```
 
-### Ensure Compatible Java Environment
-Integration tests should run with JDK 17 (or JDK 11+):
-```bash
-export JAVA_HOME=/usr/lib/jvm/java-1.17.0-openjdk-amd64
-```
+### Ensure Compatible Java Environment (JDK 17)
+Ensure that `JAVA_HOME` points to a valid JDK 17 installation:
+- Check `java -version` and `echo $JAVA_HOME`.
+- If unset or invalid, locate an installed JDK 17 on the system (or install if missing) and export `JAVA_HOME`.
 
 ## 2. Enable ADC for Integration Tests
 
@@ -65,4 +64,3 @@ mvn verify -Pintegration-test -pl gcsio
 ## 4. Verification & Troubleshooting
 - **Token Check:** Verify valid credentials using `gcloud auth application-default print-access-token`.
 - **Permissions:** Verify the authenticated account has appropriate IAM permissions on the test bucket (e.g., `roles/storage.objectAdmin`).
-- **Reference:** [Connector FAQs: Using ADC for local testing](http://go/connector-faqs#can-we-use-application-default-credentials-adc-for-local-testing??)

--- a/.gemini/skills/running-integration-test.md
+++ b/.gemini/skills/running-integration-test.md
@@ -1,0 +1,68 @@
+---
+name: running-integration-test
+description: >-
+  Use this skill whenever the user asks to run integration tests locally,
+  or mentions running GCS connector tests with Application Default Credentials (ADC)
+  or the GCS_TEST_APPLICATION_DEFAULT_ENABLE flag.
+---
+
+# Running Integration Tests with Application Default Credentials (ADC)
+
+This guide and skill provides step-by-step instructions for running Google Cloud Hadoop Connector integration tests locally using Application Default Credentials (ADC).
+
+## 1. Prerequisites
+
+### Authenticate with ADC
+Ensure your local environment has valid Application Default Credentials:
+```bash
+gcloud auth application-default login
+```
+*(Verify your active token anytime using `gcloud auth application-default print-access-token`)*.
+
+### Configure Google Cloud Project ID
+Verify that the `GCS_TEST_PROJECT_ID` environment variable is set:
+```bash
+export GCS_TEST_PROJECT_ID="<your-gcp-project-id>"
+```
+
+### Ensure Compatible Java Environment
+Integration tests should run with JDK 17 (or JDK 11+):
+```bash
+export JAVA_HOME=/usr/lib/jvm/java-1.17.0-openjdk-amd64
+```
+
+## 2. Enable ADC for Integration Tests
+
+Set the `GCS_TEST_APPLICATION_DEFAULT_ENABLE` environment variable to `true`. This instructs `TestConfiguration` to use ADC when a service account keyfile is not configured:
+```bash
+export GCS_TEST_APPLICATION_DEFAULT_ENABLE=true
+```
+
+## 3. Running Integration Tests via Maven
+
+Integration tests are executed using Maven's `integration-test` profile (configured via `maven-failsafe-plugin`).
+
+### Run all integration tests in `gcs` module:
+```bash
+mvn verify -Pintegration-test -pl gcs
+```
+
+### Run a specific integration test class:
+```bash
+mvn verify -Pintegration-test -Dit.test=GoogleHadoopFSInputStreamAnalyticsIntegrationTest -pl gcs
+```
+
+### Run a single test method:
+```bash
+mvn verify -Pintegration-test -Dit.test=GoogleHadoopFSInputStreamAnalyticsIntegrationTest#testRead -pl gcs
+```
+
+### Run integration tests in other modules (e.g. `gcsio`):
+```bash
+mvn verify -Pintegration-test -pl gcsio
+```
+
+## 4. Verification & Troubleshooting
+- **Token Check:** Verify valid credentials using `gcloud auth application-default print-access-token`.
+- **Permissions:** Verify the authenticated account has appropriate IAM permissions on the test bucket (e.g., `roles/storage.objectAdmin`).
+- **Reference:** [Connector FAQs: Using ADC for local testing](http://go/connector-faqs#can-we-use-application-default-credentials-adc-for-local-testing??)

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -63,6 +63,7 @@ This guide defines coding standards, architecture principles, performance rules,
 * **Precise Exception Assertions:** Use `assertThrows(ExpectedException.class, () -> ...)` rather than catching generic `IOException` or `Exception` to avoid masking unexpected runtime errors.
 * **Fakes Over Mocks:** Use `FakeGoogleCloudStorage` or `test-lib` fake implementations rather than fragile mock objects.
 * **Test Resource Isolation:** Integration tests must generate unique GCS object URIs (e.g., appending UUIDs or tags) to prevent resource collisions during parallel test executions.
+* **Local Integration Testing with ADC:** When running integration tests locally without a service account JSON key, use the [running-integration-test skill](skills/running-integration-test.md) to authenticate via Application Default Credentials (`gcloud auth application-default login`) and set `GCS_TEST_APPLICATION_DEFAULT_ENABLE=true`.
 
 ---
 
@@ -85,3 +86,4 @@ When writing, refactoring, or reviewing code for this repository, coding agents 
 7. Check inner loops for unnecessary object allocations, lambdas, or string concatenations.
 8. Enforce Guava `Preconditions` for argument checks and Google Truth for test assertions.
 9. Translate low-level storage exceptions to standard Hadoop `IOException` types without duplicate logging.
+10. When asked to execute or instruct running integration tests locally, coding agents MUST follow the [running-integration-test skill](skills/running-integration-test.md) to set up ADC credentials and ensure `GCS_TEST_APPLICATION_DEFAULT_ENABLE=true` is exported.


### PR DESCRIPTION
## Summary
Adds a dedicated skill and style guide rule for executing local integration tests using Application Default Credentials (ADC) via the `GCS_TEST_APPLICATION_DEFAULT_ENABLE` flag.