### PR TITLE
Update Dockerfile base image

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -14,10 +14,7 @@
 
 # This Dockerfile creates an image for running presubmit tests.
 # The package below is for OpenJDK 17.
-FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/openjdk@sha256:779635c0c3d23cc8dbab2d8c1ee4cf2a9202e198dfc8f4c0b279824d9b8e0f22
-
-# Install the tools Maven Wrapper needs to download its JAR
-RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y curl wget
+FROM eclipse-temurin:17-jdk
 
 # Copy everything into the container to allow concurrent build execution
 COPY . /hadoop-connectors


### PR DESCRIPTION
Replaced OpenJDK base image with Eclipse Temurin and removed unnecessary installation of curl and wget.