### PR TITLE
Add testing utilities directory to ignore in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,4 @@
 
 ignore:
   - ".*/generated-sources/.*"
+  - ".*/testing/.*"


### PR DESCRIPTION
The current Codecov configuration [includes testing directories](https://screenshot-v2.corp.google.com/6ppfv4mltfsug), which pollutes the final coverage metrics. This change updates codecov.yml to ignore these directories, ensuring more accurate and representative coverage reports.